### PR TITLE
Sync upstream addon changes

### DIFF
--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:4.6.1
+          image: grafana/grafana:4.6.2
           env:
             - name: GF_SERVER_HTTP_PORT
               value: "8080"

--- a/addons/prometheus/rules.yaml
+++ b/addons/prometheus/rules.yaml
@@ -218,8 +218,8 @@ data:
             disappeared from service discovery.
           summary: API server unreachable
       - alert: K8SApiServerLatency
-        expr: histogram_quantile(0.99, sum(apiserver_request_latencies_bucket{subresource!="log",verb!~"^(?:CONNECT|WATCHLIST|WATCH|PROXY)$"})
-          WITHOUT (instance, resource)) / 1e+06 > 1
+        expr: histogram_quantile(0.99, sum(rate(apiserver_request_latencies_bucket{subresource!="log",verb!~"^(?:CONNECT|WATCHLIST|WATCH|PROXY)$"}[10m]))
+          by (le)) / 1e+06 > 1
         for: 10m
         labels:
           severity: warning

--- a/addons/prometheus/rules.yaml
+++ b/addons/prometheus/rules.yaml
@@ -303,6 +303,33 @@ data:
           description: Kubelet {{$labels.instance}} is running {{$value}} pods, close
             to the limit of 110
           summary: Kubelet is close to pod limit
+      - alert: K8SDaemonSetsNotScheduled
+        expr: kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_current_number_scheduled
+          > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: A number of daemonsets are not scheduled.
+          summary: Daemonsets are not scheduled correctly
+      - alert: K8SDaemonSetsNotRunning
+        expr: kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_number_ready
+          > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: A number of daemonsets are not ready.
+          summary: Daemonsets are not ready
+      - alert: K8SDaemonSetsMissScheduled
+        expr: kube_daemonset_status_number_misscheduled > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: A number of daemonsets are running where they are not supposed
+            to run.
+          summary: Daemonsets are not scheduled correctly
   kubernetes.rules.yaml: |+
     groups:
     - name: ./kubernetes.rules

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -8,6 +8,7 @@ resource "matchbox_profile" "container-linux-install" {
   ]
 
   args = [
+    "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",
@@ -44,6 +45,7 @@ resource "matchbox_profile" "cached-container-linux-install" {
   ]
 
   args = [
+    "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",

--- a/bare-metal/container-linux/pxe-worker/profiles.tf
+++ b/bare-metal/container-linux/pxe-worker/profiles.tf
@@ -8,6 +8,7 @@ resource "matchbox_profile" "bootkube-worker-pxe" {
   ]
 
   args = [
+    "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",


### PR DESCRIPTION
* Update Grafana from v4.6.1 to v4.6.2 (https://github.com/grafana/grafana/releases/tag/v4.6.2)
* Fix prometheus K8SApiServerLatency alert rule (https://github.com/coreos/prometheus-operator/issues/751)
* Add prometheus rules for DaemonSets (https://github.com/coreos/prometheus-operator/pull/755)