### PR TITLE
Update Digital Ocean variables / docs to use new droplet sizes

### DIFF
--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -27,8 +27,8 @@ variable "controller_count" {
 
 variable "controller_type" {
   type        = "string"
-  default     = "2gb"
-  description = "Digital Ocean droplet size (e.g. 2gb (min), 4gb, 8gb)."
+  default     = "s-2vcpu-2gb"
+  description = "Digital Ocean droplet size (e.g. s-2vcpu-2gb, s-2vcpu-4gb, s-4vcpu-8gb)."
 }
 
 variable "worker_count" {
@@ -39,8 +39,8 @@ variable "worker_count" {
 
 variable "worker_type" {
   type        = "string"
-  default     = "512mb"
-  description = "Digital Ocean droplet size (e.g. 512mb, 1gb, 2gb, 4gb)"
+  default     = "s-1vcpu-1gb"
+  description = "Digital Ocean droplet size (e.g. s-1vcpu-1gb, s-1vcpu-2gb, s-2vcpu-2gb)"
 }
 
 variable "ssh_fingerprints" {

--- a/docs/digital-ocean.md
+++ b/docs/digital-ocean.md
@@ -106,9 +106,9 @@ module "digital-ocean-nemo" {
   cluster_name     = "nemo"
   image            = "coreos-stable"
   controller_count = 1
-  controller_type  = "2gb"
+  controller_type  = "s-2vcpu-2gb"
   worker_count     = 2
-  worker_type      = "512mb"
+  worker_type      = "s-1vcpu-1gb"
   ssh_fingerprints = ["d7:9d:79:ae:56:32:73:79:95:88:e3:a2:ab:5d:45:e7"]
 
   # output assets dir
@@ -262,16 +262,18 @@ If you uploaded an SSH key to DigitalOcean (not required), find the fingerprint 
 |:-----|:------------|:--------|:--------|
 | image | OS image for droplets | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha |
 | controller_count | Number of controllers (i.e. masters) | 1 | 1 |
-| controller_type | Digital Ocean droplet size | 2gb | 2gb (min), 4gb, 8gb |
+| controller_type | Digital Ocean droplet size | s-2vcpu-2gb | s-2vcpu-2gb, s-2vcpu-4gb, s-4vcpu-8gb, ... |
 | worker_count | Number of workers | 1 | 3 |
-| worker_type | Digital Ocean droplet size | 512mb | 512mb, 1gb, 2gb, 4gb |
+| worker_type | Digital Ocean droplet size | s-1vcpu-1gb | s-1vcpu-1gb, s-1vcpu-2gb, s-2vcpu-2gb, ... |
 | networking | Choice of networking provider | "flannel" | "flannel" |
 | pod_cidr | CIDR range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by kube-dns. | "cluster.local" | "k8s.example.com" |
 
+You can see all valid droplet sizes [on DigitalOcean's website](https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/) or by [using their `doctl` command-line tool](https://github.com/digitalocean/doctl) via `doctl compute size list`.
+
 !!! warning
-    Do not choose a `controller_type` smaller than `2gb`. The `1gb` droplet is not sufficient for running a controller and bootstrapping will fail.
+    Do not choose a `controller_type` smaller than 2GB. Smaller droplets are not sufficient for running a controller and bootstrapping will fail.
 
 !!! bug
     Digital Ocean firewalls do not yet support the IP tunneling (IP in IP) protocol used by Calico. You can try using "calico" for `networking`, but it will only work if the cloud firewall is removed (unsafe).


### PR DESCRIPTION
Digital Ocean have just [announced new droplet sizes](https://blog.digitalocean.com/new-droplet-plans/) with greater resources per price point compared with their previous offerings. They have also deprecated the existing sizes, which will be removed by July 1, 2018.

Users can now choose various combinations of CPU, memory, and disk resources, so the [droplet size names](https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/) are a bit more complex.

* Update DO variable defaults to use the new sizes.
* Update docs with links to all available sizes.

I have just created a new cluster with these new default sizes and it seems to work fine. In fact it appears that even the slightly smaller `s-1vcpu-2gb` droplet can be used for a controller.