### PR TITLE
Add disk_type variable for EBS volume type on AWS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,17 +6,22 @@ Notable changes between versions.
 
 * Remove unused, unmaintained `pxe-worker` internal module
 
+#### AWS
+
+* Add `disk_type` optional variable for setting the EBS volume type ([#176](https://github.com/poseidon/typhoon/pull/176))
+  * Change default type from `standard` to `gp2`. Prometheus etcd alerts are tuned for fast disks.
+
 #### Digital Ocean
 
 * Ensure etcd secrets are only distributed to controller hosts, not workers.
-* Remove optional variable `networking`. Only flannel works on Digital Ocean.
+* Remove `networking` optional variable. Only flannel works on Digital Ocean.
 
 #### Google Cloud
 
-* Add `disk_size` variable for setting instance disk size in GB
-* Add `controller_type` variable for setting machine type for controllers
-* Add `worker_type` variable for setting machine type for workers
-* Remove optional variable `machine_type`. Use `controller_type` and `worker_type`.
+* Add `disk_size` optional variable for setting instance disk size in GB
+* Add `controller_type` optional variable for setting machine type for controllers
+* Add `worker_type` optional variable for setting machine type for workers
+* Remove `machine_type` optional variable. Use `controller_type` and `worker_type`.
 
 #### Addons
 

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -28,7 +28,7 @@ resource "aws_instance" "controllers" {
 
   # storage
   root_block_device {
-    volume_type = "standard"
+    volume_type = "${var.disk_type}"
     volume_size = "${var.disk_size}"
   }
 

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -53,6 +53,12 @@ variable "disk_size" {
   description = "Size of the EBS volume in GB"
 }
 
+variable "disk_type" {
+  type        = "string"
+  default     = "gp2"
+  description = "Type of the EBS volume (e.g. standard, gp2, io1)"
+}
+
 variable "controller_clc_snippets" {
   type        = "list"
   description = "Controller Container Linux Config snippets"

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -46,6 +46,12 @@ variable "disk_size" {
   description = "Size of the EBS volume in GB"
 }
 
+variable "disk_type" {
+  type        = "string"
+  default     = "gp2"
+  description = "Type of the EBS volume (e.g. standard, gp2, io1)"
+}
+
 variable "clc_snippets" {
   type        = "list"
   description = "Container Linux Config snippets"

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -42,7 +42,7 @@ resource "aws_launch_configuration" "worker" {
 
   # storage
   root_block_device {
-    volume_type = "standard"
+    volume_type = "${var.disk_type}"
     volume_size = "${var.disk_size}"
   }
 

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -253,6 +253,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | worker_type | EC2 instance type for workers | "t2.small" | See below |
 | os_channel | Container Linux AMI channel | stable | stable, beta, alpha |
 | disk_size | Size of the EBS volume in GB | "40" | "100" |
+| disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |


### PR DESCRIPTION
* Change EBS volume type from `standard` ("prior generation) to `gp2` (SSD). Prometheus alerts are tuned for SSDs
* Other platforms have fast enough disks by default

rel: #175 