### PR TITLE
*: Add `ignore_changes` to lifecycle block for OS images

### DIFF
--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -36,6 +36,10 @@ resource "aws_instance" "controllers" {
   associate_public_ip_address = true
   subnet_id                   = "${element(aws_subnet.public.*.id, count.index)}"
   vpc_security_group_ids      = ["${aws_security_group.controller.id}"]
+
+  lifecycle {
+    ignore_changes = ["ami"]
+  }
 }
 
 # Controller Container Linux Config

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -50,6 +50,10 @@ resource "digitalocean_droplet" "controllers" {
   tags = [
     "${digitalocean_tag.controllers.id}",
   ]
+
+  lifecycle {
+    ignore_changes = ["image"]
+  }
 }
 
 # Tag to label controllers

--- a/digital-ocean/container-linux/kubernetes/workers.tf
+++ b/digital-ocean/container-linux/kubernetes/workers.tf
@@ -31,6 +31,10 @@ resource "digitalocean_droplet" "workers" {
   tags = [
     "${digitalocean_tag.workers.id}",
   ]
+
+  lifecycle {
+    ignore_changes = ["image"]
+  }
 }
 
 # Tag to label workers

--- a/google-cloud/container-linux/kubernetes/controllers/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/controllers.tf
@@ -49,6 +49,10 @@ resource "google_compute_instance" "controllers" {
 
   can_ip_forward = true
   tags           = ["${var.cluster_name}-controller"]
+
+  lifecycle {
+    ignore_changes = ["boot_disk"]
+  }
 }
 
 # Controller Container Linux Config

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -73,5 +73,6 @@ resource "google_compute_instance_template" "worker" {
   lifecycle {
     # To update an Instance Template, Terraform should replace the existing resource
     create_before_destroy = true
+    ignore_changes        = ["disk"]
   }
 }


### PR DESCRIPTION
Configures TF lifecycle block to ignore changes to the OS image on each platform.
Should fix the problem referenced here: https://github.com/poseidon/typhoon/pull/76#issuecomment-365525232

This wasn't extensively tested, outside of the fact that I've used the lifecycle block and `ignore_changes` before in other projects.

@dghubble let me know if this looks sane to you.