### PR TITLE
Add CA configuration for DigitalOcean

### DIFF
--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -11,4 +11,7 @@ module "bootkube" {
   pod_cidr              = "${var.pod_cidr}"
   service_cidr          = "${var.service_cidr}"
   cluster_domain_suffix = "${var.cluster_domain_suffix}"
+  ca_certificate        = "${var.ca_certificate}"
+  ca_key_alg            = "${var.ca_key_alg}"
+  ca_private_key        = "${var.ca_private_key}"
 }

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -83,3 +83,20 @@ variable "cluster_domain_suffix" {
   default     = "cluster.local"
 }
 
+variable "ca_certificate" {
+  description = "Existing PEM-encoded CA certificate (generated if blank)"
+  type        = "string"
+  default     = ""
+}
+
+variable "ca_key_alg" {
+  description = "Algorithm used to generate ca_key (required if ca_cert is specified)"
+  type        = "string"
+  default     = "RSA"
+}
+
+variable "ca_private_key" {
+  description = "Existing Certificate Authority private key (required if ca_certificate is set)"
+  type        = "string"
+  default     = ""
+}

--- a/docs/digital-ocean.md
+++ b/docs/digital-ocean.md
@@ -269,6 +269,9 @@ If you uploaded an SSH key to DigitalOcean (not required), find the fingerprint 
 | pod_cidr | CIDR range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by kube-dns. | "cluster.local" | "k8s.example.com" |
+| ca_certificate | CA certificate used by Kubernetes in PEM format | generated | "-----BEGIN CERTIFICATE..." |
+| ca_key_alg | Algorithm used to generate ca_private_key | RSA | RSA, ECDSA, ... |
+| ca_private_key | CA Key for ca_certificate | generated | "-----BEGIN RSA PRIVATE KEY..." |
 
 You can see all valid droplet sizes [on DigitalOcean's website](https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/) or by [using their `doctl` command-line tool](https://github.com/digitalocean/doctl) via `doctl compute size list`.
 
@@ -277,3 +280,6 @@ You can see all valid droplet sizes [on DigitalOcean's website](https://develope
 
 !!! bug
     Digital Ocean firewalls do not yet support the IP tunneling (IP in IP) protocol used by Calico. You can try using "calico" for `networking`, but it will only work if the cloud firewall is removed (unsafe).
+
+!!! note
+    In case of `ca_certificate` being intermediate certificate, specify your certificate chain in order that it would end with root certificate. eg. intermediate 2, intermediate 1, root.


### PR DESCRIPTION
Add bootkube-renderer supported CA variables into DigitalOcean module. This allows to specify custom CA certificate used by Kubernetes instead of generating one on the fly.

## Testing

I have validated cluster after creation by `kubectl get nodes` which resulted in list of nodes. CA crt in assets directory matches one I have provided via terraform variable.