### PR TITLE
Require minimum Terraform and plugin versions

### DIFF
--- a/aws/container-linux/kubernetes/require.tf
+++ b/aws/container-linux/kubernetes/require.tf
@@ -1,0 +1,25 @@
+# Terraform version and plugin versions
+
+terraform {
+  required_version = ">= 0.10.4"
+}
+
+provider "aws" {
+  version = "~> 1.0.0"
+}
+
+provider "local" {
+  version = "~> 1.0.0"
+}
+
+provider "null" {
+  version = "~> 1.0.0"
+}
+
+provider "template" {
+  version = "~> 1.0.0"
+}
+
+provider "tls" {
+  version = "~> 1.0.0"
+}

--- a/aws/container-linux/kubernetes/require.tf
+++ b/aws/container-linux/kubernetes/require.tf
@@ -5,21 +5,21 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "local" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "null" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "template" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "tls" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }

--- a/bare-metal/container-linux/kubernetes/require.tf
+++ b/bare-metal/container-linux/kubernetes/require.tf
@@ -1,0 +1,21 @@
+# Terraform version and plugin versions
+
+terraform {
+  required_version = ">= 0.10.4"
+}
+
+provider "local" {
+  version = "~> 1.0.0"
+}
+
+provider "null" {
+  version = "~> 1.0.0"
+}
+
+provider "template" {
+  version = "~> 1.0.0"
+}
+
+provider "tls" {
+  version = "~> 1.0.0"
+}

--- a/bare-metal/container-linux/kubernetes/require.tf
+++ b/bare-metal/container-linux/kubernetes/require.tf
@@ -5,17 +5,17 @@ terraform {
 }
 
 provider "local" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "null" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "template" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "tls" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }

--- a/digital-ocean/container-linux/kubernetes/require.tf
+++ b/digital-ocean/container-linux/kubernetes/require.tf
@@ -9,17 +9,17 @@ provider "digitalocean" {
 }
 
 provider "local" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "null" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "template" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "tls" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }

--- a/digital-ocean/container-linux/kubernetes/require.tf
+++ b/digital-ocean/container-linux/kubernetes/require.tf
@@ -1,0 +1,25 @@
+# Terraform version and plugin versions
+
+terraform {
+  required_version = ">= 0.10.4"
+}
+
+provider "digitalocean" {
+  version = "0.1.2"
+}
+
+provider "local" {
+  version = "~> 1.0.0"
+}
+
+provider "null" {
+  version = "~> 1.0.0"
+}
+
+provider "template" {
+  version = "~> 1.0.0"
+}
+
+provider "tls" {
+  version = "~> 1.0.0"
+}

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -16,7 +16,7 @@ Controllers and workers are provisioned to run a `kubelet`. A one-time [bootkube
 
 * AWS Account and IAM credentials
 * AWS Route53 DNS Zone (registered Domain Name or delegated subdomain)
-* Terraform v0.10.1+ and [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) installed locally
+* Terraform v0.10.4+ and [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) installed locally
 
 ## Terraform Setup
 
@@ -24,7 +24,7 @@ Install [Terraform](https://www.terraform.io/downloads.html) v0.10.1 on your sys
 
 ```sh
 $ terraform version
-Terraform v0.10.1
+Terraform v0.10.7
 ```
 
 Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system.

--- a/docs/bare-metal.md
+++ b/docs/bare-metal.md
@@ -12,7 +12,7 @@ Controllers are provisioned as etcd peers and run `etcd-member` (etcd3) and `kub
 * PXE-enabled [network boot](https://coreos.com/matchbox/docs/latest/network-setup.html) environment
 * Matchbox v0.6+ deployment with API enabled
 * Matchbox credentials `client.crt`, `client.key`, `ca.crt`
-* Terraform v0.9.2+ and [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) installed locally
+* Terraform v0.10.4+ and [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) installed locally
 
 ## Machines
 
@@ -113,7 +113,7 @@ Install [Terraform](https://www.terraform.io/downloads.html) v0.9.2+ on your sys
 
 ```sh
 $ terraform version
-Terraform v0.10.1
+Terraform v0.10.7
 ```
 
 Add the [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) plugin binary for your system.

--- a/docs/digital-ocean.md
+++ b/docs/digital-ocean.md
@@ -10,7 +10,7 @@ Controllers and workers are provisioned to run a `kubelet`. A one-time [bootkube
 
 * Digital Ocean Account and Token
 * Digital Ocean Domain (registered Domain Name or delegated subdomain)
-* Terraform v0.10.1+ and [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) installed locally
+* Terraform v0.10.4+ and [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) installed locally
 
 ## Terraform Setup
 
@@ -18,7 +18,7 @@ Install [Terraform](https://www.terraform.io/downloads.html) v0.10.1+ on your sy
 
 ```sh
 $ terraform version
-Terraform v0.10.1
+Terraform v0.10.7
 ```
 
 Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system.

--- a/docs/google-cloud.md
+++ b/docs/google-cloud.md
@@ -10,7 +10,7 @@ Controllers and workers are provisioned to run a `kubelet`. A one-time [bootkube
 
 * Google Cloud Account and Service Account
 * Google Cloud DNS Zone (registered Domain Name or delegated subdomain)
-* Terraform v0.9.2+ and [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) installed locally
+* Terraform v0.10.4+ and [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) installed locally
 
 ## Terraform Setup
 
@@ -18,7 +18,7 @@ Install [Terraform](https://www.terraform.io/downloads.html) v0.9.2+ on your sys
 
 ```sh
 $ terraform version
-Terraform v0.10.1
+Terraform v0.10.7
 ```
 
 Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system.

--- a/google-cloud/container-linux/kubernetes/require.tf
+++ b/google-cloud/container-linux/kubernetes/require.tf
@@ -5,21 +5,21 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 1.0.1"
+  version = "~> 1.0"
 }
 
 provider "local" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "null" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "template" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }
 
 provider "tls" {
-  version = "~> 1.0.0"
+  version = "~> 1.0"
 }

--- a/google-cloud/container-linux/kubernetes/require.tf
+++ b/google-cloud/container-linux/kubernetes/require.tf
@@ -1,0 +1,25 @@
+# Terraform version and plugin versions
+
+terraform {
+  required_version = ">= 0.10.4"
+}
+
+provider "google" {
+  version = "~> 1.0.1"
+}
+
+provider "local" {
+  version = "~> 1.0.0"
+}
+
+provider "null" {
+  version = "~> 1.0.0"
+}
+
+provider "template" {
+  version = "~> 1.0.0"
+}
+
+provider "tls" {
+  version = "~> 1.0.0"
+}


### PR DESCRIPTION
Requiring minimum versions of provider plugins makes Terraform more consistent. You don't have to guess which version of Terraform or which version of the "google" or "aws" plugins we developed against. When a version requirement changes, we'll bump it and you'll be prompted to update.

* Bump minimum Terraform version to v0.10.4
* Allow minor version updates for 1.0+ plugins
* Fix versions for plugins which are pre-1.0

### Updates

If you've been using old versions of provider plugins, you'll see an error after updating your source ref=hash to this commit or beyond.

```
$ terraform get --update
$ terraform plan
Plugin reinitialization required. Please run "terraform init".                                                                                                                                                     
Reason: Could not satisfy plugin requirements.                                                                                                                                                                     
                                                                                                                                                                                                                   
Plugins are external binaries that Terraform uses to access and manipulate                                                                                                                                         
resources. The configuration provided requires plugins which can't be located,                                                                                                                                     
don't satisfy the version constraints, or are otherwise incompatible.                                                                                                                                              
                                                                                                                                                                                                                   
3 error(s) occurred:                                                                                                                                                                                               
                                                                                                                                                                                                                   
* provider.template: no suitable version installed                                                                                                                                                                 
  version requirements: "~> 1.0.0"                                                                                                                                                                                 
  versions installed: "0.1.1"                                                                                                                                                                                      
* provider.null: no suitable version installed                                                                                                                                                                     
  version requirements: "~> 1.0.0"                                                                                                                                                                                 
  versions installed: "0.1.0"                                                                                                                                                                                      
* provider.aws: no suitable version installed                                                                                                                                                                      
  version requirements: "~> 1.0.0"                                                                                                                                                                                 
  versions installed: "0.1.4"                                                                                                                                                                                      
                                                                                                                                                                                                                   
Terraform automatically discovers provider requirements from your                                                                                                                                                  
configuration, including providers used in child modules. To see the                                                                                                                                               
requirements and constraints from each module, run "terraform providers".                                                                                                                                          
                                                                                                                                                                                                                   
error satisfying plugin requirements     
```

To install the snazzy new plugins,

```
terraform init                                                                                                                                                                                
Downloading modules...                                                                                                                                                                                             
                                                                                                                                                                                                                   
Initializing the backend...                                                                                                                                                                                        
                                                                                                                                                                                                                   
Initializing provider plugins...                                                                                                                                                                                   
- Checking for available provider plugins on https://releases.hashicorp.com...                                                                                                                                     
- Downloading plugin for provider "aws" (1.0.0)...                                                                                                                                                                 
- Downloading plugin for provider "null" (1.0.0)...                                                                                                                                                                
- Downloading plugin for provider "template" (1.0.0)...                                                                                                                                                            
                                                                                                                                                                                                                   
Terraform has been successfully initialized!
```

If you encounter issues, please open an issue as versions are a new concept for provider plugins. You can inspect provider constraints by running `terraform providers`.

### Note

I've also noticed that after updates, `template_file` will plan to touch directories (not files!) again. I've found this to be safe to apply (make sure there is nothing else in plan).

