### PR TITLE
Remove version constraints on provider plugins

### DIFF
--- a/aws/container-linux/kubernetes/require.tf
+++ b/aws/container-linux/kubernetes/require.tf
@@ -1,25 +1,5 @@
-# Terraform version and plugin versions
+# Terraform version
 
 terraform {
   required_version = ">= 0.10.4"
-}
-
-provider "aws" {
-  version = "~> 1.0"
-}
-
-provider "local" {
-  version = "~> 1.0"
-}
-
-provider "null" {
-  version = "~> 1.0"
-}
-
-provider "template" {
-  version = "~> 1.0"
-}
-
-provider "tls" {
-  version = "~> 1.0"
 }

--- a/bare-metal/container-linux/kubernetes/require.tf
+++ b/bare-metal/container-linux/kubernetes/require.tf
@@ -1,21 +1,5 @@
-# Terraform version and plugin versions
+# Terraform version
 
 terraform {
   required_version = ">= 0.10.4"
-}
-
-provider "local" {
-  version = "~> 1.0"
-}
-
-provider "null" {
-  version = "~> 1.0"
-}
-
-provider "template" {
-  version = "~> 1.0"
-}
-
-provider "tls" {
-  version = "~> 1.0"
 }

--- a/digital-ocean/container-linux/kubernetes/require.tf
+++ b/digital-ocean/container-linux/kubernetes/require.tf
@@ -1,25 +1,5 @@
-# Terraform version and plugin versions
+# Terraform version
 
 terraform {
   required_version = ">= 0.10.4"
-}
-
-provider "digitalocean" {
-  version = "0.1.2"
-}
-
-provider "local" {
-  version = "~> 1.0"
-}
-
-provider "null" {
-  version = "~> 1.0"
-}
-
-provider "template" {
-  version = "~> 1.0"
-}
-
-provider "tls" {
-  version = "~> 1.0"
 }

--- a/google-cloud/container-linux/kubernetes/require.tf
+++ b/google-cloud/container-linux/kubernetes/require.tf
@@ -1,25 +1,5 @@
-# Terraform version and plugin versions
+# Terraform version
 
 terraform {
   required_version = ">= 0.10.4"
-}
-
-provider "google" {
-  version = "~> 1.2"
-}
-
-provider "local" {
-  version = "~> 1.0"
-}
-
-provider "null" {
-  version = "~> 1.0"
-}
-
-provider "template" {
-  version = "~> 1.0"
-}
-
-provider "tls" {
-  version = "~> 1.0"
 }


### PR DESCRIPTION
* Terraform v0.11.x strongly discourages modules which have provider blocks and notably doesn't delete modules correctly if they are present https://github.com/hashicorp/terraform/issues/16824. Not being able to delete clusters is a show-stopper.
* Unfortunately, this means there are no safeguards against users continuing to use old or incompatible provider plugins
* https://github.com/hashicorp/terraform/issues/16777
* https://github.com/hashicorp/terraform/issues/16824