### PR TITLE
Enable BBR as default congestion algorithm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Notable changes between versions.
   * Older clusters (with CLUO addon) auto-update node's Container Linux version
   and will begin using Docker 17.09.
 * Fix race where `etcd-member.service` could fail to resolve peers ([#69](https://github.com/poseidon/typhoon/pull/69)) 
+* BBR is enabled as the default traffic congestion algorithm.
 
 #### Bare-Metal
 

--- a/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -135,6 +135,12 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
+    - path: /etc/sysctl.d/bbr.conf
+      filesystem: root
+      contents:
+        inline: |
+          net.core.default_qdisc=fq
+          net.ipv4.tcp_congestion_control=bbr
     - path: /opt/bootkube/bootkube-start
       filesystem: root
       mode: 0544

--- a/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -109,6 +109,12 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
+    - path: /etc/sysctl.d/bbr.conf
+      filesystem: root
+      contents:
+        inline: |
+          net.core.default_qdisc=fq
+          net.ipv4.tcp_congestion_control=bbr
     - path: /etc/kubernetes/delete-node
       filesystem: root
       mode: 0744

--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -129,6 +129,12 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
+    - path: /etc/sysctl.d/bbr.conf
+      filesystem: root
+      contents:
+        inline: |
+          net.core.default_qdisc=fq
+          net.ipv4.tcp_congestion_control=bbr
     - path: /opt/bootkube/bootkube-start
       filesystem: root
       mode: 0544

--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -94,6 +94,12 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
+    - path: /etc/sysctl.d/bbr.conf
+      filesystem: root
+      contents:
+        inline: |
+          net.core.default_qdisc=fq
+          net.ipv4.tcp_congestion_control=bbr
 networkd:
   ${networkd_content}
 passwd:

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -126,6 +126,12 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
+    - path: /etc/sysctl.d/bbr.conf
+      filesystem: root
+      contents:
+        inline: |
+          net.core.default_qdisc=fq
+          net.ipv4.tcp_congestion_control=bbr
     - path: /opt/bootkube/bootkube-start
       filesystem: root
       mode: 0544

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -100,6 +100,12 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
+    - path: /etc/sysctl.d/bbr.conf
+      filesystem: root
+      contents:
+        inline: |
+          net.core.default_qdisc=fq
+          net.ipv4.tcp_congestion_control=bbr
     - path: /etc/kubernetes/delete-node
       filesystem: root
       mode: 0744

--- a/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
+++ b/google-cloud/container-linux/kubernetes/controllers/cl/controller.yaml.tmpl
@@ -136,6 +136,12 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
+    - path: /etc/sysctl.d/bbr.conf
+      filesystem: root
+      contents:
+        inline: |
+          net.core.default_qdisc=fq
+          net.ipv4.tcp_congestion_control=bbr
     - path: /opt/bootkube/bootkube-start
       filesystem: root
       mode: 0544


### PR DESCRIPTION
This change sets BBR as the default traffic congestion algorithm which has been in the kernel since 4.9.

Closes #67.