### PR TITLE
google: etcd on-host, controllers span zones in the region

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,11 @@ Notable changes between versions.
 #### Google Cloud
 
 * Add required variable `region` (e.g. "us-central1")
+* Reduce time to bootstrap a cluster
+* Change etcd to run on-host, across controllers (etcd-member.service)
 * Change worker managed instance group to automatically span zones in a region
-* Remove `controller_preemptible` optional variable (breaking)
+* Remove support for self-hosted etcd
+* Remove `controller_preemptible` optional variable
 
 ## v1.8.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,11 @@ Notable changes between versions.
 * Add required variable `region` (e.g. "us-central1")
 * Reduce time to bootstrap a cluster
 * Change etcd to run on-host, across controllers (etcd-member.service)
-* Change worker managed instance group to automatically span zones in a region
+* Change controller instances to automatically span zones in the region
+* Change worker managed instance group to automatically span zones in the region
 * Remove support for self-hosted etcd
-* Remove `controller_preemptible` optional variable
+* Remove the `zone` required variable
+* Remove the `controller_preemptible` optional variable
 
 ## v1.8.2
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ module "google-cloud-yavin" {
 
   # Google Cloud
   region        = "us-central1"
-  zone          = "us-central1-c"
   dns_zone      = "example.com"
   dns_zone_name = "example-zone"
   os_image      = "coreos-stable-1465-6-0-v20170817"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ In 5-10 minutes (varies by platform), the cluster will be ready. This Google Clo
 $ KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
 $ kubectl get nodes
 NAME                                          STATUS   AGE    VERSION
-yavin-controller-1682.c.example-com.internal  Ready    6m     v1.8.2
+yavin-controller-0.c.example-com.internal     Ready    6m     v1.8.2
 yavin-worker-jrbf.c.example-com.internal      Ready    5m     v1.8.2
 yavin-worker-mzdm.c.example-com.internal      Ready    5m     v1.8.2
 ```
@@ -92,13 +92,10 @@ NAMESPACE     NAME                                      READY  STATUS    RESTART
 kube-system   calico-node-1cs8z                         2/2    Running   0         6m
 kube-system   calico-node-d1l5b                         2/2    Running   0         6m
 kube-system   calico-node-sp9ps                         2/2    Running   0         6m
-kube-system   etcd-operator-3329263108-f443m            1/1    Running   1         6m
 kube-system   kube-apiserver-zppls                      1/1    Running   0         6m
 kube-system   kube-controller-manager-3271970485-gh9kt  1/1    Running   0         6m
 kube-system   kube-controller-manager-3271970485-h90v8  1/1    Running   1         6m
 kube-system   kube-dns-1187388186-zj5dl                 3/3    Running   0         6m
-kube-system   kube-etcd-0000                            1/1    Running   0         5m
-kube-system   kube-etcd-network-checkpointer-crznb      1/1    Running   0         6m
 kube-system   kube-proxy-117v6                          1/1    Running   0         6m
 kube-system   kube-proxy-9886n                          1/1    Running   0         6m
 kube-system   kube-proxy-njn47                          1/1    Running   0         6m

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -14,6 +14,7 @@ resource "digitalocean_record" "controllers" {
   value = "${element(digitalocean_droplet.controllers.*.ipv4_address, count.index)}"
 }
 
+# Discrete DNS records for each controller's private IPv4 for etcd usage.
 resource "digitalocean_record" "etcds" {
   count = "${var.controller_count}"
 
@@ -25,7 +26,7 @@ resource "digitalocean_record" "etcds" {
   type = "A"
   ttl  = 300
 
-  # IPv4 addresses of controllers
+  # private IPv4 address for etcd
   value = "${element(digitalocean_droplet.controllers.*.ipv4_address_private, count.index)}"
 }
 

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -4,7 +4,7 @@ In this tutorial, we'll create a Kubernetes v1.8.2 cluster on AWS.
 
 We'll declare a Kubernetes cluster in Terraform using the Typhoon Terraform module. On apply, a VPC, gateway, subnets, auto-scaling groups of controllers and workers, network load balancers for controllers and workers, and security groups will be created.
 
-Controllers and workers are provisioned to run a `kubelet`. A one-time [bootkube](https://github.com/kubernetes-incubator/bootkube) bootstrap schedules `etcd`, `apiserver`, `scheduler`, `controller-manager`, and `kube-dns` on controllers and runs `kube-proxy` and `flannel` or `calico` on each node. A generated `kubeconfig` provides `kubectl` access to the cluster.
+Controllers and workers are provisioned to run a `kubelet`. A one-time [bootkube](https://github.com/kubernetes-incubator/bootkube) bootstrap schedules `etcd`, `apiserver`, `scheduler`, `controller-manager`, and `kube-dns` on controllers and runs `kube-proxy` and `calico` or `flannel` on each node. A generated `kubeconfig` provides `kubectl` access to the cluster.
 
 !!! warning "Alpha"
     Typhoon Kubernetes clusters on AWS are marked as "alpha".

--- a/docs/bare-metal.md
+++ b/docs/bare-metal.md
@@ -4,7 +4,7 @@ In this tutorial, we'll network boot and provison a Kubernetes v1.8.2 cluster on
 
 First, we'll deploy a [Matchbox](https://github.com/coreos/matchbox) service and setup a network boot environment. Then, we'll declare a Kubernetes cluster in Terraform using the Typhoon Terraform module and power on machines. On PXE boot, machines will install Container Linux to disk, reboot into the disk install, and provision themselves as Kubernetes controllers or workers.
 
-Controllers are provisioned as etcd peers and run `etcd-member` (etcd3) and `kubelet`. Workers are provisioned to run a `kubelet`. A one-time [bootkube](https://github.com/kubernetes-incubator/bootkube) bootstrap schedules an `apiserver`, `scheduler`, `controller-manager`, and `kube-dns` on controllers and runs `kube-proxy` and `flannel` or `calico` on each node. A generated `kubeconfig` provides `kubectl` access to the cluster.
+Controllers are provisioned as etcd peers and run `etcd-member` (etcd3) and `kubelet`. Workers are provisioned to run a `kubelet`. A one-time [bootkube](https://github.com/kubernetes-incubator/bootkube) bootstrap schedules an `apiserver`, `scheduler`, `controller-manager`, and `kube-dns` on controllers and runs `kube-proxy` and `calico` or `flannel` on each node. A generated `kubeconfig` provides `kubectl` access to the cluster.
 
 ## Requirements
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,7 @@ Formats rise and evolve. Typhoon may choose to adapt the format over time (with 
 
 ## Self-hosted etcd
 
-AWS and Google Cloud clusters run etcd as "self-hosted" pods, managed by the [etcd-operator](https://github.com/coreos/etcd-operator). By contrast, Typhoon bare-metal and Digital Ocean run an etcd peer as a systemd `etcd-member.service` on each controller (i.e. on-host).
+AWS clusters run etcd as "self-hosted" pods, managed by the [etcd-operator](https://github.com/coreos/etcd-operator). By contrast, Typhoon bare-metal, Digital Ocean, and Google Cloud run an etcd peer as a systemd `etcd-member.service` on each controller (i.e. on-host).
 
 In practice, self-hosted etcd has proven to be *ok*, but not ideal. Running the apiserver's etcd atop Kubernetes itself is inherently complex, but works in most cases. It can be opaque to debug if complex edge cases with upstream Kubernetes bugs arise.
 

--- a/docs/google-cloud.md
+++ b/docs/google-cloud.md
@@ -78,7 +78,6 @@ module "google-cloud-yavin" {
 
   # Google Cloud
   region        = "us-central1"
-  zone          = "us-central1-c"
   dns_zone      = "example.com"
   dns_zone_name = "example-zone"
   os_image      = "coreos-stable-1520-6-0-v20171012"
@@ -195,7 +194,6 @@ Learn about [version pinning](concepts.md#versioning), maintenance, and [addons]
 |:-----|:------------|:--------|
 | cluster_name | Unique cluster name (prepended to dns_zone) | "yavin" |
 | region | Google Cloud region | "us-central1" |
-| zone | Google Cloud zone | "us-central1-f" |
 | dns_zone | Google Cloud DNS zone | "google-cloud.example.com" |
 | dns_zone_name | Google Cloud DNS zone name | "example-zone" |
 | ssh_authorized_key | SSH public key for ~/.ssh_authorized_keys | "ssh-rsa AAAAB3NZ..." |

--- a/docs/google-cloud.md
+++ b/docs/google-cloud.md
@@ -4,7 +4,7 @@ In this tutorial, we'll create a Kubernetes v1.8.2 cluster on Google Compute Eng
 
 We'll declare a Kubernetes cluster in Terraform using the Typhoon Terraform module. On apply, a network, firewall rules, managed instance groups of Kubernetes controllers and workers, network load balancers for controllers and workers, and health checks will be created.
 
-Controllers and workers are provisioned to run a `kubelet`. A one-time [bootkube](https://github.com/kubernetes-incubator/bootkube) bootstrap schedules `etcd`, `apiserver`, `scheduler`, `controller-manager`, and `kube-dns` on controllers and runs `kube-proxy` and `flannel` on each node. A generated `kubeconfig` provides `kubectl` access to the cluster.
+Controllers and workers are provisioned to run a `kubelet`. A one-time [bootkube](https://github.com/kubernetes-incubator/bootkube) bootstrap schedules an `apiserver`, `scheduler`, `controller-manager`, and `kube-dns` on controllers and runs `kube-proxy` and `calico` or `flannel` on each node. A generated `kubeconfig` provides `kubectl` access to the cluster.
 
 ## Requirements
 
@@ -155,7 +155,7 @@ In 5-10 minutes, the Kubernetes cluster will be ready.
 $ KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
 $ kubectl get nodes
 NAME                                          STATUS   AGE    VERSION
-yavin-controller-1682.c.example-com.internal  Ready    6m     v1.8.2
+yavin-controller-0.c.example-com.internal     Ready    6m     v1.8.2
 yavin-worker-jrbf.c.example-com.internal      Ready    5m     v1.8.2
 yavin-worker-mzdm.c.example-com.internal      Ready    5m     v1.8.2
 ```
@@ -168,13 +168,10 @@ NAMESPACE     NAME                                      READY  STATUS    RESTART
 kube-system   calico-node-1cs8z                         2/2    Running   0         6m
 kube-system   calico-node-d1l5b                         2/2    Running   0         6m
 kube-system   calico-node-sp9ps                         2/2    Running   0         6m
-kube-system   etcd-operator-3329263108-f443m            1/1    Running   1         6m
 kube-system   kube-apiserver-zppls                      1/1    Running   0         6m
 kube-system   kube-controller-manager-3271970485-gh9kt  1/1    Running   0         6m
 kube-system   kube-controller-manager-3271970485-h90v8  1/1    Running   1         6m
 kube-system   kube-dns-1187388186-zj5dl                 3/3    Running   0         6m
-kube-system   kube-etcd-0000                            1/1    Running   0         5m
-kube-system   kube-etcd-network-checkpointer-crznb      1/1    Running   0         6m
 kube-system   kube-proxy-117v6                          1/1    Running   0         6m
 kube-system   kube-proxy-9886n                          1/1    Running   0         6m
 kube-system   kube-proxy-njn47                          1/1    Running   0         6m

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,6 @@ module "google-cloud-yavin" {
 
   # Google Cloud
   region        = "us-central1"
-  zone          = "us-central1-c"
   dns_zone      = "example.com"
   dns_zone_name = "example-zone"
   os_image      = "coreos-stable-1465-6-0-v20170817"

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ In 5-10 minutes (varies by platform), the cluster will be ready. This Google Clo
 $ KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
 $ kubectl get nodes
 NAME                                          STATUS   AGE    VERSION
-yavin-controller-1682.c.example-com.internal  Ready    6m     v1.8.2
+yavin-controller-0.c.example-com.internal     Ready    6m     v1.8.2
 yavin-worker-jrbf.c.example-com.internal      Ready    5m     v1.8.2
 yavin-worker-mzdm.c.example-com.internal      Ready    5m     v1.8.2
 ```
@@ -91,13 +91,10 @@ NAMESPACE     NAME                                      READY  STATUS    RESTART
 kube-system   calico-node-1cs8z                         2/2    Running   0         6m
 kube-system   calico-node-d1l5b                         2/2    Running   0         6m
 kube-system   calico-node-sp9ps                         2/2    Running   0         6m
-kube-system   etcd-operator-3329263108-f443m            1/1    Running   1         6m
 kube-system   kube-apiserver-zppls                      1/1    Running   0         6m
 kube-system   kube-controller-manager-3271970485-gh9kt  1/1    Running   0         6m
 kube-system   kube-controller-manager-3271970485-h90v8  1/1    Running   1         6m
 kube-system   kube-dns-1187388186-zj5dl                 3/3    Running   0         6m
-kube-system   kube-etcd-0000                            1/1    Running   0         5m
-kube-system   kube-etcd-network-checkpointer-crznb      1/1    Running   0         6m
 kube-system   kube-proxy-117v6                          1/1    Running   0         6m
 kube-system   kube-proxy-9886n                          1/1    Running   0         6m
 kube-system   kube-proxy-njn47                          1/1    Running   0         6m

--- a/docs/topics/performance.md
+++ b/docs/topics/performance.md
@@ -9,7 +9,7 @@ Provisioning times vary based on the platform. Sampling the time to create (appl
 | AWS           | 20 min | 8 min 10 sec |
 | Bare-Metal    | 10-14 min | NA  |
 | Digital Ocean | 3 min 30 sec | 20 sec |
-| Google Cloud  | 6 min 10 sec | 4 min 30 sec |
+| Google Cloud  | 4 min | 4 min 30 sec |
 
 Notes:
 

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -2,13 +2,12 @@
 module "bootkube" {
   source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=v0.8.1"
 
-  cluster_name                  = "${var.cluster_name}"
-  api_servers                   = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers                  = ["http://127.0.0.1:2379"]
-  asset_dir                     = "${var.asset_dir}"
-  networking                    = "${var.networking}"
-  network_mtu                   = 1440
-  pod_cidr                      = "${var.pod_cidr}"
-  service_cidr                  = "${var.service_cidr}"
-  experimental_self_hosted_etcd = "true"
+  cluster_name = "${var.cluster_name}"
+  api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
+  etcd_servers = "${module.controllers.etcd_fqdns}"
+  asset_dir    = "${var.asset_dir}"
+  networking   = "${var.networking}"
+  network_mtu  = 1440
+  pod_cidr     = "${var.pod_cidr}"
+  service_cidr = "${var.service_cidr}"
 }

--- a/google-cloud/container-linux/kubernetes/cluster.tf
+++ b/google-cloud/container-linux/kubernetes/cluster.tf
@@ -6,7 +6,7 @@ module "controllers" {
   # GCE
   network       = "${google_compute_network.network.name}"
   count         = "${var.controller_count}"
-  zone          = "${var.zone}"
+  region        = "${var.region}"
   dns_zone      = "${var.dns_zone}"
   dns_zone_name = "${var.dns_zone_name}"
   machine_type  = "${var.machine_type}"

--- a/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
+++ b/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
@@ -1,6 +1,29 @@
 ---
 systemd:
   units:
+    - name: etcd-member.service
+      enable: true
+      dropins:
+        - name: 40-etcd-cluster.conf
+          contents: |
+            [Service]
+            Environment="ETCD_IMAGE_TAG=v3.2.0"
+            Environment="ETCD_NAME=${etcd_name}"
+            Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
+            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"
+            Environment="ETCD_LISTEN_CLIENT_URLS=https://0.0.0.0:2379"
+            Environment="ETCD_LISTEN_PEER_URLS=https://0.0.0.0:2380"
+            Environment="ETCD_INITIAL_CLUSTER=${etcd_initial_cluster}"
+            Environment="ETCD_STRICT_RECONFIG_CHECK=true"
+            Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
+            Environment="ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/server-ca.crt"
+            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd/server.crt"
+            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd/server.key"
+            Environment="ETCD_CLIENT_CERT_AUTH=true"
+            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/peer-ca.crt"
+            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
+            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
+            Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
     - name: docker.service
       enable: true
     - name: locksmithd.service

--- a/google-cloud/container-linux/kubernetes/controllers/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/controllers.tf
@@ -14,12 +14,18 @@ resource "google_dns_record_set" "etcds" {
   rrdatas = ["${element(google_compute_instance.controllers.*.network_interface.0.address, count.index)}"]
 }
 
+# Zones in the region
+data "google_compute_zones" "available" {
+  region = "${var.region}"
+  status = "UP"
+}
+
 # Controller instances
 resource "google_compute_instance" "controllers" {
   count = "${var.count}"
 
   name         = "${var.cluster_name}-controller-${count.index}"
-  zone         = "${var.zone}"
+  zone         = "${element(data.google_compute_zones.available.names, count.index)}"
   machine_type = "${var.machine_type}"
 
   metadata {

--- a/google-cloud/container-linux/kubernetes/controllers/network.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/network.tf
@@ -30,7 +30,7 @@ resource "google_compute_target_pool" "controllers" {
   name = "${var.cluster_name}-controller-pool"
 
   instances = [
-    "${google_compute_instance.controllers.*.self_link}",
+    "${formatlist("%s/%s", google_compute_instance.controllers.*.zone, google_compute_instance.controllers.*.name)}"
   ]
 
   health_checks = [

--- a/google-cloud/container-linux/kubernetes/controllers/outputs.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/outputs.tf
@@ -1,0 +1,11 @@
+output "etcd_fqdns" {
+  value = ["${null_resource.repeat.*.triggers.domain}"]
+}
+
+output "ipv4_public" {
+  value = ["${google_compute_instance.controllers.*.network_interface.0.access_config.0.assigned_nat_ip}"]
+}
+
+output "ipv4_private" {
+  value = ["${google_compute_instance.controllers.*.network_interface.0.address}"]
+}

--- a/google-cloud/container-linux/kubernetes/controllers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/variables.tf
@@ -30,9 +30,9 @@ variable "count" {
   description = "Number of controller compute instances the instance group should manage"
 }
 
-variable "zone" {
+variable "region" {
   type        = "string"
-  description = "Google zone that compute instances in the group should be created in (e.g. gcloud compute zones list)"
+  description = "Google Cloud region (e.g. us-central1, see `gcloud compute regions list`)."
 }
 
 variable "machine_type" {

--- a/google-cloud/container-linux/kubernetes/outputs.tf
+++ b/google-cloud/container-linux/kubernetes/outputs.tf
@@ -1,3 +1,11 @@
+output "controllers_ipv4_public" {
+  value = ["${module.controllers.ipv4_public}"]
+}
+
+output "controllers_ipv4_private" {
+  value = ["${module.controllers.ipv4_private}"]
+}
+
 output "ingress_static_ip" {
   value = "${module.workers.ingress_static_ip}"
 }

--- a/google-cloud/container-linux/kubernetes/ssh.tf
+++ b/google-cloud/container-linux/kubernetes/ssh.tf
@@ -1,12 +1,80 @@
+# Secure copy etcd TLS assets and kubeconfig to controllers. Activates kubelet.service
+resource "null_resource" "copy-secrets" {
+  depends_on = ["module.controllers", "module.bootkube"]
+  count      = "${var.controller_count}"
+
+  connection {
+    type    = "ssh"
+    host    = "${element(module.controllers.ipv4_public, count.index)}"
+    user    = "core"
+    timeout = "15m"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.kubeconfig}"
+    destination = "$HOME/kubeconfig"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_ca_cert}"
+    destination = "$HOME/etcd-client-ca.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_client_cert}"
+    destination = "$HOME/etcd-client.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_client_key}"
+    destination = "$HOME/etcd-client.key"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_server_cert}"
+    destination = "$HOME/etcd-server.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_server_key}"
+    destination = "$HOME/etcd-server.key"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_peer_cert}"
+    destination = "$HOME/etcd-peer.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_peer_key}"
+    destination = "$HOME/etcd-peer.key"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /etc/ssl/etcd/etcd",
+      "sudo mv etcd-client* /etc/ssl/etcd/",
+      "sudo cp /etc/ssl/etcd/etcd-client-ca.crt /etc/ssl/etcd/etcd/server-ca.crt",
+      "sudo mv etcd-server.crt /etc/ssl/etcd/etcd/server.crt",
+      "sudo mv etcd-server.key /etc/ssl/etcd/etcd/server.key",
+      "sudo cp /etc/ssl/etcd/etcd-client-ca.crt /etc/ssl/etcd/etcd/peer-ca.crt",
+      "sudo mv etcd-peer.crt /etc/ssl/etcd/etcd/peer.crt",
+      "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
+      "sudo chown -R etcd:etcd /etc/ssl/etcd",
+      "sudo chmod -R 500 /etc/ssl/etcd",
+      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
+    ]
+  }
+}
+
 # Secure copy bootkube assets to ONE controller and start bootkube to perform
 # one-time self-hosted cluster bootstrapping.
 resource "null_resource" "bootkube-start" {
   depends_on = ["module.controllers", "module.workers", "module.bootkube"]
 
-  # TODO: SSH to a controller's IP instead of waiting on DNS resolution
   connection {
     type    = "ssh"
-    host    = "${format("%s.%s", var.cluster_name, var.dns_zone)}"
+    host    = "${element(module.controllers.ipv4_public, 0)}"
     user    = "core"
     timeout = "15m"
   }

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -8,11 +8,6 @@ variable "region" {
   description = "Google Cloud Region (e.g. us-central1, see `gcloud compute regions list`)"
 }
 
-variable "zone" {
-  type        = "string"
-  description = "Google Cloud Zone (e.g. us-central1-f, see `gcloud compute zones list`)"
-}
-
 variable "dns_zone" {
   type        = "string"
   description = "Google Cloud DNS Zone (e.g. google-cloud.dghubble.io)"

--- a/google-cloud/container-linux/kubernetes/workers/network.tf
+++ b/google-cloud/container-linux/kubernetes/workers/network.tf
@@ -1,4 +1,4 @@
-# Static IP for the Network Load Balancer
+# Static IPv4 address for the Network Load Balancer
 resource "google_compute_address" "ingress-ip" {
   name = "${var.cluster_name}-ingress-ip"
 }

--- a/google-cloud/container-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/workers/variables.tf
@@ -22,7 +22,7 @@ variable "count" {
 
 variable "region" {
   type        = "string"
-  description = "Google Cloud region to create a regional managed group of workers (e.g. us-central1, see `gcloud compute regions list`)."
+  description = "Google Cloud region (e.g. us-central1, see `gcloud compute regions list`)."
 }
 
 variable "machine_type" {


### PR DESCRIPTION
Run etcd on-host, across controllers (etcd-member.service)
  * Change controllers from a managed group to individual instances
  * Create discrete DNS records to each controller's private IP for etcd
  * Reduce time to bootstrap a cluster
  * Deprecate self-hosted-etcd on the Google Cloud platform

Create controller instances across zones in the region
  * Change controller instances to automatically span zones in a region
  * Remove the `zone` required variable

rel: #35 #13
