### PR TITLE
AWS - Private subnets

### DIFF
--- a/aws/container-linux/kubernetes/bastion.tf
+++ b/aws/container-linux/kubernetes/bastion.tf
@@ -1,0 +1,122 @@
+# kube-apiserver Network Load Balancer DNS Record
+resource "aws_route53_record" "bastion" {
+  zone_id    = "${var.dns_zone_id}"
+
+  name = "${format("bastion.%s.%s.", var.cluster_name, var.dns_zone)}"
+  type = "A"
+
+  # AWS recommends their special "alias" records for ELBs
+  alias {
+    name                   = "${aws_lb.bastion.dns_name}"
+    zone_id                = "${aws_lb.bastion.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+# Controller Network Load Balancer
+resource "aws_lb" "bastion" {
+  name               = "${var.cluster_name}-bastion"
+  load_balancer_type = "network"
+  subnets            = ["${aws_subnet.public.*.id}"]
+}
+
+resource "aws_lb_target_group" "bastion" {
+  name     = "${var.cluster_name}-bastion"
+  port     = 22
+  protocol = "TCP"
+  vpc_id   = "${aws_vpc.network.id}"
+
+  # Kubelet HTTP health check
+  health_check {
+    protocol            = "TCP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 10
+  }
+}
+
+resource "aws_lb_listener" "bastion-22" {
+  load_balancer_arn = "${aws_lb.bastion.arn}"
+  port              = "22"
+  protocol          = "TCP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.bastion.arn}"
+    type             = "forward"
+  }
+}
+
+# Private network needs a bastion to be able to connect to Instances in the private network.
+resource "aws_security_group" "bastion" {
+  name        = "${var.cluster_name}-bastion"
+  vpc_id      = "${aws_vpc.network.id}"
+  description = "Security group for bastion"
+
+  tags = {
+    KubernetesCluster = "${var.cluster_name}"
+  }
+}
+
+resource "aws_security_group_rule" "bastion-ssh" {
+  security_group_id = "${aws_security_group.bastion.id}"
+
+  type        = "ingress"
+  protocol    = "tcp"
+  from_port   = 22
+  to_port     = 22
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "bastion-egress" {
+  security_group_id = "${aws_security_group.bastion.id}"
+
+  type             = "egress"
+  protocol         = "-1"
+  from_port        = 0
+  to_port          = 0
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+resource "aws_launch_configuration" "bastion" {
+  image_id                    = "${data.aws_ami.coreos.image_id}"
+  instance_type               = "t2.micro"
+  key_name                    = "${var.keypair_name}"
+  security_groups             = ["${aws_security_group.bastion.id}"]
+  associate_public_ip_address = true
+
+  root_block_device = {
+    volume_type           = "gp2"
+    volume_size           = 12
+    delete_on_termination = true
+  }
+
+  lifecycle = {
+    create_before_destroy = false
+  }
+}
+
+resource "aws_autoscaling_group" "bastion" {
+  name                 = "bastion-asg"
+  launch_configuration = "${aws_launch_configuration.bastion.name}"
+  min_size             = 1
+  max_size             = 1
+
+  # network
+  vpc_zone_identifier = ["${aws_subnet.public.*.id}"]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+
+  tags = [{
+    key                 = "Name"
+    value               = "${var.cluster_name}-bastion"
+    propagate_at_launch = true
+  }]
+}
+
+resource "aws_autoscaling_attachment" "bastion_tg_attachment" {
+  autoscaling_group_name = "${aws_autoscaling_group.bastion.id}"
+  alb_target_group_arn   = "${aws_lb_target_group.bastion.arn}"
+}

--- a/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -163,8 +163,3 @@ storage:
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"
-passwd:
-  users:
-    - name: core
-      ssh_authorized_keys:
-        - "${ssh_authorized_key}"

--- a/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/aws/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -125,8 +125,3 @@ storage:
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)
-passwd:
-  users:
-    - name: core
-      ssh_authorized_keys:
-        - "${ssh_authorized_key}"

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -21,6 +21,9 @@ resource "aws_instance" "controllers" {
     Name = "${var.cluster_name}-controller-${count.index}"
   }
 
+  # keypair access to box.
+  key_name = "${var.keypair_name}"
+
   instance_type = "${var.controller_type}"
 
   ami       = "${data.aws_ami.coreos.image_id}"
@@ -33,8 +36,8 @@ resource "aws_instance" "controllers" {
   }
 
   # network
-  associate_public_ip_address = true
-  subnet_id                   = "${element(aws_subnet.public.*.id, count.index)}"
+  associate_public_ip_address = false
+  subnet_id                   = "${element(aws_subnet.private.*.id, count.index)}"
   vpc_security_group_ids      = ["${aws_security_group.controller.id}"]
 }
 
@@ -53,7 +56,6 @@ data "template_file" "controller_config" {
     etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
 
     k8s_dns_service_ip      = "${cidrhost(var.service_cidr, 10)}"
-    ssh_authorized_key      = "${var.ssh_authorized_key}"
     cluster_domain_suffix   = "${var.cluster_domain_suffix}"
     kubeconfig_ca_cert      = "${module.bootkube.ca_cert}"
     kubeconfig_kubelet_cert = "${module.bootkube.kubelet_cert}"

--- a/aws/container-linux/kubernetes/network.tf
+++ b/aws/container-linux/kubernetes/network.tf
@@ -17,7 +17,7 @@ resource "aws_internet_gateway" "gateway" {
   tags = "${map("Name", "${var.cluster_name}")}"
 }
 
-resource "aws_route_table" "default" {
+resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.network.id}"
 
   route {
@@ -30,11 +30,11 @@ resource "aws_route_table" "default" {
     gateway_id      = "${aws_internet_gateway.gateway.id}"
   }
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = "${map("Name", "${var.cluster_name}-public")}"
 }
 
+# Public network.  Bastion, NAT and LoadBalancers only.
 # Subnets (one per availability zone)
-
 resource "aws_subnet" "public" {
   count = "${length(data.aws_availability_zones.all.names)}"
 
@@ -52,6 +52,55 @@ resource "aws_subnet" "public" {
 resource "aws_route_table_association" "public" {
   count = "${length(data.aws_availability_zones.all.names)}"
 
-  route_table_id = "${aws_route_table.default.id}"
+  route_table_id = "${aws_route_table.public.id}"
   subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
+}
+
+# Private network - Controllers and Workers
+resource "aws_subnet" "private" {
+  count = "${length(data.aws_availability_zones.all.names)}"
+
+  vpc_id            = "${aws_vpc.network.id}"
+  availability_zone = "${data.aws_availability_zones.all.names[count.index]}"
+
+  cidr_block                      = "${cidrsubnet(var.host_cidr, 4, count.index + length(data.aws_availability_zones.all.names))}"
+  ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.network.ipv6_cidr_block, 8, count.index + length(data.aws_availability_zones.all.names))}"
+  map_public_ip_on_launch         = false
+  assign_ipv6_address_on_creation = false
+
+  tags = "${map("Name", "${var.cluster_name}-private-${count.index}")}"
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = "${aws_vpc.network.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    nat_gateway_id = "${aws_nat_gateway.nat.id}"
+  }
+
+  tags = "${map("Name", "${var.cluster_name}-private")}"
+}
+
+resource "aws_route_table_association" "private" {
+  count = "${length(data.aws_availability_zones.all.names)}"
+
+  route_table_id = "${aws_route_table.private.id}"
+  subnet_id      = "${element(aws_subnet.private.*.id, count.index + length(data.aws_availability_zones.all.names))}"
+}
+
+# NAT required to pull images from private subnets
+resource "aws_eip" "nat" {
+  vpc      = true
+}
+
+
+resource "aws_nat_gateway" "nat" {
+  depends_on = ["aws_internet_gateway.gateway"]
+  allocation_id = "${aws_eip.nat.id}"
+  subnet_id     = "${aws_subnet.public.0.id}"
+
+  tags {
+    Name = "${var.cluster_name}-NAT"
+  }
 }

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -13,11 +13,6 @@ variable "dns_zone_id" {
   description = "AWS DNS Zone ID (e.g. Z3PAABBCFAKEC0)"
 }
 
-variable "ssh_authorized_key" {
-  type        = "string"
-  description = "SSH public key for user 'core'"
-}
-
 variable "os_channel" {
   type        = "string"
   default     = "stable"
@@ -99,4 +94,14 @@ variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by kube-dns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   type        = "string"
   default     = "cluster.local"
+}
+
+variable "keypair_name" {
+  description = "The name of the EC2 KeyPair to use for instance created in this template."
+  type        = "string"
+}
+
+variable "instance_pem" {
+  description = "The location of EC2 PEM file to use for communicating to created instances."
+  type        = "string"
 }

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -11,7 +11,7 @@ resource "aws_autoscaling_group" "workers" {
   health_check_grace_period = 30
 
   # network
-  vpc_zone_identifier = ["${aws_subnet.public.*.id}"]
+  vpc_zone_identifier = ["${aws_subnet.private.*.id}"]
 
   # template
   launch_configuration = "${aws_launch_configuration.worker.name}"
@@ -36,6 +36,9 @@ resource "aws_launch_configuration" "worker" {
 
   user_data = "${data.ct_config.worker_ign.rendered}"
 
+  # keypair access to box.
+  key_name = "${var.keypair_name}"
+
   # storage
   root_block_device {
     volume_type = "standard"
@@ -58,7 +61,6 @@ data "template_file" "worker_config" {
   vars = {
     k8s_dns_service_ip      = "${cidrhost(var.service_cidr, 10)}"
     k8s_etcd_service_ip     = "${cidrhost(var.service_cidr, 15)}"
-    ssh_authorized_key      = "${var.ssh_authorized_key}"
     cluster_domain_suffix   = "${var.cluster_domain_suffix}"
     kubeconfig_ca_cert      = "${module.bootkube.ca_cert}"
     kubeconfig_kubelet_cert = "${module.bootkube.kubelet_cert}"


### PR DESCRIPTION
Launches controllers and workers in a private subnet.

* Creates a NAT and Bastion
* Launches load balancers, nat, gateway and bastion in public subnets
* Launces controllers and workers in private subnets.
* Uses the AWS KeyPair association for instances, removing the need for ssh-authorized-key, but adding the need for the pem to be on the working machine.
* Tunnels to controllers and workers via the bastion.

## Testing

I've created a cluster and deployed all the addons to it, with no issues.

Time to create has increased a touch.