### PR TITLE
Add Wants=rpc-statd.service to Kubelet

### DIFF
--- a/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -23,6 +23,7 @@ systemd:
       contents: |
         [Unit]
         Description=Kubelet via Hyperkube ACI
+        Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \

--- a/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -23,6 +23,7 @@ systemd:
       contents: |
         [Unit]
         Description=Kubelet via Hyperkube ACI
+        Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \

--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -56,6 +56,7 @@ systemd:
       contents: |
         [Unit]
         Description=Kubelet via Hyperkube ACI
+        Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \

--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -31,6 +31,7 @@ systemd:
       contents: |
         [Unit]
         Description=Kubelet via Hyperkube ACI
+        Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \

--- a/bare-metal/container-linux/pxe-worker/cl/bootkube-worker.yaml.tmpl
+++ b/bare-metal/container-linux/pxe-worker/cl/bootkube-worker.yaml.tmpl
@@ -31,6 +31,7 @@ systemd:
       contents: |
         [Unit]
         Description=Kubelet via Hyperkube ACI
+        Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -33,6 +33,7 @@ systemd:
         Description=Kubelet via Hyperkube ACI
         Requires=coreos-metadata.service
         After=coreos-metadata.service
+        Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
         EnvironmentFile=/run/metadata/coreos

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -33,6 +33,7 @@ systemd:
         Description=Kubelet via Hyperkube ACI
         Requires=coreos-metadata.service
         After=coreos-metadata.service
+        Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
         EnvironmentFile=/run/metadata/coreos

--- a/google-cloud/container-linux/controllers/cl/controller.yaml.tmpl
+++ b/google-cloud/container-linux/controllers/cl/controller.yaml.tmpl
@@ -23,6 +23,7 @@ systemd:
       contents: |
         [Unit]
         Description=Kubelet via Hyperkube ACI
+        Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \

--- a/google-cloud/container-linux/workers/cl/worker.yaml.tmpl
+++ b/google-cloud/container-linux/workers/cl/worker.yaml.tmpl
@@ -23,6 +23,7 @@ systemd:
       contents: |
         [Unit]
         Description=Kubelet via Hyperkube ACI
+        Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \


### PR DESCRIPTION
* Mounting NFS exports as volumes from some NFS servers fails because the kubelet isn't starting rpc-statd as expected. Describing pods that are stuck creating shows rpc.statd is required for remote locking
* Starting rpc-statd.service resolves the issue and all NFS mounts seem to be working.
* Recommended approach https://github.com/coreos/bugs/issues/2074

```
Mounting command: mount   
Mounting arguments: 10.3.0.14:/exports/example /var/lib/kubelet/pods/6a8f4a2e-a186-11e7-9952-6cae8b5b4268/volumes/kubernetes.io~nfs/data-volume nfs []
Output: mount.nfs: rpc.statd is not running but is required for remote locking.                          
mount.nfs: Either use '-o nolock' to keep locks local, or start statd.                                   
mount.nfs: an incorrect mount option was specified
```

### Observation

I noticed this deploying a newer NFS server for myself. Notably, the Kubernetes cluster (which did not have `rpc-statd` running) was still able to mount NFS exports from another, older NFS server (~Fedora 24 host). Otherwise I'd be getting alerts. Working theory is that older NFS setups continued working because they maybe aren't requiring locking correctly. Logs on the host didn't identify anything amiss. Needs further investigation.