### PR TITLE
Allow Google accelerators (i.e. GPUs) on workers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@ Notable changes between versions.
 * Add kubelet `--volume-plugin-dir` flag to allow flexvolume plugins ([#142](https://github.com/poseidon/typhoon/pull/142))
 * Add `kubeconfig` variable to `controllers` and `workers` submodules ([#147](https://github.com/poseidon/typhoon/pull/147))
 * Remove `kubeconfig_*` variables from `controllers` and `workers` submodules ([#147](https://github.com/poseidon/typhoon/pull/147))
+* Allow initial experimentation with accelerators (i.e. GPUs) on workers ([#161](https://github.com/poseidon/typhoon/pull/161)) (unofficial)
+  * Require `terraform-provider-google` v1.6.0
 
 #### Addons
 

--- a/google-cloud/container-linux/kubernetes/require.tf
+++ b/google-cloud/container-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 1.2"
+  version = "~> 1.6"
 }
 
 provider "local" {

--- a/google-cloud/container-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/workers/variables.tf
@@ -77,3 +77,17 @@ variable "cluster_domain_suffix" {
   type        = "string"
   default     = "cluster.local"
 }
+
+# unofficial, undocumented, unsupported, temporary
+
+variable "accelerator_type" {
+  type = "string"
+  default = ""
+  description = "Google Compute Engine accelerator type (e.g. nvidia-tesla-k80, see gcloud compute accelerator-types list)"
+}
+
+variable "accelerator_count" {
+  type = "string"
+  default = "0"
+  description = "Number of compute engine accelerators"
+}

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -63,8 +63,12 @@ resource "google_compute_instance_template" "worker" {
   }
 
   can_ip_forward = true
-
   tags = ["worker", "${var.cluster_name}-worker", "${var.name}-worker"]
+
+  guest_accelerator {
+    count = "${var.accelerator_count}"
+    type = "${var.accelerator_type}"
+  }
 
   lifecycle {
     # To update an Instance Template, Terraform should replace the existing resource


### PR DESCRIPTION
**Warning**: This does **not** magically make GPUs work on Container Linux or Kubernetes. It simply allows advanced users to begin experimenting with them. Like the comments imply, this feature is unofficial, undocumented, unsupported, and may be changed or removed at any time.

Caveats:

* Requires changes to Google Cloud default quotas
* Requires using `terraform-provider-google` 1.6.0 or higher to work with "0" GPUs properly
* Requires compiling your own kernel modules on Container Linux. (It's possible, I've done it. Just lots of rough edges)
* Some instances will remain un-created forever, because no GPU model is uniformly available across zones and workers are randomized into zones within a region automatically (a Typhoon feature). We just have to fiddle with the count until GCP learns to only try to create the instance in a zone it can actually be created in.
