### PR TITLE
Add variables for mounting additional volumes to kubelet pod

### DIFF
--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -66,7 +66,7 @@ systemd:
           --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
           --mount volume=opt-cni-bin,target=/opt/cni/bin \
           --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
+          --mount volume=var-log,target=/var/log \${controller_mount_parameters}
           --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
@@ -74,7 +74,7 @@ systemd:
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
-        ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins
+        ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins${controller_mount_dirs}
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \

--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -42,7 +42,7 @@ systemd:
           --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
           --mount volume=opt-cni-bin,target=/opt/cni/bin \
           --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
+          --mount volume=var-log,target=/var/log \${worker_mount_parameters}
           --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
@@ -50,7 +50,7 @@ systemd:
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
-        ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins
+        ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins${worker_mount_dirs}
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -92,12 +92,14 @@ data "template_file" "controller-configs" {
   template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
 
   vars {
-    domain_name           = "${element(var.controller_domains, count.index)}"
-    etcd_name             = "${element(var.controller_names, count.index)}"
-    etcd_initial_cluster  = "${join(",", formatlist("%s=https://%s:2380", var.controller_names, var.controller_domains))}"
-    k8s_dns_service_ip    = "${module.bootkube.kube_dns_service_ip}"
-    cluster_domain_suffix = "${var.cluster_domain_suffix}"
-    ssh_authorized_key    = "${var.ssh_authorized_key}"
+    domain_name                 = "${element(var.controller_domains, count.index)}"
+    etcd_name                   = "${element(var.controller_names, count.index)}"
+    etcd_initial_cluster        = "${join(",", formatlist("%s=https://%s:2380", var.controller_names, var.controller_domains))}"
+    k8s_dns_service_ip          = "${module.bootkube.kube_dns_service_ip}"
+    cluster_domain_suffix       = "${var.cluster_domain_suffix}"
+    ssh_authorized_key          = "${var.ssh_authorized_key}"
+    controller_mount_parameters = "${join("", formatlist("\n          --volume=tf-vol-%s,kind=host,source=%s \\\n          --mount volume=tf-vol-%s,target=%s \\", var.kubelet_controller_mount_points, keys(var.kubelet_controller_mount_points_mapping), var.kubelet_controller_mount_points, values(var.kubelet_controller_mount_points_mapping) ) )}"
+    controller_mount_dirs       = "${join("", formatlist("\n        ExecStartPre=/bin/mkdir -p %s", keys(var.kubelet_controller_mount_points_mapping)))}"
 
     # Terraform evaluates both sides regardless and element cannot be used on 0 length lists
     networkd_content = "${length(var.controller_networkds) == 0 ? "" : element(concat(var.controller_networkds, list("")), count.index)}"
@@ -117,10 +119,12 @@ data "template_file" "worker-configs" {
   template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
 
   vars {
-    domain_name           = "${element(var.worker_domains, count.index)}"
-    k8s_dns_service_ip    = "${module.bootkube.kube_dns_service_ip}"
-    cluster_domain_suffix = "${var.cluster_domain_suffix}"
-    ssh_authorized_key    = "${var.ssh_authorized_key}"
+    domain_name             = "${element(var.worker_domains, count.index)}"
+    k8s_dns_service_ip      = "${module.bootkube.kube_dns_service_ip}"
+    cluster_domain_suffix   = "${var.cluster_domain_suffix}"
+    ssh_authorized_key      = "${var.ssh_authorized_key}"
+    worker_mount_parameters = "${join("", formatlist("\n          --volume=tf-vol-%s,kind=host,source=%s \\\n          --mount volume=tf-vol-%s,target=%s \\", var.kubelet_worker_mount_points, keys(var.kubelet_worker_mount_points_mapping), var.kubelet_worker_mount_points, values(var.kubelet_worker_mount_points_mapping) ) )}"
+    worker_mount_dirs       = "${join("", formatlist("\n        ExecStartPre=/bin/mkdir -p %s", keys(var.kubelet_worker_mount_points_mapping)))}"
 
     # Terraform evaluates both sides regardless and element cannot be used on 0 length lists
     networkd_content = "${length(var.worker_networkds) == 0 ? "" : element(concat(var.worker_networkds, list("")), count.index)}"

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -122,6 +122,30 @@ variable "kernel_args" {
   default     = []
 }
 
+variable "kubelet_controller_mount_points" {
+  description = "Additional mount points for kubelet on controller node - names of rkt volumes"
+  type = "list"
+  default = []
+}
+
+variable "kubelet_controller_mount_points_mapping" {
+  description = "Mappings for additional kubelet controller mount points as a source=target map"
+  type = "map"
+  default = {}
+}
+
+variable "kubelet_worker_mount_points" {
+  description = "Additional mount points for kubelet on worker node - names of rkt volumes"
+  type = "list"
+  default = []
+}
+
+variable "kubelet_worker_mount_points_mapping" {
+  description = "Mappings for additional kubelet worker mount points as a source=target map"
+  type = "map"
+  default = {}
+}
+
 # unofficial, undocumented, unsupported, temporary
 
 variable "controller_networkds" {


### PR DESCRIPTION
Added new variables that allow to add additional mounting points to kubelet pods. It is necessary if we want kubelet to map Ceph RBD volumes (ceph configuration directory needs to be accessible from kubelet pod).

`controller-configs` template is extended with another parameter that is created from the mount list. It adds `--volume` and `--mount` parameters to `rkt run` args and `ExecStartPre`s with directory creation. Value is optional and empty by default.

Unfortunately, I had to create 2 variables for each type of kubelet pod. `for` is not implemented in terraform yet and parameters have to be created by `formatlist`, where I can't find the current list index during iteration, can't even use `range` list so I am unable to create unique volume name and need to pass it from another list.
Same issue is described here:
https://github.com/hashicorp/terraform/issues/2769
and last comment announces solution for this problems in near future.

Tested & working without any changes, on 3-node configuration that works with master code

To add `ceph-conf` volume to controller node with `/etc/ceph:/etc/ceph` mapping add following variables:
```
kubelet_controller_mount_points = ["ceph-conf"]
kubelet_controller_mount_points_mapping = { "/etc/ceph" = "/etc/ceph" }
```