### PR TITLE
Cleanup remote provision steps across platforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Notable changes between versions.
 
 #### Digital Ocean
 
+* Ensure etcd secrets are only distributed to controller hosts, not workers.
 * Remove optional variable `networking`. Only flannel works on Digital Ocean.
 
 #### Google Cloud

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -56,10 +56,10 @@ data "template_file" "controller_config" {
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
     etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
 
-    k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
-    ssh_authorized_key    = "${var.ssh_authorized_key}"
-    cluster_domain_suffix = "${var.cluster_domain_suffix}"
     kubeconfig            = "${indent(10, module.bootkube.kubeconfig)}"
+    ssh_authorized_key    = "${var.ssh_authorized_key}"
+    k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
+    cluster_domain_suffix = "${var.cluster_domain_suffix}"
   }
 }
 

--- a/bare-metal/container-linux/kubernetes/ssh.tf
+++ b/bare-metal/container-linux/kubernetes/ssh.tf
@@ -1,5 +1,5 @@
 # Secure copy etcd TLS assets and kubeconfig to controllers. Activates kubelet.service
-resource "null_resource" "copy-etcd-secrets" {
+resource "null_resource" "copy-controller-secrets" {
   count = "${length(var.controller_names)}"
 
   connection {
@@ -61,13 +61,13 @@ resource "null_resource" "copy-etcd-secrets" {
       "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
       "sudo chown -R etcd:etcd /etc/ssl/etcd",
       "sudo chmod -R 500 /etc/ssl/etcd",
-      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
     ]
   }
 }
 
 # Secure copy kubeconfig to all workers. Activates kubelet.service
-resource "null_resource" "copy-kubeconfig" {
+resource "null_resource" "copy-worker-secrets" {
   count = "${length(var.worker_names)}"
 
   connection {
@@ -84,7 +84,7 @@ resource "null_resource" "copy-kubeconfig" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
     ]
   }
 }
@@ -95,13 +95,16 @@ resource "null_resource" "bootkube-start" {
   # Without depends_on, this remote-exec may start before the kubeconfig copy.
   # Terraform only does one task at a time, so it would try to bootstrap
   # while no Kubelets are running.
-  depends_on = ["null_resource.copy-etcd-secrets", "null_resource.copy-kubeconfig"]
+  depends_on = [
+    "null_resource.copy-controller-secrets",
+    "null_resource.copy-worker-secrets",
+  ]
 
   connection {
     type    = "ssh"
     host    = "${element(var.controller_domains, 0)}"
     user    = "core"
-    timeout = "30m"
+    timeout = "15m"
   }
 
   provisioner "file" {
@@ -111,7 +114,7 @@ resource "null_resource" "bootkube-start" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv /home/core/assets /opt/bootkube",
+      "sudo mv $HOME/assets /opt/bootkube",
       "sudo systemctl start bootkube",
     ]
   }

--- a/digital-ocean/container-linux/kubernetes/ssh.tf
+++ b/digital-ocean/container-linux/kubernetes/ssh.tf
@@ -81,7 +81,7 @@ resource "null_resource" "copy-worker-secrets" {
     content     = "${module.bootkube.kubeconfig}"
     destination = "$HOME/kubeconfig"
   }
- 
+
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",

--- a/google-cloud/container-linux/kubernetes/controllers/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers/controllers.tf
@@ -65,10 +65,10 @@ data "template_file" "controller_config" {
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
     etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
 
+    kubeconfig            = "${indent(10, var.kubeconfig)}"
+    ssh_authorized_key    = "${var.ssh_authorized_key}"
     k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
-    ssh_authorized_key    = "${var.ssh_authorized_key}"
-    kubeconfig            = "${indent(10, var.kubeconfig)}"
   }
 }
 

--- a/google-cloud/container-linux/kubernetes/ssh.tf
+++ b/google-cloud/container-linux/kubernetes/ssh.tf
@@ -1,6 +1,5 @@
-# Secure copy etcd TLS assets and kubeconfig to controllers. Activates kubelet.service
-resource "null_resource" "copy-secrets" {
-  depends_on = ["module.bootkube"]
+# Secure copy etcd TLS assets to controllers.
+resource "null_resource" "copy-controller-secrets" {
   count      = "${var.controller_count}"
 
   connection {
@@ -8,11 +7,6 @@ resource "null_resource" "copy-secrets" {
     host    = "${element(module.controllers.ipv4_public, count.index)}"
     user    = "core"
     timeout = "15m"
-  }
-
-  provisioner "file" {
-    content     = "${module.bootkube.kubeconfig}"
-    destination = "$HOME/kubeconfig"
   }
 
   provisioner "file" {
@@ -62,7 +56,6 @@ resource "null_resource" "copy-secrets" {
       "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
       "sudo chown -R etcd:etcd /etc/ssl/etcd",
       "sudo chmod -R 500 /etc/ssl/etcd",
-      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
     ]
   }
 }
@@ -70,7 +63,12 @@ resource "null_resource" "copy-secrets" {
 # Secure copy bootkube assets to ONE controller and start bootkube to perform
 # one-time self-hosted cluster bootstrapping.
 resource "null_resource" "bootkube-start" {
-  depends_on = ["module.controllers", "module.bootkube", "module.workers", "null_resource.copy-secrets"]
+  depends_on = [
+    "module.bootkube",
+    "module.controllers",
+    "module.workers",
+    "null_resource.copy-controller-secrets",
+  ]
 
   connection {
     type    = "ssh"
@@ -86,7 +84,7 @@ resource "null_resource" "bootkube-start" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv /home/core/assets /opt/bootkube",
+      "sudo mv $HOME/assets /opt/bootkube",
       "sudo systemctl start bootkube",
     ]
   }

--- a/google-cloud/container-linux/kubernetes/ssh.tf
+++ b/google-cloud/container-linux/kubernetes/ssh.tf
@@ -1,6 +1,6 @@
 # Secure copy etcd TLS assets to controllers.
 resource "null_resource" "copy-controller-secrets" {
-  count      = "${var.controller_count}"
+  count = "${var.controller_count}"
 
   connection {
     type    = "ssh"

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -35,14 +35,14 @@ variable "worker_count" {
 }
 
 variable controller_type {
-  type = "string"
-  default = "n1-standard-1"
+  type        = "string"
+  default     = "n1-standard-1"
   description = "Machine type for controllers (see `gcloud compute machine-types list`)"
 }
 
 variable worker_type {
-  type = "string"
-  default = "n1-standard-1"
+  type        = "string"
+  default     = "n1-standard-1"
   description = "Machine type for controllers (see `gcloud compute machine-types list`)"
 }
 


### PR DESCRIPTION
* Ensure etcd secrets are only distributed to controller hosts (Digital Ocean)
  * On DO, etcd secrets were erroneously distributed to worker nodes. Note etcd secrets always had permission 500 and were owned by etcd:etcd. But still, workers don't need these secrets.
* Remove redundant kubeconfig copy on AWS and GCP
  * AWS and Google Cloud make use of auto-scaling groups and managed instance groups, respectively. As such, the kubeconfig is already held in cloud user-data
  * Controller instances are provisioned with a kubeconfig from user-data. Its redundant to use a Terraform remote file copy step for the kubeconfig
* Use consistent naming of remote provision steps
* Replace usage of /home/core with $HOME