### PR TITLE
Expose root volume kernel args, allow additional args

### DIFF
--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -12,6 +12,7 @@ resource "matchbox_profile" "container-linux-install" {
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
+    "${var.kernel_args}",
   ]
 
   container_linux_config = "${data.template_file.container-linux-install-config.rendered}"
@@ -47,6 +48,7 @@ resource "matchbox_profile" "cached-container-linux-install" {
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
+    "${var.kernel_args}",
   ]
 
   container_linux_config = "${data.template_file.cached-container-linux-install-config.rendered}"

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -109,3 +109,9 @@ variable "container_linux_oem" {
   default     = ""
   description = "Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
 }
+
+variable "kernel_args" {
+  description = "Additional kernel arguments the servers should boot with."
+  type        = "list"
+  default     = []
+}

--- a/bare-metal/container-linux/pxe-worker/profiles.tf
+++ b/bare-metal/container-linux/pxe-worker/profiles.tf
@@ -8,12 +8,11 @@ resource "matchbox_profile" "bootkube-worker-pxe" {
   ]
 
   args = [
-    "root=/dev/sda1",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
-    "kvm-intel.nested=1",
+    "${var.kernel_args}",
   ]
 
   container_linux_config = "${file("${path.module}/cl/bootkube-worker.yaml.tmpl")}"

--- a/bare-metal/container-linux/pxe-worker/variables.tf
+++ b/bare-metal/container-linux/pxe-worker/variables.tf
@@ -53,3 +53,14 @@ variable "kube_dns_service_ip" {
   type        = "string"
   default     = "10.3.0.10"
 }
+
+# optional
+
+variable "kernel_args" {
+  description = "Additional kernel arguments the server should boot with."
+  type        = "list"
+
+  default = [
+    "root=/dev/sda1",
+  ]
+}


### PR DESCRIPTION
Expose root volume kernel args, allow additional args.
`bare-metal/container-linux/pxe-worker` module only for now.

* Add `kernel_args` input variable - kernel arguments that supplement the defaults.
  * NOTE: `kvm-intel.nested=1` is the default value to preserve previous behavior. So a user will wipe that out if they define this variable themselves and omit it.
* Add `root_partition` input variable - allows customizing the R/W ROOT partition for container-linux
* Add `root_ramdisk_fstype` input variable - allows choosing between tempfs or btrfs if `root_partition` is empty

Current behavior is to ignore `root_partition` if the user sets `root_ramdisk_fstype`.

## Testing

### Test (1/3) - `root_ramdisk_fstype` set

Module config:
```hcl
# [...]
  # kernel
  root_partition = "/dev/sda1"
  root_ramdisk_fstype = "btrfs"
# [...]
```

ipxe script
```
$ curl "http://control.zbrbdl:8080/ipxe?uuid=7ea01178-3f57-a94c-b2c8-540e8ce14aad&mac=98-de-d0-00-21-39"

#!ipxe
kernel http://alpha.release.core-os.net/amd64-usr/1535.2.0/coreos_production_pxe.vmlinuz rootfstype=btrfs coreos.config.url=http://control.zbrbdl.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=yes console=tty0 console=ttyS0 kvm-intel.nested=1
initrd http://alpha.release.core-os.net/amd64-usr/1535.2.0/coreos_production_pxe_image.cpio.gz 
boot
```

Host environment
```
core@worker-01 ~ $ cat /proc/cmdline 
rootflags=rw mount.usrflags=ro rootfstype=btrfs coreos.config.url=http://control.zbrbdl.com:8080/ignition?uuid=7ea01178-3f57-a94c-b2c8-540e8ce14aad&mac=98-de-d0-00-21-39 coreos.first_boot=yes console=tty0 console=ttyS0 kvm-intel.nested=1

core@worker-01 ~ $ findmnt /       
TARGET SOURCE     FSTYPE OPTIONS
/      /dev/loop0 btrfs  rw,relatime,seclabel,compress=lzo,discard,space_cache,subvolid=5,subvol=/
```

### Test (2/3) - Default settings, (`root_ramdisk_fstype` not set)

ipxe script:
```
#!ipxe
kernel http://alpha.release.core-os.net/amd64-usr/1535.2.0/coreos_production_pxe.vmlinuz root=/dev/sda1 coreos.config.url=http://control.zbrbdl.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=yes console=tty0 console=ttyS0 kvm-intel.nested=1
initrd http://alpha.release.core-os.net/amd64-usr/1535.2.0/coreos_production_pxe_image.cpio.gz 
boot
```

### Test (3/3) - Custom kernel parameters
Module config:
```hcl
# [...]
  # kernel
  kernel_args = [
    "ipv6.disable=1",
  ]
# [...]
```
ipxe script
```
#!ipxe
kernel http://alpha.release.core-os.net/amd64-usr/1535.2.0/coreos_production_pxe.vmlinuz root=/dev/sda1 coreos.config.url=http://control.zbrbdl.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=yes console=tty0 console=ttyS0 ipv6.disable=1
initrd http://alpha.release.core-os.net/amd64-usr/1535.2.0/coreos_production_pxe_image.cpio.gz 
boot
```