### PR TITLE
Update worker.yaml.tmpl to make iSCSI volumes work

### DIFF
--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -43,6 +43,10 @@ systemd:
           --mount volume=opt-cni-bin,target=/opt/cni/bin \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log \
+          --volume iscsiconf,kind=host,source=/etc/iscsi/ \
+          --mount volume=iscsiconf,target=/etc/iscsi/ \
+          --volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
+          --mount volume=iscsiadm,target=/sbin/iscsiadm \
           --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests


### PR DESCRIPTION
Adding iscsiadm and the iscsid config to be accessed from the kublet container
If iscsid has been configured on container linux as described here (https://coreos.com/os/docs/latest/iscsi.html) and the iscsi target is reachable from the worker this should allow iscsi volumes to work.


## Testing

In a local bare-metal typhoon deploy I was able to get iscsi volumes to work with this change made locally


