### PR TITLE
Update example BGPPeer manifest

### DIFF
--- a/docs/topics/hardware.md
+++ b/docs/topics/hardware.md
@@ -162,14 +162,14 @@ show ip bgp neighbors
 show ip route bgp
 ```
 
-Be sure to register the peer by creating a Calico `bgpPeer` CRD with `kubectl apply`.
+Be sure to register the peer by creating a Calico `BGPPeer` CRD with `kubectl apply`.
 
 ```
-apiVersion: v1
-kind: bgpPeer
+apiVersion: crd.projectcalico.org/v1
+kind: BGPPeer
 metadata:
-  peerIP: LAN_IP
-  scope: global
+  name: NAME
 spec:
+  peerIP: LAN_IP
   asNumber: 64512
 ```


### PR DESCRIPTION
Previous example may have been outdated. It resulted in `error: unable to recognize "example.yaml": no matches for /, Kind=bgpPeer` .

See https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/bgppeer.