### PR TITLE
Fixed images for addons documentation

### DIFF
--- a/docs/addons/grafana.md
+++ b/docs/addons/grafana.md
@@ -14,7 +14,7 @@ kubectl port-forward grafana-POD-ID 8080 -n monitoring
 
 Visit [127.0.0.1:8080](http://127.0.0.1:8080) to view the bundled dashboards.
 
-![Grafana Capacity Planning](/img/grafana-capacity.png)
-![Grafana Control Plane](/img/grafana-control-plane.png)
-![Grafana Node View](/img/grafana-node.png)
+![Grafana Capacity Planning](../img/grafana-capacity.png)
+![Grafana Control Plane](../img/grafana-control-plane.png)
+![Grafana Node View](../img/grafana-node.png)
 

--- a/docs/addons/prometheus.md
+++ b/docs/addons/prometheus.md
@@ -41,10 +41,10 @@ kubectl port-forward prometheus-POD-ID 9090 -n monitoring
 
 Visit [127.0.0.1:9090](http://127.0.0.1:9090) to query [expressions](http://127.0.0.1:9090/graph), view [targets](http://127.0.0.1:9090/targets), or check [alerts](http://127.0.0.1:9090/alerts).
 
-![Prometheus Graph](/img/prometheus-graph.png)
+![Prometheus Graph](../img/prometheus-graph.png)
 <br/>
-![Prometheus Targets](/img/prometheus-targets.png)
+![Prometheus Targets](../img/prometheus-targets.png)
 <br/>
-![Prometheus Alerts](/img/prometheus-alerts.png)
+![Prometheus Alerts](../img/prometheus-alerts.png)
 
 Use [Grafana](/addons/grafana.md) to view or build dashboards that use Prometheus as the datasource.


### PR DESCRIPTION
Fixed images for addons documentation.

Changed path from / -> ../ which is correct to display the images inline in the markdown.
