### PR TITLE
Google Cloud regional workers and improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between versions.
 
 ## Latest
 
+#### Google Cloud
+
+* Add required variable `region`
+* Change worker managed instance group to automatically span zones in a region
+
 ## v1.8.2
 
 * Kubernetes v1.8.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,9 @@ Notable changes between versions.
 
 #### Google Cloud
 
-* Add required variable `region`
+* Add required variable `region` (e.g. "us-central1")
 * Change worker managed instance group to automatically span zones in a region
+* Remove `controller_preemptible` optional variable (breaking)
 
 ## v1.8.2
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ module "google-cloud-yavin" {
   source = "git::https://github.com/poseidon/typhoon//google-cloud/container-linux/kubernetes"
 
   # Google Cloud
+  region        = "us-central1"
   zone          = "us-central1-c"
   dns_zone      = "example.com"
   dns_zone_name = "example-zone"

--- a/docs/google-cloud.md
+++ b/docs/google-cloud.md
@@ -240,5 +240,5 @@ Check the list of valid [machine types](https://cloud.google.com/compute/docs/ma
 
 #### Preemption
 
-Add `worker_premeptible = "true"` to allow worker nodes to be [preempted](https://cloud.google.com/compute/docs/instances/preemptible) at random, but pay [significantly](https://cloud.google.com/compute/pricing) less. Clusters tolerate stopping instances fairly well (reschedules pods, but cannot drain) and preemption provides a nice reward for running fault-tolerant cluster systems.`
+Add `worker_preemeptible = "true"` to allow worker nodes to be [preempted](https://cloud.google.com/compute/docs/instances/preemptible) at random, but pay [significantly](https://cloud.google.com/compute/pricing) less. Clusters tolerate stopping instances fairly well (reschedules pods, but cannot drain) and preemption provides a nice reward for running fault-tolerant cluster systems.`
 

--- a/docs/google-cloud.md
+++ b/docs/google-cloud.md
@@ -77,6 +77,7 @@ module "google-cloud-yavin" {
   source = "git::https://github.com/poseidon/typhoon//google-cloud/container-linux/kubernetes"
 
   # Google Cloud
+  region        = "us-central1"
   zone          = "us-central1-c"
   dns_zone      = "example.com"
   dns_zone_name = "example-zone"
@@ -196,6 +197,7 @@ Learn about [version pinning](concepts.md#versioning), maintenance, and [addons]
 | Name | Description | Example |
 |:-----|:------------|:--------|
 | cluster_name | Unique cluster name (prepended to dns_zone) | "yavin" |
+| region | Google Cloud region | "us-central1" |
 | zone | Google Cloud zone | "us-central1-f" |
 | dns_zone | Google Cloud DNS zone | "google-cloud.example.com" |
 | dns_zone_name | Google Cloud DNS zone name | "example-zone" |

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ module "google-cloud-yavin" {
   source = "git::https://github.com/poseidon/typhoon//google-cloud/container-linux/kubernetes"
 
   # Google Cloud
+  region        = "us-central1"
   zone          = "us-central1-c"
   dns_zone      = "example.com"
   dns_zone_name = "example-zone"

--- a/google-cloud/container-linux/kubernetes/cluster.tf
+++ b/google-cloud/container-linux/kubernetes/cluster.tf
@@ -29,8 +29,8 @@ module "workers" {
 
   # GCE
   network      = "${google_compute_network.network.name}"
+  region       = "${var.region}"
   count        = "${var.worker_count}"
-  zone         = "${var.zone}"
   machine_type = "${var.machine_type}"
   os_image     = "${var.os_image}"
   preemptible  = "${var.worker_preemptible}"

--- a/google-cloud/container-linux/kubernetes/cluster.tf
+++ b/google-cloud/container-linux/kubernetes/cluster.tf
@@ -11,7 +11,6 @@ module "controllers" {
   dns_zone_name = "${var.dns_zone_name}"
   machine_type  = "${var.machine_type}"
   os_image      = "${var.os_image}"
-  preemptible   = "${var.controller_preemptible}"
 
   # configuration
   networking              = "${var.networking}"

--- a/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
+++ b/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
@@ -147,4 +147,4 @@ passwd:
   users:
     - name: core
       ssh_authorized_keys:
-        - "${ssh_authorized_keys}"
+        - "${ssh_authorized_key}"

--- a/google-cloud/container-linux/kubernetes/controllers/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/controllers.tf
@@ -45,11 +45,6 @@ resource "google_compute_instance_template" "controller" {
     user-data = "${data.ct_config.controller_ign.rendered}"
   }
 
-  scheduling {
-    automatic_restart = "${var.preemptible ? false : true}"
-    preemptible       = "${var.preemptible}"
-  }
-
   disk {
     auto_delete  = true
     boot         = true

--- a/google-cloud/container-linux/kubernetes/controllers/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/controllers.tf
@@ -50,10 +50,6 @@ resource "google_compute_instance_template" "controller" {
     boot         = true
     source_image = "${var.os_image}"
     disk_size_gb = "${var.disk_size}"
-
-    // Set explicit name to match the new default name set by the API.
-    // https://github.com/terraform-providers/terraform-provider-google/issues/574
-    device_name = "persistent-disk-0"
   }
 
   network_interface {

--- a/google-cloud/container-linux/kubernetes/controllers/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/controllers.tf
@@ -23,7 +23,7 @@ data "template_file" "controller_config" {
   vars = {
     k8s_dns_service_ip      = "${cidrhost(var.service_cidr, 10)}"
     k8s_etcd_service_ip     = "${cidrhost(var.service_cidr, 15)}"
-    ssh_authorized_keys     = "${var.ssh_authorized_key}"
+    ssh_authorized_key     = "${var.ssh_authorized_key}"
     kubeconfig_ca_cert      = "${var.kubeconfig_ca_cert}"
     kubeconfig_kubelet_cert = "${var.kubeconfig_kubelet_cert}"
     kubeconfig_kubelet_key  = "${var.kubeconfig_kubelet_key}"

--- a/google-cloud/container-linux/kubernetes/controllers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/variables.tf
@@ -51,12 +51,6 @@ variable "disk_size" {
   description = "The size of the disk in gigabytes."
 }
 
-variable "preemptible" {
-  type        = "string"
-  default     = "false"
-  description = "If enabled, Compute Engine will terminate instances randomly within 24 hours"
-}
-
 // configuration
 
 variable "networking" {

--- a/google-cloud/container-linux/kubernetes/require.tf
+++ b/google-cloud/container-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 1.0"
+  version = "~> 1.1"
 }
 
 provider "local" {

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -51,12 +51,6 @@ variable "worker_count" {
   description = "Number of workers"
 }
 
-variable "controller_preemptible" {
-  type        = "string"
-  default     = "false"
-  description = "If enabled, Compute Engine will terminate controllers randomly within 24 hours"
-}
-
 variable "worker_preemptible" {
   type        = "string"
   default     = "false"

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -3,9 +3,14 @@ variable "cluster_name" {
   description = "Cluster name"
 }
 
+variable "region" {
+  type        = "string"
+  description = "Google Cloud Region (e.g. us-central1, see `gcloud compute regions list`)"
+}
+
 variable "zone" {
   type        = "string"
-  description = "Google Cloud zone (e.g. us-central1-f, see `gcloud compute zones list`)"
+  description = "Google Cloud Zone (e.g. us-central1-f, see `gcloud compute zones list`)"
 }
 
 variable "dns_zone" {

--- a/google-cloud/container-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/workers/variables.tf
@@ -20,9 +20,9 @@ variable "count" {
   description = "Number of worker compute instances the instance group should manage"
 }
 
-variable "zone" {
+variable "region" {
   type        = "string"
-  description = "Google zone that compute instances in the group should be created in (e.g. gcloud compute zones list)"
+  description = "Google Cloud region to create a regional managed group of workers (e.g. us-central1, see `gcloud compute regions list`)."
 }
 
 variable "machine_type" {

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -56,10 +56,6 @@ resource "google_compute_instance_template" "worker" {
     boot         = true
     source_image = "${var.os_image}"
     disk_size_gb = "${var.disk_size}"
-
-    // Set explicit name to match the new default name set by the API.
-    // https://github.com/terraform-providers/terraform-provider-google/issues/574
-    device_name = "persistent-disk-0"
   }
 
   network_interface {

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -1,16 +1,17 @@
-# Managed Instance Group
-resource "google_compute_instance_group_manager" "workers" {
+# Regional managed instance group maintains a homogeneous set of workers that
+# span the zones in the region.
+resource "google_compute_region_instance_group_manager" "workers" {
   name        = "${var.cluster_name}-worker-group"
   description = "Compute instance group of ${var.cluster_name} workers"
 
-  # Instance name prefix for instances in the group
+  # instance name prefix for instances in the group
   base_instance_name = "${var.cluster_name}-worker"
   instance_template  = "${google_compute_instance_template.worker.self_link}"
-  update_strategy    = "RESTART"
-  zone               = "${var.zone}"
-  target_size        = "${var.count}"
+  region             = "${var.region}"
 
-  # Target pool instances in the group should be added into
+  target_size = "${var.count}"
+
+  # target pool to which instances in the group should be added
   target_pools = [
     "${google_compute_target_pool.workers.self_link}",
   ]


### PR DESCRIPTION
* Change Google Cloud module to require the `region` variable (CHANGE)
* Worker managed instance group creates workers across zones in a region.
  * Example: region: us-central1 means a worker may go in us-central1-c, us-central1-f, us-central1-a, etc.
  * Tolerate Google Cloud zone failures or capacity problems
  * Tradeoff: Changing user-data will no longer automatically roll workers. You can delete old instances and they'll be replaced by new instances. Worthwhile tradeoff since mutating user-data should only be needed in special cases. See https://github.com/terraform-providers/terraform-provider-google/pull/394
* Improvement/Note for Preemptible VMs:
  * If worker preemption is enabled, replacement instances can now be drawn from any zone in the region, which should avoid scheduling issues that were possible before if a single zone aggressively preempted instances (presumably due to Google Cloud capacity).

Cleanups:

* Fix typo in internal template variable name: ssh_authorized_keys should be ssh_authorized_key to match the user facing variable which only allows a single SSH authorized key
* Remove `controller_preemptible` option: Controller preemption is not safe or covered in documentation. Delete the option, the variable is a holdover from old experiments (BREAKING)
* Require google provider plugin 1.1 or higher which includes fix: terraform-providers/terraform-provider-google#574. Allows us to remove the static persistent disk name workaround (CHANGE)