### PR TITLE
addons: Update CLUO to fix compatability with Kubernetes 1.9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,13 +7,15 @@ Notable changes between versions.
 * Add Terraform v0.11.x support
   * Add explicit "providers" section to modules for Terraform v0.11.x
   * Retain support for Terraform v0.10.4+
-* Add [migration guide](https://github.com/poseidon/typhoon/blob/master/docs/topics/maintenance.md) from Terraform v0.10.x to v0.11.x (action required!)
+* Add [migration guide](https://github.com/poseidon/typhoon/blob/master/docs/topics/maintenance.md) from Terraform v0.10.x to v0.11.x (**action required!**)
 * Update etcd from 3.2.13 to 3.2.14
 * Update kube-dns from v1.14.7 to v1.14.8
 * Use separate service account for kube-dns
 
 #### Addons
 
+* Update CLUO to v0.5.0 to fix compatibility with Kubernetes 1.9 (**important**)
+  * Earlier versions can't roll out Container Linux updates on Kubernetes 1.9 nodes ([cluo#163](https://github.com/coreos/container-linux-update-operator/issues/163))
 * Update kube-state-metrics from v1.1.0 to v1.2.0
 * Fix RBAC cluster role for kube-state-metrics
 

--- a/addons/cluo/update-agent.yaml
+++ b/addons/cluo/update-agent.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: update-agent
-        image: quay.io/coreos/container-linux-update-operator:v0.4.1
+        image: quay.io/coreos/container-linux-update-operator:v0.5.0
         command:
         - "/bin/update-agent"
         volumeMounts:

--- a/addons/cluo/update-operator.yaml
+++ b/addons/cluo/update-operator.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: update-operator
-        image: quay.io/coreos/container-linux-update-operator:v0.4.1
+        image: quay.io/coreos/container-linux-update-operator:v0.5.0
         command:
         - "/bin/update-operator"
         env:


### PR DESCRIPTION
* Update CLUO from v0.4.1 to v0.5.0
* Earlier versions of CLUO fail to drain nodes on Kubernetes 1.9 so nodes drain one at a time repeatedly and Container Linux OS updates are not applied to nodes.
* Check current OS versions via `kubectl get nodes --show-labels`

rel: https://github.com/coreos/container-linux-update-operator/issues/163