### PR TITLE
DigitalOcean: ssh_key should be a list

### DIFF
--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -45,7 +45,7 @@ resource "digitalocean_droplet" "controllers" {
   private_networking = true
 
   user_data = "${element(data.ct_config.controller_ign.*.rendered, count.index)}"
-  ssh_keys  = "${var.ssh_fingerprints}"
+  ssh_keys  = [ "${var.ssh_fingerprints}" ]
 
   tags = [
     "${digitalocean_tag.controllers.id}",

--- a/digital-ocean/container-linux/kubernetes/workers.tf
+++ b/digital-ocean/container-linux/kubernetes/workers.tf
@@ -26,7 +26,7 @@ resource "digitalocean_droplet" "workers" {
   private_networking = true
 
   user_data = "${data.ct_config.worker_ign.rendered}"
-  ssh_keys  = "${var.ssh_fingerprints}"
+  ssh_keys  = [ "${var.ssh_fingerprints}" ]
 
   tags = [
     "${digitalocean_tag.workers.id}",


### PR DESCRIPTION
Make `ssh_key` param for controller and worker droplets a list by
wrapping in `[ ]`. Tested with these versions:
Terraform v0.11.3
	+ provider.ct (unversioned)
	+ provider.digitalocean v0.1.3
	+ provider.local v1.1.0
	+ provider.null v1.0.0
	+ provider.template v1.0.0
	+ provider.tls v1.0.1