### PR TITLE
Fix Prometheus data dir to /var/lib/prometheus

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Notable changes between versions.
   * Add `spot_price` to internal `workers` module for spot [worker pools](https://typhoon.psdn.io/advanced/worker-pools/)
   * Note: Unlike GCP `preemptible` workers, spot instances require you to pick a bid price.
 
+#### Addons
+
+* Fix Prometheus data directory location ([#203](https://github.com/poseidon/typhoon/pull/203))
+
 ## v1.10.2
 
 * [Introduce](https://typhoon.psdn.io/announce/#april-26-2018) Typhoon for Fedora Atomic ([#199](https://github.com/poseidon/typhoon/pull/199))

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -20,7 +20,8 @@ spec:
       - name: prometheus
         image: quay.io/prometheus/prometheus:v2.2.1
         args:
-          - '--config.file=/etc/prometheus/prometheus.yaml'
+          - --config.file=/etc/prometheus/prometheus.yaml
+          - --storage.tsdb.path=/var/lib/prometheus
         ports:
         - name: web
           containerPort: 9090


### PR DESCRIPTION
* A data volume (emptyDir) is mounted to `/var/lib/prometheus`
* Users could swap emptyDir for any desired volume if data persistence is desired. Prometheus previously defaulted to keeping its data in ./data relative to /prometheus. Override this behavior to store data in `/var/lib/prometheus`