### PR TITLE
Allow users to specify a custom SSH port

### DIFF
--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -115,6 +115,13 @@ systemd:
         ExecStartPost=/bin/touch /opt/bootkube/init_bootkube.done
         [Install]
         WantedBy=multi-user.target
+    - name: sshd.socket
+      dropins:
+      - name: 10-sshd-port.conf
+        contents: |
+          [Socket]
+          ListenStream=
+          ListenStream=${ssh_port}
 storage:
   files:
     - path: /etc/kubernetes/kubelet.env
@@ -157,3 +164,22 @@ storage:
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"
+    - path: /etc/ssh/sshd_config
+      filesystem: root
+      mode: 0600
+      contents:
+        inline: |
+          UsePrivilegeSeparation sandbox
+          Subsystem sftp internal-sftp
+          UseDNS no
+
+          PermitRootLogin no
+
+          AllowUsers core
+          AuthenticationMethods publickey
+          PubkeyAuthentication yes
+
+          LoginGraceTime 30
+
+          ClientAliveInterval 300
+          ClientAliveCountMax 0

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -88,6 +88,13 @@ systemd:
         ExecStop=/etc/kubernetes/delete-node
         [Install]
         WantedBy=multi-user.target
+    - name: sshd.socket
+      dropins:
+      - name: 10-sshd-port.conf
+        contents: |
+          [Socket]
+          ListenStream=
+          ListenStream=${ssh_port}
 storage:
   files:
     - path: /etc/kubernetes/kubelet.env
@@ -118,3 +125,22 @@ storage:
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)
+    - path: /etc/ssh/sshd_config
+      filesystem: root
+      mode: 0600
+      contents:
+        inline: |
+          UsePrivilegeSeparation sandbox
+          Subsystem sftp internal-sftp
+          UseDNS no
+
+          PermitRootLogin no
+
+          AllowUsers core
+          AuthenticationMethods publickey
+          PubkeyAuthentication yes
+
+          LoginGraceTime 30
+
+          ClientAliveInterval 300
+          ClientAliveCountMax 0

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -72,6 +72,8 @@ data "template_file" "controller_config" {
     etcd_initial_cluster  = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
     k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
+
+    ssh_port = "${var.ssh_port}"
   }
 }
 

--- a/digital-ocean/container-linux/kubernetes/network.tf
+++ b/digital-ocean/container-linux/kubernetes/network.tf
@@ -7,7 +7,7 @@ resource "digitalocean_firewall" "rules" {
   inbound_rule = [
     {
       protocol         = "tcp"
-      port_range       = "22"
+      port_range       = "${var.ssh_port}"
       source_addresses = ["0.0.0.0/0", "::/0"]
     },
     {

--- a/digital-ocean/container-linux/kubernetes/ssh.tf
+++ b/digital-ocean/container-linux/kubernetes/ssh.tf
@@ -6,6 +6,7 @@ resource "null_resource" "copy-secrets" {
     type    = "ssh"
     host    = "${element(concat(digitalocean_droplet.controllers.*.ipv4_address, digitalocean_droplet.workers.*.ipv4_address), count.index)}"
     user    = "core"
+    port    = "${var.ssh_port}"
     timeout = "15m"
   }
 
@@ -75,6 +76,7 @@ resource "null_resource" "bootkube-start" {
     type    = "ssh"
     host    = "${digitalocean_droplet.controllers.0.ipv4_address}"
     user    = "core"
+    port    = "${var.ssh_port}"
     timeout = "15m"
   }
 

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -48,6 +48,12 @@ variable "ssh_fingerprints" {
   description = "SSH public key fingerprints. (e.g. see `ssh-add -l -E md5`)"
 }
 
+variable "ssh_port" {
+  type        = "string"
+  default     = "22"
+  description = "SSH server port"
+}
+
 variable "controller_clc_snippets" {
   type        = "list"
   description = "Controller Container Linux Config snippets"

--- a/digital-ocean/container-linux/kubernetes/workers.tf
+++ b/digital-ocean/container-linux/kubernetes/workers.tf
@@ -45,6 +45,8 @@ data "template_file" "worker_config" {
   vars = {
     k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
+
+    ssh_port = "${var.ssh_port}"
   }
 }
 


### PR DESCRIPTION
High level description of the change.

Allow users to specify what port SSH listen on and configure connection idle timeouts for SSH.

## Testing

```bash
$ terraform plan
$ terraform apply
```
