### PR TITLE
addons: Update from Prometheus v1.8.2 to v2.0.0

### DIFF
--- a/addons/prometheus/config.yaml
+++ b/addons/prometheus/config.yaml
@@ -8,6 +8,14 @@ data:
     # Global config
     global:
       scrape_interval: 15s
+
+    # AlertManager
+    alerting:
+      alertmanagers:
+      - static_configs:
+        - targets:
+          - alertmanager:9093
+
     # Scrape configs for running Prometheus on a Kubernetes cluster.
     # This uses separate scrape configs for cluster components (i.e. API server, node)
     # and services to allow each to use different authentication configs.
@@ -214,3 +222,5 @@ data:
     # Rule files
     rule_files:
       - "/etc/prometheus/rules/*.rules"
+      - "/etc/prometheus/rules/*.yaml"
+      - "/etc/prometheus/rules/*.yml"

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -16,12 +16,9 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: quay.io/prometheus/prometheus:v1.8.2
+        image: quay.io/prometheus/prometheus:v2.0.0
         args:
-          - '-config.file=/etc/prometheus/prometheus.yaml'
-          - '-storage.local.retention=12h'
-          - '-storage.local.memory-chunks=500000'
-          - '-alertmanager.url=http://alertmanager:9093'
+          - '--config.file=/etc/prometheus/prometheus.yaml'
         ports:
         - name: web
           containerPort: 9090


### PR DESCRIPTION
* Migration Guide: https://prometheus.io/docs/prometheus/2.0/migration/
* Use the `promtool` (its in the tarball) to convert v1 rules to v2
