### PR TITLE
Update Prometheus and Grafana monitoring stack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@ Notable changes between versions.
 
 #### Addons
 
+* Update Prometheus from 2.1.0 to 2.2.0 ([#153](https://github.com/poseidon/typhoon/pull/153))
+* Update Grafana from v4.6.3 to v5.0.0 ([#153](https://github.com/poseidon/typhoon/pull/153))
 * Update heapster from v1.5.0 to v1.5.1 ([#131](https://github.com/poseidon/typhoon/pull/131))
   * Use separate service account
 * Update nginx-ingress from 0.10.2 to 0.11.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,7 @@ Notable changes between versions.
 #### Addons
 
 * Update Prometheus from 2.1.0 to 2.2.0 ([#153](https://github.com/poseidon/typhoon/pull/153))
-* Update Grafana from v4.6.3 to v5.0.0 ([#153](https://github.com/poseidon/typhoon/pull/153))
+* Update Grafana from v4.6.3 to v5.0.1 ([#153](https://github.com/poseidon/typhoon/pull/153))
 * Update heapster from v1.5.0 to v1.5.1 ([#131](https://github.com/poseidon/typhoon/pull/131))
   * Use separate service account
 * Update nginx-ingress from 0.10.2 to 0.11.0

--- a/addons/grafana/dashboard-providers.yaml
+++ b/addons/grafana/dashboard-providers.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-providers
+  namespace: monitoring
+data:
+  dashboard-providers.yaml: |+
+    apiVersion: 1
+    providers:
+    - name: 'default'
+      ordId: 1
+      folder: ''
+      type: file
+      options:
+        path: /var/lib/grafana/dashboards

--- a/addons/grafana/dashboards.yaml
+++ b/addons/grafana/dashboards.yaml
@@ -6,13 +6,11 @@ metadata:
 data:
   deployment-dashboard.json: |+
     {
-      "dashboard":
-    {
       "__inputs": [
         {
           "description": "",
           "label": "prometheus",
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "pluginId": "prometheus",
           "pluginName": "Prometheus",
           "type": "datasource"
@@ -39,7 +37,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -110,7 +108,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -181,7 +179,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "Bps",
               "gauge": {
@@ -262,7 +260,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -333,7 +331,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -403,7 +401,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -473,7 +471,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -550,7 +548,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -665,7 +663,7 @@ data:
           {
             "allValue": ".*",
             "current": {},
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "Namespace",
@@ -685,7 +683,7 @@ data:
           {
             "allValue": null,
             "current": {},
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "Deployment",
@@ -737,24 +735,11 @@ data:
       "title": "Deployment",
       "version": 1
     }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
   etcd-dashboard.json: |+
-    {
-      "dashboard":
     {
       "__inputs": [
         {
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "label": "prometheus",
           "description": "",
           "type": "datasource",
@@ -813,7 +798,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "format": "none",
@@ -889,7 +874,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 0,
@@ -978,7 +963,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 0,
@@ -1079,7 +1064,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "decimals": null,
               "editable": false,
               "error": false,
@@ -1161,7 +1146,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 0,
@@ -1250,7 +1235,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 0,
@@ -1342,7 +1327,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 5,
@@ -1422,7 +1407,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 5,
@@ -1502,7 +1487,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 0,
@@ -1582,7 +1567,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "decimals": null,
               "editable": false,
               "error": false,
@@ -1676,7 +1661,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 0,
@@ -1782,7 +1767,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "decimals": 0,
               "editable": false,
               "error": false,
@@ -1909,26 +1894,13 @@ data:
       "title": "etcd",
       "version": 4
     }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
   kubernetes-capacity-planning-dashboard.json: |+
-    {
-      "dashboard":
     {
       "__inputs": [
         {
           "description": "",
           "label": "prometheus",
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "pluginId": "prometheus",
           "pluginName": "Prometheus",
           "type": "datasource"
@@ -1954,7 +1926,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -2032,7 +2004,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -2134,7 +2106,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -2250,7 +2222,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -2333,7 +2305,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -2440,7 +2412,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percentunit",
               "gauge": {
@@ -2522,7 +2494,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -2604,7 +2576,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -2695,7 +2667,7 @@ data:
               "aliasColors": {},
               "bars": false,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -2782,7 +2754,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -2897,26 +2869,13 @@ data:
       "title": "Kubernetes Capacity Planning",
       "version": 4
     }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
   kubernetes-cluster-health-dashboard.json: |+
-    {
-      "dashboard":
     {
       "__inputs": [
         {
           "description": "",
           "label": "prometheus",
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "pluginId": "prometheus",
           "pluginName": "Prometheus",
           "type": "datasource"
@@ -2944,7 +2903,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3025,7 +2984,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3101,7 +3060,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3177,7 +3136,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3263,7 +3222,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3339,7 +3298,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3415,7 +3374,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3491,7 +3450,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3605,26 +3564,13 @@ data:
       "title": "Kubernetes Cluster Health",
       "version": 9
     }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
   kubernetes-cluster-status-dashboard.json: |+
-    {
-      "dashboard":
     {
       "__inputs": [
         {
           "description": "",
           "label": "prometheus",
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "pluginId": "prometheus",
           "pluginName": "Prometheus",
           "type": "datasource"
@@ -3651,7 +3597,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3723,7 +3669,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -3805,7 +3751,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -3877,7 +3823,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -3949,7 +3895,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -4021,7 +3967,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -4103,7 +4049,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -4175,7 +4121,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -4247,7 +4193,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -4319,7 +4265,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -4429,26 +4375,13 @@ data:
       "title": "Kubernetes Cluster Status",
       "version": 3
     }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
   kubernetes-control-plane-status-dashboard.json: |+
-    {
-      "dashboard":
     {
       "__inputs": [
         {
           "description": "",
           "label": "prometheus",
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "pluginId": "prometheus",
           "pluginName": "Prometheus",
           "type": "datasource"
@@ -4475,7 +4408,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -4550,7 +4483,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -4625,7 +4558,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -4700,7 +4633,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -4783,7 +4716,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -4869,7 +4802,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -4944,7 +4877,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -5069,26 +5002,13 @@ data:
       "title": "Kubernetes Control Plane Status",
       "version": 3
     }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
   kubernetes-resource-requests-dashboard.json: |+
-    {
-      "dashboard":
     {
       "__inputs": [
         {
           "description": "",
           "label": "prometheus",
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "pluginId": "prometheus",
           "pluginName": "Prometheus",
           "type": "datasource"
@@ -5113,7 +5033,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "description": "This represents the total [CPU resource requests](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu) in the cluster.\nFor comparison the total [allocatable CPU cores](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md) is also shown.",
               "editable": false,
               "error": false,
@@ -5202,7 +5122,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -5284,7 +5204,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "description": "This represents the total [memory resource requests](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory) in the cluster.\nFor comparison the total [allocatable memory](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md) is also shown.",
               "editable": false,
               "error": false,
@@ -5373,7 +5293,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -5486,26 +5406,13 @@ data:
       "title": "Kubernetes Resource Requests",
       "version": 2
     }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
   nodes-dashboard.json: |+
-    {
-      "dashboard":
     {
       "__inputs": [
         {
           "description": "",
           "label": "prometheus",
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "pluginId": "prometheus",
           "pluginName": "Prometheus",
           "type": "datasource"
@@ -5532,7 +5439,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -5611,7 +5518,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -5713,7 +5620,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -5825,7 +5732,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percent",
               "gauge": {
@@ -5907,7 +5814,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -6014,7 +5921,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(245, 54, 54, 0.9)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "percentunit",
               "gauge": {
@@ -6096,7 +6003,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -6178,7 +6085,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -6270,7 +6177,7 @@ data:
           {
             "allValue": null,
             "current": {},
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": null,
@@ -6322,26 +6229,13 @@ data:
       "title": "Nodes",
       "version": 2
     }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
   pods-dashboard.json: |+
-    {
-      "dashboard":
     {
       "__inputs": [
         {
           "description": "",
           "label": "prometheus",
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "pluginId": "prometheus",
           "pluginName": "Prometheus",
           "type": "datasource"
@@ -6366,7 +6260,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -6472,7 +6366,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -6576,7 +6470,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -6662,7 +6556,7 @@ data:
           {
             "allValue": ".*",
             "current": {},
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "prometheus",
             "hide": 0,
             "includeAll": true,
             "label": "Namespace",
@@ -6682,7 +6576,7 @@ data:
           {
             "allValue": null,
             "current": {},
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "Pod",
@@ -6702,7 +6596,7 @@ data:
           {
             "allValue": ".*",
             "current": {},
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "prometheus",
             "hide": 0,
             "includeAll": true,
             "label": "Container",
@@ -6754,26 +6648,13 @@ data:
       "title": "Pods",
       "version": 1
     }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
   statefulset-dashboard.json: |+
-    {
-      "dashboard":
     {
       "__inputs": [
         {
           "description": "",
           "label": "prometheus",
-          "name": "DS_PROMETHEUS",
+          "name": "prometheus",
           "pluginId": "prometheus",
           "pluginName": "Prometheus",
           "type": "datasource"
@@ -6800,7 +6681,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -6871,7 +6752,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -6942,7 +6823,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "Bps",
               "gauge": {
@@ -7023,7 +6904,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -7094,7 +6975,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -7164,7 +7045,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -7234,7 +7115,7 @@ data:
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "format": "none",
               "gauge": {
@@ -7311,7 +7192,7 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "prometheus",
               "editable": false,
               "error": false,
               "fill": 1,
@@ -7405,7 +7286,7 @@ data:
           {
             "allValue": ".*",
             "current": {},
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "Namespace",
@@ -7425,7 +7306,7 @@ data:
           {
             "allValue": null,
             "current": {},
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "StatefulSet",
@@ -7476,24 +7357,5 @@ data:
       "timezone": "browser",
       "title": "StatefulSet",
       "version": 1
-    }
-    ,
-      "inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "type": "datasource",
-          "value": "prometheus"
-        }
-      ],
-      "overwrite": true
-    }
-  prometheus-datasource.json: |+
-    {
-        "access": "proxy",
-        "basicAuth": false,
-        "name": "prometheus",
-        "type": "prometheus",
-        "url": "http://prometheus.monitoring.svc"
     }
 ---

--- a/addons/grafana/datasources.yaml
+++ b/addons/grafana/datasources.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: monitoring
+data:
+  prometheus.yaml: |+
+    apiVersion: 1
+    datasources:
+    - name: prometheus
+      type: prometheus
+      access: proxy
+      orgId: 1
+      url: http://prometheus.monitoring.svc.cluster.local
+      version: 1
+      editable: false

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:5.0.0
+          image: grafana/grafana:5.0.1
           env:
             - name: GF_SERVER_HTTP_PORT
               value: "8080"

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:4.6.3
+          image: grafana/grafana:5.0.0
           env:
             - name: GF_SERVER_HTTP_PORT
               value: "8080"
@@ -30,7 +30,7 @@ spec:
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "true"
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE
-              value: Admin
+              value: Viewer
           ports:
             - name: http
               containerPort: 8080
@@ -41,22 +41,20 @@ spec:
             limits:
               memory: 200Mi
               cpu: 200m
-        - name: grafana-watcher
-          image: quay.io/coreos/grafana-watcher:v0.0.8
-          args:
-            - '--watch-dir=/etc/grafana/dashboards'
-            - '--grafana-url=http://localhost:8080'
-          resources:
-            requests:
-              memory: "16Mi"
-              cpu: "50m"
-            limits:
-              memory: "32Mi"
-              cpu: "100m"
           volumeMounts:
-          - name: dashboards
-            mountPath: /etc/grafana/dashboards
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: dashboard-providers
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
       volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboard-providers
+          configMap:
+            name: grafana-dashboard-providers
         - name: dashboards
           configMap:
             name: grafana-dashboards

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: quay.io/prometheus/prometheus:v2.1.0
+        image: quay.io/prometheus/prometheus:v2.2.0-rc.1
         args:
           - '--config.file=/etc/prometheus/prometheus.yaml'
         ports:

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: quay.io/prometheus/prometheus:v2.2.0-rc.1
+        image: quay.io/prometheus/prometheus:v2.2.0
         args:
           - '--config.file=/etc/prometheus/prometheus.yaml'
         ports:

--- a/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: addon-resizer
-        image: gcr.io/google_containers/addon-resizer:1.0
+        image: gcr.io/google_containers/addon-resizer:1.7
         resources:
           limits:
             cpu: 100m
@@ -54,8 +54,8 @@ spec:
           - /pod_nanny
           - --container=kube-state-metrics
           - --cpu=100m
-          - --extra-cpu=2m
-          - --memory=150Mi
-          - --extra-memory=30Mi
+          - --extra-cpu=1m
+          - --memory=100Mi
+          - --extra-memory=2Mi
           - --threshold=5
           - --deployment=kube-state-metrics

--- a/addons/prometheus/exporters/kube-state-metrics/service.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/service.yaml
@@ -15,5 +15,5 @@ spec:
   ports:
     - name: metrics
       protocol: TCP
-      port: 80
+      port: 8080
       targetPort: 8080

--- a/addons/prometheus/rules.yaml
+++ b/addons/prometheus/rules.yaml
@@ -353,7 +353,7 @@ data:
           description: Prometheus failed to scrape {{ $value }}% of kubelets.
       - alert: K8SKubeletDown
         expr: (absent(up{job="kubelet"} == 1) or count(up{job="kubelet"} == 0) / count(up{job="kubelet"}))
-          * 100 > 1
+          * 100 > 10
         for: 1h
         labels:
           severity: critical
@@ -588,3 +588,11 @@ data:
           description: '{{$labels.job}} at {{$labels.instance}} has a corrupted write-ahead
             log (WAL).'
           summary: Prometheus write-ahead log is corrupted
+      - alert: PrometheusNotIngestingSamples
+        expr: rate(prometheus_tsdb_head_samples_appended_total[5m]) <= 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: "Prometheus {{ $labels.namespace }}/{{ $labels.pod}} isn't ingesting samples."
+          summary: "Prometheus isn't ingesting samples"

--- a/addons/prometheus/service.yaml
+++ b/addons/prometheus/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: prometheus
   namespace: monitoring
+  annotations:
+    prometheus.io/scrape: 'true'
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
### Prometheus

* Annotate Prometheus service to scrape metrics from Prometheus itself (enables Prometheus* alerts)
* Update kube-state-metrics addon-resizer to 1.7
* Use port 8080 for kube-state-metrics
* Add PrometheusNotIngestingSamples alert rule
* Change K8SKubeletDown alert rule to fire when 10% of kubelets are down, not 1%
  * coreos/prometheus-operator#1032

### Grafana

* Update from Grafana v4.6.3 to v5.0.1
* Change dashboard org role to Viewer