### PR TITLE
Remove author employment disclosure note

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,5 +134,3 @@ Typhoon addresses real world needs, which you may share. It is honest about limi
 Typhoon is not a product, trial, or free-tier. It is not run by a company, does not offer support or services, and does not accept or make any money. It is not associated with any operating system or platform vendor.
 
 Typhoon clusters will contain only [free](https://www.debian.org/intro/free) components. Cluster components will not collect data on users without their permission.
-
-*Disclosure: The author works for Red Hat (prev CoreOS), but Typhoon is unassociated and maintained independently.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,5 +125,3 @@ Typhoon addresses real world needs, which you may share. It is honest about limi
 Typhoon is not a product, trial, or free-tier. It is not run by a company, does not offer support or services, and does not accept or make any money. It is not associated with any operating system or platform vendor.
 
 Typhoon clusters will contain only [free](https://www.debian.org/intro/free) components. Cluster components will not collect data on users without their permission.
-
-*Disclosure: The author works for Red Hat (prev CoreOS), but Typhoon is unassociated and maintained independently.*


### PR DESCRIPTION
The author no longer works for CoreOS or Red Hat. There is no longer any ambiguity that this project is independently maintained so there isn't a real need for the disclosure.

Typhoon development continues as usual.