### PR TITLE
Update from docker 1.12 to docker 17.09

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,9 @@ Notable changes between versions.
 ## Latest
 
 * Kubernetes v1.8.4
-* Calico related bug fixes
+* Enable Docker 17.09 on Container Linux (replaces Docker 1.12)
 * Update Calico from v2.6.1 to v2.6.3
 * Update flannel from v0.9.0 to v0.9.1
-* Use service accounts for kube-proxy and pod-checkpointer
 
 ## v1.8.3
 

--- a/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -129,6 +129,11 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
           KUBELET_IMAGE_TAG=v1.8.4
+    - path: /etc/coreos/docker-1.12
+      filesystem: root
+      contents:
+        inline: |
+          no
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -104,6 +104,11 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
           KUBELET_IMAGE_TAG=v1.8.4
+    - path: /etc/coreos/docker-1.12
+      filesystem: root
+      contents:
+        inline: |
+          no
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -121,6 +121,11 @@ storage:
       contents:
         inline:
           ${domain_name}
+    - path: /etc/coreos/docker-1.12
+      filesystem: root
+      contents:
+        inline: |
+          no
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -87,6 +87,11 @@ storage:
       contents:
         inline:
           ${domain_name}
+    - path: /etc/coreos/docker-1.12
+      filesystem: root
+      contents:
+        inline: |
+          no
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/bare-metal/container-linux/pxe-worker/cl/bootkube-worker.yaml.tmpl
+++ b/bare-metal/container-linux/pxe-worker/cl/bootkube-worker.yaml.tmpl
@@ -103,6 +103,11 @@ storage:
       contents:
         inline:
           {{.domain_name}}
+    - path: /etc/coreos/docker-1.12
+      filesystem: root
+      contents:
+        inline: |
+          no
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -120,6 +120,11 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
           KUBELET_IMAGE_TAG=v1.8.4
+    - path: /etc/coreos/docker-1.12
+      filesystem: root
+      contents:
+        inline: |
+          no
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -95,6 +95,11 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
           KUBELET_IMAGE_TAG=v1.8.4
+    - path: /etc/coreos/docker-1.12
+      filesystem: root
+      contents:
+        inline: |
+          no
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
+++ b/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
@@ -130,6 +130,11 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
           KUBELET_IMAGE_TAG=v1.8.4
+    - path: /etc/coreos/docker-1.12
+      filesystem: root
+      contents:
+        inline: |
+          no
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/google-cloud/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/google-cloud/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -105,6 +105,11 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
           KUBELET_IMAGE_TAG=v1.8.4
+    - path: /etc/coreos/docker-1.12
+      filesystem: root
+      contents:
+        inline: |
+          no
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:


### PR DESCRIPTION
Kubernetes 1.8 recommends docker 17.03. Container Linux stable ships with 1.12 which is still fine for Kubernetes 1.8. An upcoming stable release will switch to 17.09 though. This PR shares some docker 17.09 testing work I've been doing to help identify any issues.

**UPDATE: Typhoon will move directly to Docker 17.09.**

Docker's version mess:

* 1.12 - technically (near)deprecated by Docker. Most well used since most Container Linux Kubernetes clusters use this version. 
* 17.03 - Kubernetes 1.8 recommendation
* 17.09 - Upcoming Docker version on Container Linux stable

So far, clusters run ok with Docker 17.09.
```
$ docker version
Client:
 Version:      17.09.0-ce
 API version:  1.32
 Go version:   go1.8.2
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:24:58 2017
 OS/Arch:      linux/amd64

Server:
 Version:      17.09.0-ce
 API version:  1.32 (minimum version 1.12)
 Go version:   go1.8.2
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:24:58 2017
 OS/Arch:      linux/amd64
 Experimental: false
```

```
$ kubectl describe nodes | grep docker
Container Runtime Version:     docker://Unknown
...
```