### PR TITLE
README.md: fix addons link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Typhoon distributes upstream Kubernetes, architectural conventions, and cluster 
 * Kubernetes v1.7.3 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
 * Self-hosted control plane, single or multi master, workloads isolated to workers
 * On-cluster etcd with TLS, [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)-enabled
-* Ready for Ingress, Metrics, Dashboards, and other optional [addons](docs/addons.md)
+* Ready for Ingress, Metrics, Dashboards, and other optional [addons](https://typhoon.psdn.io/addons/overview/)
 
 ## Modules
 


### PR DESCRIPTION
Fix the addons link, which is going to an old markdown doc. Point to the actual website, since this is what the other docs links do.