### PR TITLE
Fixes issue with etcd DNS resolution via locally provided nameserver.

### DIFF
--- a/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -41,6 +41,7 @@ systemd:
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'
         [Install]
         RequiredBy=kubelet.service
+        RequiredBy=etcd-member.service
     - name: kubelet.service
       enable: true
       contents: |

--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -50,6 +50,7 @@ systemd:
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'
         [Install]
         RequiredBy=kubelet.service
+        RequiredBy=etcd-member.service
     - name: kubelet.service
       contents: |
         [Unit]

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -50,6 +50,7 @@ systemd:
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'
         [Install]
         RequiredBy=kubelet.service
+        RequiredBy=etcd-member.service
     - name: kubelet.service
       contents: |
         [Unit]

--- a/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
+++ b/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
@@ -41,6 +41,7 @@ systemd:
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'
         [Install]
         RequiredBy=kubelet.service
+        RequiredBy=etcd-member.service
     - name: kubelet.service
       enable: true
       contents: |


### PR DESCRIPTION
## Issue

When restarting masters, `etcd-member.service` fails to be able to reverse lookup the names of the TLS nodes as DNS hasn't been defined yet. As a side effect causes some issues with CLUO deployed ;)

```
Dec 04 07:27:16 node0.cluster.com etcd-wrapper[875]: 2017-12-04 07:27:16.092239 I | etcdmain: rejected connection from "192.168.15.13:44308" (tls: "192.168.15.13" does not match any of DNSNames ["node0.int.cluster.com" "node3.int.cluster.com" "*.kube-etcd.kube-system.svc.cluster.local" "kube-etcd-client.kube-system.svc.cluster.local"])
```

I've only used this on bare-metal so not sure if it effects other module types.

## Change Details

This change makes it so that the `wait-for-dns.service` uses the `RequiredBy` directive for `etcd-member.service`.

## Testing

I've used this fix previously from prior to Typhoon and has been running successfully in more than one cluster.