### PR TITLE
Switch Ingress ELB to a network load balancer

### DIFF
--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -1,4 +1,4 @@
 output "ingress_dns_name" {
-  value       = "${aws_elb.ingress.dns_name}"
-  description = "DNS name of the ELB for distributing traffic to Ingress controllers"
+  value       = "${aws_lb.ingress.dns_name}"
+  description = "DNS name of the network load balancer for distributing traffic to Ingress controllers"
 }

--- a/aws/container-linux/kubernetes/require.tf
+++ b/aws/container-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.0"
+  version = "~> 1.7"
 }
 
 provider "local" {


### PR DESCRIPTION
Typhoon clusters include an AWS load balancer for pairing with Ingress Controller deployments to terminate multiple HTTP and HTTPS applications exposed via Ingress.

Until now, Typhoon has used elastic load balancers (ELBs) (now called "classic balancers"). AWS now offers Network Load Balancers (NLBs) which can handle millions of requests per second. This is important given that the balancer multiplexes or terminates multiple end-user applications.

Impact:

* Create an Ingress network load balancer instead of an elastic load balancer
* Workers are added to `worker-http` and `workers-https` target groups (similar to GCP target pools)
* Relax the firewall rules to expose the Ingress health port. NLBs do not have their own security group, so they cannot be independently permitted to health check Ingress controllers.
* Require terraform-provider-aws 1.7 or higher (NLBs were introduced in 1.1, but it took until 1.7 for the bugs to be sorted out)

## Testing

Used for the maintainer's AWS clusters and to serve a few HTTPS apps via Ingress. This has been used with Nginx Ingress 0.10.2 and 0.11.0.