### PR TITLE
Add ignore_changes for AWS worker image_id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Notable changes between versions.
   * Require terraform-provider-aws 1.7.0 or higher
 * Allow groups of workers to be defined and joined to a cluster (i.e. worker pools) ([#150](https://github.com/poseidon/typhoon/pull/150))
 * Add kubelet `--volume-plugin-dir` flag to allow flexvolume plugins ([#142](https://github.com/poseidon/typhoon/pull/142))
+* Fix controller and worker launch configs to ignore AMI changes ([#126](https://github.com/poseidon/typhoon/pull/126), [#158](https://github.com/poseidon/typhoon/pull/158))
 
 #### Digital Ocean
 

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -24,7 +24,6 @@ resource "aws_autoscaling_group" "workers" {
   lifecycle {
     # override the default destroy and replace update behavior
     create_before_destroy = true
-    ignore_changes        = ["image_id"]
   }
 
   tags = [{
@@ -53,6 +52,7 @@ resource "aws_launch_configuration" "worker" {
   lifecycle {
     // Override the default destroy and replace update behavior
     create_before_destroy = true
+    ignore_changes        = ["image_id"]
   }
 }
 


### PR DESCRIPTION
Fix AWS worker launch configs and worker pool launch configs to stop producing a diff when Container Linux releases a new AMI.

* AWS controllers were protected by the fix https://github.com/poseidon/typhoon/commit/c8313751d7ec4af5766cc93c7cd29ccbc2cb7a7d
* AWS workers were not, because the `image_id` field is on the launch config, not the scaling group.