### PR TITLE
Enable Kubelet API bearer token authentication

### DIFF
--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -97,7 +97,9 @@ systemd:
           --node-labels=node-role.kubernetes.io/controller="true" \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
+          --authentication-token-webhook \
+          --authorization-mode=Webhook
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -68,7 +68,9 @@ systemd:
           --network-plugin=cni \
           --node-labels=node-role.kubernetes.io/node \
           --pod-manifest-path=/etc/kubernetes/manifests \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
+          --authentication-token-webhook \
+          --authorization-mode=Webhook
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=5


### PR DESCRIPTION
High level description of the change.

Enable Kubelet [API bearer token authentication](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/) on controllers and workers. I need to do this because otherwise Prometheus as installed by [kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus) isn't able to scrape Kubelet targets. I've verified that with my change, Kubelet scraping works.

## Testing

I deployed a new cluster with these changes, deployed kube-prometheus and saw that Kubelet targets were successfully scraped.
