### PR TITLE
bare-metal: Add support for Calico networking

### DIFF
--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -1,11 +1,12 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=v0.6.1"
+  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=a52f99e8cc8b395cf2b28f74a9f79c01b63e99ae"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]
   etcd_servers                  = ["${var.controller_domains}"]
   asset_dir                     = "${var.asset_dir}"
+  networking                    = "${var.networking}"
   pod_cidr                      = "${var.pod_cidr}"
   service_cidr                  = "${var.service_cidr}"
   experimental_self_hosted_etcd = "${var.experimental_self_hosted_etcd}"

--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -153,6 +153,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           # Move experimental manifests
+          [ -d /opt/bootkube/assets/manifests-* ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -62,6 +62,12 @@ variable "asset_dir" {
   type        = "string"
 }
 
+variable "networking" {
+  description = "Choice of networking provider (flannel or calico)"
+  type        = "string"
+  default     = "flannel"
+}
+
 variable "pod_cidr" {
   description = "CIDR IP range to assign Kubernetes pods"
   type        = "string"


### PR DESCRIPTION
* Add `networking` variable for bare-metal that allows "flannel" or "calico"

## Testing

This is running in several bare-metal environments. Peering with routing hardware works as well. Still gaining confidence in it. Need separate experimentation on cloud providers (with separate MTU).

rel: https://github.com/poseidon/bootkube-terraform/pull/10