### PR TITLE
Fix overly strict firewall for GCP "worker pools"

### DIFF
--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -79,12 +79,17 @@ Create a cluster following the Google Cloud [tutorial](../google-cloud.md#cluste
 module "yavin-worker-pool" {
   source = "git::https://github.com/poseidon/typhoon//google-cloud/container-linux/kubernetes/workers?ref=v1.9.4"
 
+  providers = {
+    google = "google.default"
+  }
+
   # Google Cloud
-  region  = "us-central1"
-  network = "${module.google-cloud-yavin.network_name}"
+  region       = "us-central1"
+  network      = "${module.google-cloud-yavin.network_name}"
+  cluster_name = "yavin"
 
   # configuration
-  cluster_name       = "yavin-16x"
+  name               = "yavin-16x"
   kubeconfig         = "${module.google-cloud-yavin.kubeconfig}"
   ssh_authorized_key = "${var.ssh_authorized_key}"
   
@@ -123,7 +128,8 @@ The Google Cloud internal `workers` module supports a number of [variables](http
 |:-----|:------------|:--------|
 | region | Must be set to `region` of cluster | "us-central1" |
 | network | Must be set to `network_name` output by cluster | "${module.cluster.network_name}" |
-| cluster_name | Unique name | "yavin-worker-pool" |
+| name | Unique name (distinct from cluster name) | "yavin-16x" |
+| cluster_name | Must be set to `cluster_name` of cluster | "yavin" |
 | kubeconfig | Must be set to `kubeconfig` output by cluster | "${module.cluster.kubeconfig}" |
 | ssh_authorized_key | SSH public key for ~/.ssh_authorized_keys | "ssh-rsa AAAAB3NZ..." |
 

--- a/google-cloud/container-linux/kubernetes/cluster.tf
+++ b/google-cloud/container-linux/kubernetes/cluster.tf
@@ -3,11 +3,11 @@ module "controllers" {
   cluster_name = "${var.cluster_name}"
 
   # GCE
-  network       = "${google_compute_network.network.name}"
-  count         = "${var.controller_count}"
   region        = "${var.region}"
+  network       = "${google_compute_network.network.name}"
   dns_zone      = "${var.dns_zone}"
   dns_zone_name = "${var.dns_zone_name}"
+  count         = "${var.controller_count}"
   machine_type  = "${var.machine_type}"
   os_image      = "${var.os_image}"
 
@@ -21,11 +21,12 @@ module "controllers" {
 
 module "workers" {
   source       = "workers"
+  name         = "${var.cluster_name}"
   cluster_name = "${var.cluster_name}"
 
   # GCE
-  network      = "${google_compute_network.network.name}"
   region       = "${var.region}"
+  network      = "${google_compute_network.network.name}"
   count        = "${var.worker_count}"
   machine_type = "${var.machine_type}"
   os_image     = "${var.os_image}"

--- a/google-cloud/container-linux/kubernetes/workers/ingress.tf
+++ b/google-cloud/container-linux/kubernetes/workers/ingress.tf
@@ -1,18 +1,18 @@
 # Static IPv4 address for the Network Load Balancer
 resource "google_compute_address" "ingress-ip" {
-  name = "${var.cluster_name}-ingress-ip"
+  name = "${var.name}-ingress-ip"
 }
 
 # Network Load Balancer (i.e. forwarding rules)
 resource "google_compute_forwarding_rule" "worker-http-lb" {
-  name       = "${var.cluster_name}-worker-http-rule"
+  name       = "${var.name}-worker-http-rule"
   ip_address = "${google_compute_address.ingress-ip.address}"
   port_range = "80"
   target     = "${google_compute_target_pool.workers.self_link}"
 }
 
 resource "google_compute_forwarding_rule" "worker-https-lb" {
-  name       = "${var.cluster_name}-worker-https-rule"
+  name       = "${var.name}-worker-https-rule"
   ip_address = "${google_compute_address.ingress-ip.address}"
   port_range = "443"
   target     = "${google_compute_target_pool.workers.self_link}"
@@ -20,7 +20,7 @@ resource "google_compute_forwarding_rule" "worker-https-lb" {
 
 # Network Load Balancer target pool of instances.
 resource "google_compute_target_pool" "workers" {
-  name = "${var.cluster_name}-worker-pool"
+  name = "${var.name}-worker-pool"
 
   health_checks = [
     "${google_compute_http_health_check.ingress.name}",
@@ -31,7 +31,7 @@ resource "google_compute_target_pool" "workers" {
 
 # Ingress HTTP Health Check
 resource "google_compute_http_health_check" "ingress" {
-  name        = "${var.cluster_name}-ingress-health"
+  name        = "${var.name}-ingress-health"
   description = "Health check Ingress controller health host port"
 
   timeout_sec        = 5

--- a/google-cloud/container-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/workers/variables.tf
@@ -1,11 +1,16 @@
-variable "cluster_name" {
+variable "name" {
   type        = "string"
-  description = "Unique cluster name"
+  description = "Unique name"
 }
 
-variable "ssh_authorized_key" {
+variable "cluster_name" {
   type        = "string"
-  description = "SSH public key for logging in as user 'core'"
+  description = "Cluster name"
+}
+
+variable "region" {
+  type        = "string"
+  description = "Google Cloud region (e.g. us-central1, see `gcloud compute regions list`)."
 }
 
 variable "network" {
@@ -19,11 +24,6 @@ variable "count" {
   type        = "string"
   default     = "1"
   description = "Number of worker compute instances the instance group should manage"
-}
-
-variable "region" {
-  type        = "string"
-  description = "Google Cloud region (e.g. us-central1, see `gcloud compute regions list`)."
 }
 
 variable "machine_type" {
@@ -52,6 +52,16 @@ variable "preemptible" {
 
 # configuration
 
+variable "kubeconfig" {
+  type        = "string"
+  description = "Generated Kubelet kubeconfig"
+}
+
+variable "ssh_authorized_key" {
+  type        = "string"
+  description = "SSH public key for logging in as user 'core'"
+}
+
 variable "service_cidr" {
   description = <<EOD
 CIDR IP range to assign Kubernetes services.
@@ -66,9 +76,4 @@ variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by kube-dns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   type        = "string"
   default     = "cluster.local"
-}
-
-variable "kubeconfig" {
-  type        = "string"
-  description = "Generated Kubelet kubeconfig"
 }

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -1,11 +1,11 @@
 # Regional managed instance group maintains a homogeneous set of workers that
 # span the zones in the region.
 resource "google_compute_region_instance_group_manager" "workers" {
-  name        = "${var.cluster_name}-worker-group"
-  description = "Compute instance group of ${var.cluster_name} workers"
+  name        = "${var.name}-worker-group"
+  description = "Compute instance group of ${var.name} workers"
 
   # instance name prefix for instances in the group
-  base_instance_name = "${var.cluster_name}-worker"
+  base_instance_name = "${var.name}-worker"
   instance_template  = "${google_compute_instance_template.worker.self_link}"
   region             = "${var.region}"
 
@@ -35,7 +35,7 @@ data "ct_config" "worker_ign" {
 }
 
 resource "google_compute_instance_template" "worker" {
-  name_prefix  = "${var.cluster_name}-worker-"
+  name_prefix  = "${var.name}-worker-"
   description  = "Worker Instance template"
   machine_type = "${var.machine_type}"
 
@@ -64,7 +64,7 @@ resource "google_compute_instance_template" "worker" {
 
   can_ip_forward = true
 
-  tags = ["worker", "${var.cluster_name}-worker"]
+  tags = ["worker", "${var.cluster_name}-worker", "${var.name}-worker"]
 
   lifecycle {
     # To update an Instance Template, Terraform should replace the existing resource


### PR DESCRIPTION
* Fix issue where worker firewall rules didn't apply to additional workers attached to a GCP cluster using the new "worker pools" feature (unreleased, #148). Solves host connection timeouts and pods not being scheduled to attached worker pools.
* Add `name` field to GCP internal worker module to represent the unique name of the worker pool
* Use `cluster_name` field of GCP internal worker module for passing the name of the cluster to which workers should be attached

## Notes

No security impact. The worker pool firewalls default to disallow. This issue is about lacking whitelisting rules (i.e. they're too strict) that should be present.

No breakages. The new required `name` field is not covered in the changelog because through the v1.9.3 release, the Terraform "worker" submodule was considered internal. No docs suggested it could be used directly and there were a number of issues with attempting to do so.

## Testing

Evaluated this after running into issues with workloads that required scheduling on the attached "worker pool". Verified cross-worker-pool network pod-to-pod connectivity and pods scheduled across pools.
