### PR TITLE
Add support for Calico networking on cloud platforms

### DIFF
--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -1,12 +1,13 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=a52f99e8cc8b395cf2b28f74a9f79c01b63e99ae"
+  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=5ffbfec46dc05721eaf9d15c3c9bbedefaead1bc"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]
   etcd_servers                  = ["${var.controller_domains}"]
   asset_dir                     = "${var.asset_dir}"
   networking                    = "${var.networking}"
+  network_mtu                   = "${var.network_mtu}"
   pod_cidr                      = "${var.pod_cidr}"
   service_cidr                  = "${var.service_cidr}"
   experimental_self_hosted_etcd = "${var.experimental_self_hosted_etcd}"

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -68,6 +68,12 @@ variable "networking" {
   default     = "flannel"
 }
 
+variable "network_mtu" {
+  description = "CNI interface MTU (applies to calico only)"
+  type        = "string"
+  default     = "1480"
+}
+
 variable "pod_cidr" {
   description = "CIDR IP range to assign Kubernetes pods"
   type        = "string"

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,11 +1,13 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=v0.6.1"
+  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=5ffbfec46dc05721eaf9d15c3c9bbedefaead1bc"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
   etcd_servers                  = ["http://127.0.0.1:2379"]
   asset_dir                     = "${var.asset_dir}"
+  networking                    = "${var.networking}"
+  network_mtu                   = 1440
   pod_cidr                      = "${var.pod_cidr}"
   service_cidr                  = "${var.service_cidr}"
   experimental_self_hosted_etcd = "true"

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -124,6 +124,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           # Move experimental manifests
+          [ -d /opt/bootkube/assets/manifests-* ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
           BOOTKUBE_ACI="$${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -55,6 +55,12 @@ variable "asset_dir" {
   type        = "string"
 }
 
+variable "networking" {
+  description = "Choice of networking provider (flannel or calico)"
+  type        = "string"
+  default     = "flannel"
+}
+
 variable "pod_cidr" {
   description = "CIDR IP range to assign Kubernetes pods"
   type        = "string"

--- a/docs/bare-metal.md
+++ b/docs/bare-metal.md
@@ -357,6 +357,8 @@ Learn about [version pinning](concepts.md#versioning), maintenance, and [addons]
 | install_disk | Disk device where Container Linux should be installed | "/dev/sda" | "/dev/sdb" |
 | container_linux_oem | Specify alternative OEM image ids for the disk install | "" | "vmware_raw", "xen" |
 | experimental_self_hosted_etcd | Self-host etcd as pods on Kubernetes (not recommended) | false | true |
+| networking | Choice of networking provider | "flannel" | "flannel" or "calico" |
+| network_mtu | CNI interface MTU (calico-only) | 1480 | - | 
 | pod_cidr | CIDR range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR range to assgin to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 

--- a/docs/digital-ocean.md
+++ b/docs/digital-ocean.md
@@ -238,8 +238,12 @@ If you uploaded an SSH key to DigitalOcean (not required), find the fingerprint 
 | controller_type | Digital Ocean droplet size | 2gb | 2gb (min), 4gb, 8gb |
 | worker_count | Number of workers | 1 | 3 |
 | worker_type | Digital Ocean droplet size | 512mb | 512mb, 1gb, 2gb, 4gb |
+| networking | Choice of networking provider | "flannel" | "flannel" |
 | pod_cidr | CIDR range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR range to assgin to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 
 !!! warning
     Do not choose a `controller_type` smaller than `2gb`. The `1gb` droplet is not sufficient for running a controller and bootstrapping will fail.
+
+!!! bug
+    Digital Ocean firewalls do not yet support the IP tunneling (IP in IP) protocol used by Calico. You can try using "calico" for `networking`, but it will only work if the cloud firewall is removed (unsafe).

--- a/docs/google-cloud.md
+++ b/docs/google-cloud.md
@@ -230,6 +230,7 @@ resource "google_dns_managed_zone" "zone-for-clusters" {
 | controller_count | Number of controllers (i.e. masters) | 1 | 1 |
 | worker_count | Number of workers | 1 | 3 |
 | worker_preemptible | If enabled, Compute Engine will terminate controllers randomly within 24 hours | false | true |
+| networking | Choice of networking provider | "flannel" | "flannel" or "calico" |
 | pod_cidr | CIDR range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR range to assgin to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,9 +12,9 @@ Typhoon distributes upstream Kubernetes, architectural conventions, and cluster 
 ## Features
 
 * Kubernetes v1.7.3 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
-* Self-hosted control plane, single or multi master, workloads isolated to workers
-* On-cluster etcd with TLS, [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)-enabled
-* Ready for Ingress, Metrics, Dashboards, and other optional [addons](addons/overview.md)
+* Single or multi-master, workloads isolated on workers, [flannel](https://github.com/coreos/flannel) or [Calico](https://www.projectcalico.org/) networking (with BGP peering)
+* On-cluster etcd with TLS, [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)-enabled, [network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+* Ready for Ingress, Dashboards, Metrics and other optional [addons](addons/overview.md)
 * Provided via Terraform Modules
 
 ## Modules

--- a/google-cloud/container-linux/controllers/cl/controller.yaml.tmpl
+++ b/google-cloud/container-linux/controllers/cl/controller.yaml.tmpl
@@ -120,6 +120,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           # Move experimental manifests
+          [ -d /opt/bootkube/assets/manifests-* ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
           BOOTKUBE_ACI="$${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"

--- a/google-cloud/container-linux/controllers/variables.tf
+++ b/google-cloud/container-linux/controllers/variables.tf
@@ -59,6 +59,12 @@ variable "preemptible" {
 
 // configuration
 
+variable "networking" {
+  description = "Choice of networking provider (flannel or calico)"
+  type        = "string"
+  default     = "flannel"
+}
+
 variable "service_cidr" {
   description = <<EOD
 CIDR IP range to assign Kubernetes services.

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -1,11 +1,13 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=v0.6.1"
+  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=5ffbfec46dc05721eaf9d15c3c9bbedefaead1bc"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
   etcd_servers                  = ["http://127.0.0.1:2379"]
   asset_dir                     = "${var.asset_dir}"
+  networking                    = "${var.networking}"
+  network_mtu                   = 1440
   pod_cidr                      = "${var.pod_cidr}"
   service_cidr                  = "${var.service_cidr}"
   experimental_self_hosted_etcd = "true"

--- a/google-cloud/container-linux/kubernetes/cluster.tf
+++ b/google-cloud/container-linux/kubernetes/cluster.tf
@@ -14,6 +14,7 @@ module "controllers" {
   preemptible   = "${var.controller_preemptible}"
 
   # configuration
+  networking              = "${var.networking}"
   service_cidr            = "${var.service_cidr}"
   kubeconfig_ca_cert      = "${module.bootkube.ca_cert}"
   kubeconfig_kubelet_cert = "${module.bootkube.kubelet_cert}"

--- a/google-cloud/container-linux/kubernetes/network.tf
+++ b/google-cloud/container-linux/kubernetes/network.tf
@@ -44,3 +44,23 @@ resource "google_compute_firewall" "allow-internal" {
 
   source_ranges = ["10.0.0.0/8"]
 }
+
+# Calico BGP and IPIP
+# https://docs.projectcalico.org/v2.5/reference/public-cloud/gce
+resource "google_compute_firewall" "allow-calico" {
+  count = "${var.networking == "calico" ? 1 : 0}"
+
+  name    = "${var.cluster_name}-allow-calico"
+  network = "${google_compute_network.network.name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["179"]
+  }
+
+  allow {
+    protocol = "ipip"
+  }
+
+  source_ranges = ["10.0.0.0/8"]
+}

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -65,6 +65,12 @@ variable "asset_dir" {
   type        = "string"
 }
 
+variable "networking" {
+  description = "Choice of networking provider (flannel or calico)"
+  type        = "string"
+  default     = "flannel"
+}
+
 variable "pod_cidr" {
   description = "CIDR IP range to assign Kubernetes pods"
   type        = "string"


### PR DESCRIPTION
* Add `networking` variable ("flannel" or "calico") for Google Cloud and Digital Ocean.

rel: Calico added as a networking option on bare-metal in #9.

## Testing

* Runs production workloads on GCE.
* Digital Ocean firewalls don't yet support the IP tunneling protocol. You can run Calico if the cloud firewall is removed, but this isn't safe. This should be considered a partial implementation pending Digital Ocean improvements.