### PR TITLE
Enable AWS NLB cross-zone load balancing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ Notable changes between versions.
 * Switch Ingress elastic load balancer to a network load balancer ([#141](https://github.com/poseidon/typhoon/pull/141))
   * AWS [NLBs](https://aws.amazon.com/blogs/aws/new-network-load-balancer-effortless-scaling-to-millions-of-requests-per-second/) can handle millions of RPS with high throughput and low latency.
   * Require terraform-provider-aws 1.7.0 or higher
+* Enable cross-zone NLB load balancing ([#159](https://github.com/poseidon/typhoon/pull/159))
+  * [Announcement](https://aws.amazon.com/about-aws/whats-new/2018/02/network-load-balancer-now-supports-cross-zone-load-balancing/): Requests are automatically evenly distributed to targets regardless of AZ
+  * Require terraform-provider-aws 1.11.0 or higher
 * Allow groups of workers to be defined and joined to a cluster (i.e. worker pools) ([#150](https://github.com/poseidon/typhoon/pull/150))
 * Add kubelet `--volume-plugin-dir` flag to allow flexvolume plugins ([#142](https://github.com/poseidon/typhoon/pull/142))
 * Fix controller and worker launch configs to ignore AMI changes ([#126](https://github.com/poseidon/typhoon/pull/126), [#158](https://github.com/poseidon/typhoon/pull/158))

--- a/aws/container-linux/kubernetes/apiserver.tf
+++ b/aws/container-linux/kubernetes/apiserver.tf
@@ -20,6 +20,8 @@ resource "aws_lb" "apiserver" {
   internal           = false
 
   subnets = ["${aws_subnet.public.*.id}"]
+
+  enable_cross_zone_load_balancing = true
 }
 
 # Forward HTTP traffic to controllers

--- a/aws/container-linux/kubernetes/require.tf
+++ b/aws/container-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.7"
+  version = "~> 1.11"
 }
 
 provider "local" {

--- a/aws/container-linux/kubernetes/workers/ingress.tf
+++ b/aws/container-linux/kubernetes/workers/ingress.tf
@@ -5,6 +5,8 @@ resource "aws_lb" "ingress" {
   internal           = false
 
   subnets = ["${var.subnet_ids}"]
+
+  enable_cross_zone_load_balancing = true
 }
 
 # Forward HTTP traffic to workers


### PR DESCRIPTION
Cross zone load balancing is a new feature available now that we use NLBs. According to the AWS blog [announcement](https://aws.amazon.com/about-aws/whats-new/2018/02/network-load-balancer-now-supports-cross-zone-load-balancing/),

* Before: "Prior to this support, Network Load Balancer routed requests only to targets located in the same Availability Zone. This meant that in scenarios where the clients were caching the DNS information of a zonal Network Load Balancer, some targets could receive a disproportionally higher number of inbound requests."
* Enabled: "requests are distributed equally to your targets regardless of the Availability Zone in which they are located"

We're opting to enable cross zone load balancing for the apiserver and ingress.

Testing: In Progress
Requires: terraform-aws-provider v0.11.0 or higher
rel: https://github.com/terraform-providers/terraform-provider-aws/pull/3537
