### PR TITLE
Add temporary variables for multi-nic testing

### DIFF
--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -107,22 +107,6 @@ systemd:
         ExecStart=/opt/bootkube/bootkube-start
         ExecStartPost=/bin/touch /opt/bootkube/init_bootkube.done
 storage:
-  {{ if index . "pxe" }}
-  disks:
-    - device: /dev/sda
-      wipe_table: true
-      partitions:
-        - label: ROOT
-  filesystems:
-    - name: root
-      mount:
-        device: "/dev/sda1"
-        format: "ext4"
-        create:
-          force: true
-          options:
-            - "-LROOT"
-  {{end}}
   files:
     - path: /etc/kubernetes/kubelet.env
       filesystem: root

--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -172,6 +172,8 @@ storage:
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"
+networkd:
+  ${networkd_content}
 passwd:
   users:
     - name: core

--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -108,6 +108,8 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
+networkd:
+  ${networkd_content}
 passwd:
   users:
     - name: core

--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -73,22 +73,6 @@ systemd:
         WantedBy=multi-user.target
 
 storage:
-  {{ if index . "pxe" }}
-  disks:
-    - device: /dev/sda
-      wipe_table: true
-      partitions:
-        - label: ROOT
-  filesystems:
-    - name: root
-      mount:
-        device: "/dev/sda1"
-        format: "ext4"
-        create:
-          force: true
-          options:
-            - "-LROOT"
-  {{end}}
   files:
     - path: /etc/kubernetes/kubelet.env
       filesystem: root

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -87,6 +87,7 @@ data "template_file" "controller-configs" {
     etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", var.controller_names, var.controller_domains))}"
     k8s_dns_service_ip   = "${module.bootkube.kube_dns_service_ip}"
     ssh_authorized_key   = "${var.ssh_authorized_key}"
+    networkd_content = "${element(var.controller_networkds, count.index)}"
   }
 }
 
@@ -106,5 +107,6 @@ data "template_file" "worker-configs" {
     domain_name        = "${element(var.worker_domains, count.index)}"
     k8s_dns_service_ip = "${module.bootkube.kube_dns_service_ip}"
     ssh_authorized_key = "${var.ssh_authorized_key}"
+    networkd_content = "${element(var.worker_networkds, count.index)}"
   }
 }

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -111,7 +111,22 @@ variable "container_linux_oem" {
 }
 
 variable "kernel_args" {
-  description = "Additional kernel arguments the servers should boot with."
+  description = "Additional kernel arguments to provide at PXE boot."
   type        = "list"
   default     = []
 }
+
+# unofficial, undocumented, unsupported, temporary
+
+variable "controller_networkds" {
+  type = "list"
+  description = "Controller Container Linux config networkd section"
+  default = []
+}
+
+variable "worker_networkds" {
+  type = "list"
+  description = "Worker Container Linux config networkd section"
+  default = []
+}
+

--- a/bare-metal/container-linux/pxe-worker/variables.tf
+++ b/bare-metal/container-linux/pxe-worker/variables.tf
@@ -57,9 +57,8 @@ variable "kube_dns_service_ip" {
 # optional
 
 variable "kernel_args" {
-  description = "Additional kernel arguments the server should boot with."
+  description = "Additional kernel arguments to provide at PXE boot."
   type        = "list"
-
   default = [
     "root=/dev/sda1",
   ]

--- a/docs/topics/performance.md
+++ b/docs/topics/performance.md
@@ -29,7 +29,7 @@ Network performance varies based on the platform and CNI plugin. `iperf` was use
 | AWS (calico, MTU 8991)     | ?      | 976 MB/s     | 900-999 MB/s |
 | Bare-Metal (flannel)       | 1 GB/s | 934 MB/s     | 903 MB/s     | 
 | Bare-Metal (calico)        | 1 GB/s | 941 MB/s     | 931 MB/s     |
-| Bare-Metal (flannel, bond) | 3 GB/s | TODO         | TODO         | 
+| Bare-Metal (flannel, bond) | 3 GB/s |  2.3 GB/s    | 1.17 GB/s    | 
 | Bare-Metal (calico, bond)  | 3 GB/s |  2.3 GB/s    | 1.17 GB/s    |
 | Digital Ocean              | ?      | 938 MB/s     | 820-880 MB/s |
 | Google Cloud (flannel)     | ?      | 1.94 GB/s    | 1.76 GB/s    |
@@ -43,4 +43,4 @@ Notes:
 * Only [certain AWS EC2 instance types](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/network_mtu.html#jumbo_frame_instances) allow jumbo frames. This is why the default MTU on AWS must be 1480.
 * Between Flannel and Calico, performance differences are usually minimal. Platform and configuration differenes dominate.
 * Pods do not seem to be able to leverage the hosts' bonded NIC setup. Possibly a testing artifact.
-
+* Observing the same bonded NIC pod-to-pod limit suggests the bottleneck lies below flannel and calico.


### PR DESCRIPTION
Completed tests on the bonded NIC test cluster show flannel hits the the same pod-to-pod bandwidth limit that Calico does. This strongly suggests the bottleneck lies below flannel/Calico so no need to pester Calico about it (docker limit? host misconfiguration? if we team do we get the same limit?)

For now, let's post the results and commit these temporary variables.