### PR TITLE
Update min Google plugin and remove target pool workaround

### DIFF
--- a/google-cloud/container-linux/kubernetes/controllers/network.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/network.tf
@@ -30,7 +30,7 @@ resource "google_compute_target_pool" "controllers" {
   name = "${var.cluster_name}-controller-pool"
 
   instances = [
-    "${formatlist("%s/%s", google_compute_instance.controllers.*.zone, google_compute_instance.controllers.*.name)}",
+    "${google_compute_instance.controllers.*.self_link}",
   ]
 
   health_checks = [

--- a/google-cloud/container-linux/kubernetes/require.tf
+++ b/google-cloud/container-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 1.1"
+  version = "~> 1.2"
 }
 
 provider "local" {


### PR DESCRIPTION
* With google provider 1.2, target pool instances can use self_link
and zone/name formats without causing a diff on each plan
* Original workaround: 77fc14db719
