### PR TITLE
AWS Cloud Provider

### DIFF
--- a/aws/container-linux/kubernetes/ami.tf
+++ b/aws/container-linux/kubernetes/ami.tf
@@ -14,6 +14,6 @@ data "aws_ami" "coreos" {
 
   filter {
     name   = "name"
-    values = ["CoreOS-${var.os_channel}-*"]
+    values = ["CoreOS-${var.os_channel}-${var.os_version}*"]
   }
 }

--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -2,6 +2,7 @@
 module "bootkube" {
   source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=533e82f833c166297abd249ac3d4853d6ebed364"
 
+  cloud_provider = "${var.cloud_provider}"
   cluster_name = "${var.cluster_name}"
   api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
   etcd_servers = ["${aws_route53_record.etcds.*.fqdn}"]

--- a/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -28,6 +28,21 @@ systemd:
       enable: true
     - name: locksmithd.service
       mask: true
+    - name: set-aws-fqdn.service
+      enable: true
+      contents: |
+        [Unit]
+        Wants=network-online.target
+        After=network-online.target
+        Description=Set Hostname Workaround
+        Before=kubelet.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/sh -c "/usr/bin/hostnamectl set-hostname $(curl -s http://169.254.169.254/latest/meta-data/hostname)"
+
+        [Install]
+        RequiredBy=kubelet.service
     - name: wait-for-dns.service
       enable: true
       contents: |
@@ -74,6 +89,7 @@ systemd:
           --client-ca-file=/etc/kubernetes/ca.crt \
           --cluster_dns=${k8s_dns_service_ip} \
           --cluster_domain=cluster.local \
+          --cloud-provider=${cloud_provider} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --exit-on-lock-contention \
           --kubeconfig=/etc/kubernetes/kubeconfig \

--- a/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -5,6 +5,21 @@ systemd:
       enable: true
     - name: locksmithd.service
       mask: true
+    - name: set-aws-fqdn.service
+      enable: true
+      contents: |
+        [Unit]
+        Wants=network-online.target
+        After=network-online.target
+        Description=Set Hostname Workaround
+        Before=kubelet.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/sh -c "/usr/bin/hostnamectl set-hostname $(curl -s http://169.254.169.254/latest/meta-data/hostname)"
+
+        [Install]
+        RequiredBy=kubelet.service
     - name: wait-for-dns.service
       enable: true
       contents: |
@@ -50,6 +65,7 @@ systemd:
           --client-ca-file=/etc/kubernetes/ca.crt \
           --cluster_dns=${k8s_dns_service_ip} \
           --cluster_domain=cluster.local \
+          --cloud-provider=${cloud_provider} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --exit-on-lock-contention \
           --kubeconfig=/etc/kubernetes/kubeconfig \

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -18,7 +18,7 @@ resource "aws_instance" "controllers" {
   depends_on = ["aws_iam_role.controller_role"]
   count = "${var.controller_count}"
 
-  tags = "${map("Name", "${var.cluster_name}-controller-${count.index}", "kubernetes.io/cluster/${var.cluster_name}", "owned", "KubernetesCluster", "${var.cluster_name}")}"
+  tags = "${map("Name", "${var.cluster_name}-controller-${count.index}", "kubernetes.io/cluster/${var.cluster_name}", "owned", "KubernetesCluster", "${var.cluster_name}", "kubernetes.io/role/master", "")}"
 
   instance_type = "${var.controller_type}"
 

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -18,10 +18,7 @@ resource "aws_instance" "controllers" {
   depends_on = ["aws_iam_role.controller_role"]
   count = "${var.controller_count}"
 
-  tags = {
-      Name = "${var.cluster_name}-controller-${count.index}"
-      KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${map("Name", "${var.cluster_name}-controller-${count.index}", "kubernetes.io/cluster/${var.cluster_name}", "owned", "KubernetesCluster", "${var.cluster_name}")}"
 
   instance_type = "${var.controller_type}"
 
@@ -92,7 +89,7 @@ resource "aws_security_group" "controller" {
 
   vpc_id = "${aws_vpc.network.id}"
 
-  tags = "${map("Name", "${var.cluster_name}-controller")}"
+  tags = "${map("Name", "${var.cluster_name}-controller", "kubernetes.io/cluster/${var.cluster_name}", "owned", "KubernetesCluster", "${var.cluster_name}")}"
 }
 
 resource "aws_security_group_rule" "controller-icmp" {

--- a/aws/container-linux/kubernetes/iam.tf
+++ b/aws/container-linux/kubernetes/iam.tf
@@ -1,0 +1,117 @@
+# IAM Roles and Policies for Controllers (Masters) and Workers (Nodes)
+
+## Controllers / Masters
+data "aws_iam_policy_document" "controller_role_doc" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "controller_role" {
+  name               = "${var.cluster_name}-controller-instance-role"
+  assume_role_policy = "${data.aws_iam_policy_document.controller_role_doc.json}"
+}
+
+# Permission borrowed from https://github.com/kubernetes/kops/issues/1873
+data "aws_iam_policy_document" "controller_policy_doc" {
+  statement {
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:CreateRoute",
+      "ec2:CreateSecurityGroup",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DeleteRoute",
+      "ec2:DeleteVolume",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeInstances",
+      "ec2:DescribeRouteTables",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeVolumes",
+      "ec2:DetachVolume",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:RevokeSecurityGroupIngress",
+      "elasticloadbalancing:AttachLoadBalancerToSubnets",
+      "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+      "elasticloadbalancing:CreateLoadBalancer",
+      "elasticloadbalancing:CreateLoadBalancerPolicy",
+      "elasticloadbalancing:CreateLoadBalancerListeners",
+      "elasticloadbalancing:ConfigureHealthCheck",
+      "elasticloadbalancing:DeleteLoadBalancer",
+      "elasticloadbalancing:DeleteLoadBalancerListeners",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeLoadBalancerAttributes",
+      "elasticloadbalancing:DetachLoadBalancerFromSubnets",
+      "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+      "elasticloadbalancing:ModifyLoadBalancerAttributes",
+      "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+      "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup"
+    ]
+    resources = [ "*" ]
+  }
+}
+
+resource "aws_iam_role_policy" "controller_policy" {
+  name        = "${var.cluster_name}-controller-instance-role-policy"
+  # path        = "/"
+  role = "${aws_iam_role.controller_role.id}"
+  policy = "${data.aws_iam_policy_document.controller_policy_doc.json}"
+}
+
+resource "aws_iam_instance_profile" "controller_profile" {
+  name  = "${var.cluster_name}-controller-instance-role"
+  role = "${aws_iam_role.controller_role.name}"
+}
+
+## Workers / Nodes
+data "aws_iam_policy_document" "worker_role_doc" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "worker_role" {
+  name               = "${var.cluster_name}-worker-instance-role"
+  assume_role_policy = "${data.aws_iam_policy_document.worker_role_doc.json}"
+}
+
+# Permission borrowed from https://github.com/kubernetes/kops/issues/1873
+data "aws_iam_policy_document" "worker_policy_doc" {
+  statement {
+    actions = ["ec2:DescribeInstances"]
+    resources = [ "*" ]
+  }
+  statement {
+    actions = ["sts:AssumeRole"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "worker_policy" {
+  name        = "${var.cluster_name}-worker-instance-role-policy"
+  # path        = "/"
+  role = "${aws_iam_role.worker_role.id}"
+  policy = "${data.aws_iam_policy_document.worker_policy_doc.json}"
+}
+
+resource "aws_iam_instance_profile" "worker_profile" {
+  name  = "${var.cluster_name}-worker-instance-role"
+  role = "${aws_iam_role.worker_role.name}"
+}

--- a/aws/container-linux/kubernetes/network.tf
+++ b/aws/container-linux/kubernetes/network.tf
@@ -8,13 +8,13 @@ resource "aws_vpc" "network" {
   enable_dns_support               = true
   enable_dns_hostnames             = true
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = "${map("Name", "${var.cluster_name}", "kubernetes.io/cluster/${var.cluster_name}", "owned", "KubernetesCluster", "${var.cluster_name}")}"
 }
 
 resource "aws_internet_gateway" "gateway" {
   vpc_id = "${aws_vpc.network.id}"
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = "${map("Name", "${var.cluster_name}", "kubernetes.io/cluster/${var.cluster_name}", "owned", "KubernetesCluster", "${var.cluster_name}")}"
 }
 
 resource "aws_route_table" "default" {
@@ -30,7 +30,7 @@ resource "aws_route_table" "default" {
     gateway_id      = "${aws_internet_gateway.gateway.id}"
   }
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = "${map("Name", "${var.cluster_name}", "kubernetes.io/cluster/${var.cluster_name}", "owned", "KubernetesCluster", "${var.cluster_name}")}"
 }
 
 # Subnets (one per availability zone)
@@ -46,7 +46,7 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch         = true
   assign_ipv6_address_on_creation = true
 
-  tags = "${map("Name", "${var.cluster_name}-public-${count.index}")}"
+  tags = "${map("Name", "${var.cluster_name}-public-${count.index}", "kubernetes.io/role/elb", "" , "kubernetes.io/cluster/${var.cluster_name}", "owned", "KubernetesCluster", "${var.cluster_name}")}"
 }
 
 resource "aws_route_table_association" "public" {

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -30,6 +30,12 @@ variable "os_channel" {
   description = "Container Linux AMI channel (stable, beta, alpha)"
 }
 
+variable "os_version" {
+  type        = "string"
+  default     = ""
+  description = "Container Linux OS version (for example 1548.0.0). Latest if empty."
+}
+
 variable "disk_size" {
   type        = "string"
   default     = "40"

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -3,6 +3,12 @@ variable "cluster_name" {
   description = "Cluster name"
 }
 
+variable "cloud_provider" {
+  type        = "string"
+  description = "The cloud provider"
+  default = "aws"
+}
+
 variable "dns_zone" {
   type        = "string"
   description = "AWS DNS Zone (e.g. aws.dghubble.io)"

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -22,11 +22,23 @@ resource "aws_autoscaling_group" "workers" {
     ignore_changes        = ["image_id"]
   }
 
-  tags = [{
-    key                 = "Name"
-    value               = "${var.cluster_name}-worker"
-    propagate_at_launch = true
-  }]
+  tags = [
+    {
+      key                 = "Name"
+      value               = "${var.cluster_name}-worker"
+      propagate_at_launch = true
+    },
+    # {
+    #   key = "kubernetes.io/cluster/${var.cluster_name}"
+    #   value = "owned"
+    #   propagate_at_launch = true
+    # },
+    {
+      key                 = "KubernetesCluster"
+      value               = "${var.cluster_name}"
+      propagate_at_launch = true
+    }
+  ]
 }
 
 # Worker template
@@ -41,6 +53,9 @@ resource "aws_launch_configuration" "worker" {
     volume_type = "standard"
     volume_size = "${var.disk_size}"
   }
+
+  # iam
+  iam_instance_profile = "${aws_iam_instance_profile.worker_profile.name}"
 
   # network
   security_groups = ["${aws_security_group.worker.id}"]
@@ -63,6 +78,7 @@ data "template_file" "worker_config" {
     kubeconfig_kubelet_cert = "${module.bootkube.kubelet_cert}"
     kubeconfig_kubelet_key  = "${module.bootkube.kubelet_key}"
     kubeconfig_server       = "${module.bootkube.server}"
+    cloud_provider          = "${var.cloud_provider}"
   }
 }
 

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -28,11 +28,11 @@ resource "aws_autoscaling_group" "workers" {
       value               = "${var.cluster_name}-worker"
       propagate_at_launch = true
     },
-    # {
-    #   key = "kubernetes.io/cluster/${var.cluster_name}"
-    #   value = "owned"
-    #   propagate_at_launch = true
-    # },
+    {
+      key = "kubernetes.io/cluster/${var.cluster_name}"
+      value = "owned"
+      propagate_at_launch = true
+    },
     {
       key                 = "KubernetesCluster"
       value               = "${var.cluster_name}"
@@ -95,7 +95,7 @@ resource "aws_security_group" "worker" {
 
   vpc_id = "${aws_vpc.network.id}"
 
-  tags = "${map("Name", "${var.cluster_name}-worker")}"
+  tags = "${map("Name", "${var.cluster_name}-worker", "kubernetes.io/cluster/${var.cluster_name}", "owned", "KubernetesCluster", "${var.cluster_name}")}"
 }
 
 resource "aws_security_group_rule" "worker-icmp" {


### PR DESCRIPTION
I wanted to be able to dynamically provision ebs volumes and create elb v1 from kubernetes service with type=LoadBalancer.

* Tag resources with cluster name,
* Ability to select CoreOS version,
* Set FQDN of CoreOS instance,
* Created IAM role and policy required for controller nodes.

## Testing

* I have deployed a cluster in AWS. Created a storageClass. Created statefulset with persistentVolumeClaims. EBS volumes created with success in AWS.

* I have created the following service with `kubectl apply`

```
kind: Service
apiVersion: v1
metadata:
  name: nginx-ingress-controller
  namespace: ingress-nginx
  labels:
    app: ingress-nginx
  annotations:
    # Enable PROXY protocol
    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
    # Increase the ELB idle timeout to avoid issues with WebSockets or Server-Sent Events.
    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
    # enable cross-zone load balancing
    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
spec:
  type: LoadBalancer
  externalTrafficPolicy: Local
  healthCheckNodePort: 30000
  selector:
    app: ingress-nginx
  ports:
  - name: http
    # protocol: TCP
    port: 80
    targetPort: http
  - name: https
    protocol: TCP
    port: 443
    targetPort: https
  - name: healthz
    protocol: TCP
    port: 30000
    targetPort: 10254
```

TCP ELB created with success in AWS. Deploying nginx-ingress-controller and creating an ingress works as well.