### PR TITLE
google-cloud: Remove deprecated automatic_restart field

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Typhoon provides a Terraform Module for each supported operating system and plat
 ## Docs
 
 * [https://typhoon.psdn.io](https://typhoon.psdn.io)
-* [Getting Started](https://typhoon.psdn.io/getting-started/)
+* [Concepts](https://typhoon.psdn.io/concepts/)
 * [Bare-Metal](https://typhoon.psdn.io/bare-metal/)
 * [Digital Ocean](https://typhoon.psdn.io/digital-ocean/)
 * [Google-Cloud](https://typhoon.psdn.io/google-cloud/)
@@ -44,12 +44,12 @@ module "yavin-cluster" {
   zone               = "us-central1-c"
   dns_zone           = "example.com"
   dns_zone_name      = "example-zone"
-  os_image           = "coreos-stable-1409-7-0-v20170719"
+  os_image           = "coreos-stable-1465-6-0-v20170817"
   
   # Cluster
   cluster_name       = "yavin"
   controller_count   = 1
-  worker_count       = 3  
+  worker_count       = 2
   ssh_authorized_key = "${var.ssh_authorized_key}"
 
   # output assets dir

--- a/google-cloud/container-linux/controllers/controllers.tf
+++ b/google-cloud/container-linux/controllers/controllers.tf
@@ -50,9 +50,6 @@ resource "google_compute_instance_template" "controller" {
     preemptible       = "${var.preemptible}"
   }
 
-  # QUIRK: Undocumented field defaults to true if not set
-  automatic_restart = "${var.preemptible ? false : true}"
-
   disk {
     auto_delete  = true
     boot         = true

--- a/google-cloud/container-linux/workers/workers.tf
+++ b/google-cloud/container-linux/workers/workers.tf
@@ -50,9 +50,6 @@ resource "google_compute_instance_template" "worker" {
     preemptible       = "${var.preemptible}"
   }
 
-  # QUIRK: Undocumented field defaults to true if not set
-  automatic_restart = "${var.preemptible ? false : true}"
-
   disk {
     auto_delete  = true
     boot         = true


### PR DESCRIPTION
* In terraform-provider-google v0.1.3, it is no longer necessary to supply a (duplicated) value for the instance_template field automatic_restart
* Previously this field was set to match the scheduling automatic_restart since the field defaulted to true and would cause plan to always show changes were needed

Now that the field is removed in terraform-provider-google v0.1.3, users will see the following error:

```
* module.mycluster.module.controllers.google_compute_instance_template.controller: "automatic_restart": [REMOVED] Use 'scheduling.automatic_restart' instead.
* module.mycluster.module.workers.google_compute_instance_template.worker: "automatic_restart": [REMOVED] Use 'scheduling.automatic_restart' instead.
```

This PR removes Typhoon's use of the field to correspond.

## Migration

Typhoon no longer setting the field means the `terraform-provider-google` plugin version must be v0.1.3 or higher. Otherwise, you'll get the original bug with `terraform plan` always trying to make changes. Update the plugin before bumping an existing google-cloud cluster to a version of Typhoon containing this commit.

Terraform does not update plugins unless you ask.
```
provider "google" {
  version = "0.1.3"
  ...
}
```

Run

```
terraform init -get-plugins -upgrade=true
```

See https://www.terraform.io/docs/configuration/providers.html#provider-versions for details on provider versioning. If you don't care about doing it cleanly/safely you might just `rm -rf .terraform` and re-run `terraform init`.