### PR TITLE
Edit digital ocean port range and ordering to suppress diff

### DIFF
--- a/digital-ocean/container-linux/kubernetes/network.tf
+++ b/digital-ocean/container-linux/kubernetes/network.tf
@@ -22,12 +22,12 @@ resource "digitalocean_firewall" "rules" {
     },
     {
       protocol    = "udp"
-      port_range  = "all"
+      port_range  = "1-65535"
       source_tags = ["${digitalocean_tag.controllers.name}", "${digitalocean_tag.workers.name}"]
     },
     {
       protocol    = "tcp"
-      port_range  = "all"
+      port_range  = "1-65535"
       source_tags = ["${digitalocean_tag.controllers.name}", "${digitalocean_tag.workers.name}"]
     },
   ]
@@ -35,17 +35,18 @@ resource "digitalocean_firewall" "rules" {
   # allow all outbound traffic
   outbound_rule = [
     {
-      protocol              = "icmp"
+      protocol              = "tcp"
+      port_range            = "1-65535"
       destination_addresses = ["0.0.0.0/0", "::/0"]
     },
     {
       protocol              = "udp"
-      port_range            = "all"
+      port_range            = "1-65535"
       destination_addresses = ["0.0.0.0/0", "::/0"]
     },
     {
-      protocol              = "tcp"
-      port_range            = "all"
+      protocol              = "icmp"
+      port_range            = "1-65535"
       destination_addresses = ["0.0.0.0/0", "::/0"]
     },
   ]


### PR DESCRIPTION
* Change port range from keyword "all" to "1-65535", which is the
same but with digitalocean provider 0.1.3 doesn't produce a diff
* Rearrange egress firewall rules to order the Digtial Ocean API
and provider returns. In current testing, this fixes the last diff
that was present on `terraform plan`.

With `digitalocean` provider 0.1.3 and the module at this commit, `terraform plan` seems to show no diff. This could change in future as it relies on some ordering and conventions on the Digital Ocean API side, but it should fix #3.

*Note: Its odd to specify ports for ICMP, but it seems to be the only way to satisfy the Terraform provider, which doesn't understand ICMP concepts. The Digital Ocean API just ignores the ICMP port value, correctly.*