### PR TITLE
bare-metal: Remove support for experimental_self_hosted_etcd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Notable changes between versions.
 #### Bare-Metal
 
 * Add `network_mtu` to allow CNI interface MTU customization
+* Remove support for `experimental_self_hosted_etcd`
 
 ## v1.7.3
 

--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -10,5 +10,4 @@ module "bootkube" {
   network_mtu                   = "${var.network_mtu}"
   pod_cidr                      = "${var.pod_cidr}"
   service_cidr                  = "${var.service_cidr}"
-  experimental_self_hosted_etcd = "${var.experimental_self_hosted_etcd}"
 }

--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -1,7 +1,6 @@
 ---
 systemd:
   units:
-    {{ if eq .etcd_on_host "true" }}
     - name: etcd-member.service
       enable: true
       dropins:
@@ -25,7 +24,6 @@ systemd:
             Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
             Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
             Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
-    {{ end }}
     - name: docker.service
       enable: true
     - name: locksmithd.service

--- a/bare-metal/container-linux/kubernetes/groups.tf
+++ b/bare-metal/container-linux/kubernetes/groups.tf
@@ -23,10 +23,6 @@ resource "matchbox_group" "controller" {
     mac = "${element(var.controller_macs, count.index)}"
     os  = "installed"
   }
-
-  metadata {
-    etcd_on_host = "${var.experimental_self_hosted_etcd ? "false" : "true"}"
-  }
 }
 
 resource "matchbox_group" "worker" {

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -109,8 +109,3 @@ variable "container_linux_oem" {
   default     = ""
   description = "Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
 }
-
-variable "experimental_self_hosted_etcd" {
-  default     = "false"
-  description = "Create self-hosted etcd cluster as pods on Kubernetes, instead of on-hosts"
-}

--- a/docs/bare-metal.md
+++ b/docs/bare-metal.md
@@ -362,10 +362,9 @@ Learn about [version pinning](concepts.md#versioning), maintenance, and [addons]
 
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
-| cached_install | Whether machines should PXE boot from the Matchbox `/assets` cache. Admin MUST have downloaded Container Linux images into the cache to use this | false | true |
+| cached_install | Whether machines should PXE boot and install from the Matchbox `/assets` cache. Admin MUST have downloaded Container Linux images into the cache to use this | false | true |
 | install_disk | Disk device where Container Linux should be installed | "/dev/sda" | "/dev/sdb" |
 | container_linux_oem | Specify alternative OEM image ids for the disk install | "" | "vmware_raw", "xen" |
-| experimental_self_hosted_etcd | Self-host etcd as pods on Kubernetes (not recommended) | false | true |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | network_mtu | CNI interface MTU (calico-only) | 1480 | - | 
 | pod_cidr | CIDR range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |


### PR DESCRIPTION
* Transition from discouraging self-hosted etcd for bare-metal, to removing it as an option
* See #13 and FAQ for self-hosted etcd discussion