### PR TITLE
addons: Update kube-state-metrics deployment

### DIFF
--- a/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
@@ -32,13 +32,6 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
-        resources:
-          requests:
-            memory: 100Mi
-            cpu: 100m
-          limits:
-            memory: 200Mi
-            cpu: 200m
       - name: addon-resizer
         image: gcr.io/google_containers/addon-resizer:1.0
         resources:

--- a/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
@@ -6,8 +6,9 @@ metadata:
 spec:
   replicas: 1
   strategy:
+    type: RollingUpdate
     rollingUpdate:
-      maxUnavilable: 1
+      maxUnavailable: 1
   selector:
     matchLabels:
       name: kube-state-metrics


### PR DESCRIPTION
* Fix typo in kube-state-metrics strategy
* Omit static resource requests/limits from kube-state-metrics
  * Allow the addon-resizer to dynamically set resource values
  * kubernetes/kube-state-metrics#285