### PR TITLE
Create separate bare-metal container-linux-install profiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,12 @@ Notable changes between versions.
 * Update kube-dns from v1.14.7 to v1.14.8
 * Use separate service account for kube-dns
 
+#### Bare-Metal
+
+* Use per-node Container Linux install profiles ([#97](https://github.com/poseidon/typhoon/pull/97))
+  * Allow Container Linux channel/version to be chosen per-cluster
+  * Fix issue where cluster deletion could require `terraform apply` multiple times
+
 ## v1.9.1
 
 * Kubernetes [v1.9.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#v191)

--- a/bare-metal/container-linux/kubernetes/groups.tf
+++ b/bare-metal/container-linux/kubernetes/groups.tf
@@ -3,7 +3,7 @@ resource "matchbox_group" "container-linux-install" {
   count = "${length(var.controller_names) + length(var.worker_names)}"
 
   name    = "${format("container-linux-install-%s", element(concat(var.controller_names, var.worker_names), count.index))}"
-  profile = "${var.cached_install == "true" ? matchbox_profile.cached-container-linux-install.name : matchbox_profile.container-linux-install.name}"
+  profile = "${var.cached_install == "true" ? element(matchbox_profile.cached-container-linux-install.*.name, count.index) : element(matchbox_profile.container-linux-install.*.name, count.index)}"
 
   selector {
     mac = "${element(concat(var.controller_macs, var.worker_macs), count.index)}"

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -1,6 +1,8 @@
 // Container Linux Install profile (from release.core-os.net)
 resource "matchbox_profile" "container-linux-install" {
-  name   = "container-linux-install"
+  count = "${length(var.controller_names) + length(var.worker_names)}"
+  name  = "${format("%s-container-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+
   kernel = "http://${var.container_linux_channel}.release.core-os.net/amd64-usr/${var.container_linux_version}/coreos_production_pxe.vmlinuz"
 
   initrd = [
@@ -16,10 +18,12 @@ resource "matchbox_profile" "container-linux-install" {
     "${var.kernel_args}",
   ]
 
-  container_linux_config = "${data.template_file.container-linux-install-config.rendered}"
+  container_linux_config = "${element(data.template_file.container-linux-install-configs.*.rendered, count.index)}"
 }
 
-data "template_file" "container-linux-install-config" {
+data "template_file" "container-linux-install-configs" {
+  count = "${length(var.controller_names) + length(var.worker_names)}"
+
   template = "${file("${path.module}/cl/container-linux-install.yaml.tmpl")}"
 
   vars {
@@ -37,7 +41,9 @@ data "template_file" "container-linux-install-config" {
 // Container Linux Install profile (from matchbox /assets cache)
 // Note: Admin must have downloaded container_linux_version into matchbox assets.
 resource "matchbox_profile" "cached-container-linux-install" {
-  name   = "cached-container-linux-install"
+  count = "${length(var.controller_names) + length(var.worker_names)}"
+  name  = "${format("%s-cached-container-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+
   kernel = "/assets/coreos/${var.container_linux_version}/coreos_production_pxe.vmlinuz"
 
   initrd = [
@@ -53,10 +59,12 @@ resource "matchbox_profile" "cached-container-linux-install" {
     "${var.kernel_args}",
   ]
 
-  container_linux_config = "${data.template_file.cached-container-linux-install-config.rendered}"
+  container_linux_config = "${element(data.template_file.cached-container-linux-install-configs.*.rendered, count.index)}"
 }
 
-data "template_file" "cached-container-linux-install-config" {
+data "template_file" "cached-container-linux-install-configs" {
+  count = "${length(var.controller_names) + length(var.worker_names)}"
+
   template = "${file("${path.module}/cl/container-linux-install.yaml.tmpl")}"
 
   vars {


### PR DESCRIPTION
Create separate bare-metal `container-linux-install` (or `cached-container-linux-install`) profiles for each node in a cluster. Name the profile after the cluster and node name (should be unique):

  * Fix contention bug around bare-metal "container-linux-install" profile `terraform apply`. Apply ensures Matchbox profiles and groups are created for each cluster and its nodes. "container-linux-install" is not namespaced, meaning deletion of a cluster requests the profile's deletion, but existing clusters request its creation (or continued existence). This can mean users have to run `terraform apply` more than once until the constraints are satisfied (i.e. a deletion and recreation occurs).
  * Allows Container Linux installs to vary between clusters instead of using one global container-linux-install profile (e.g. different clusters may now install different Container Linux versions).