### PR TITLE
bm-docs: Add missing port to matchbox_http_endpoint

### DIFF
--- a/docs/bare-metal.md
+++ b/docs/bare-metal.md
@@ -160,7 +160,7 @@ module "bare-metal-mercury" {
   source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes"
   
   # install
-  matchbox_http_endpoint  = "http://matchbox.example.com"
+  matchbox_http_endpoint  = "http://matchbox.example.com:8080"
   container_linux_channel = "stable"
   container_linux_version = "1576.4.0"
   ssh_authorized_key      = "ssh-rsa AAAAB3Nz..."


### PR DESCRIPTION
`matchbox_http_endpoint` does not specify the port number used in the BM TF example. This leads to machines not properly PXE booting using the example module provided, as they cannot reach the matchbox service.