### PR TITLE
Render etcd_initial_cluster using a template_file

### DIFF
--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -54,7 +54,7 @@ data "template_file" "controller_config" {
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
 
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
+    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
 
     kubeconfig            = "${indent(10, module.bootkube.kubeconfig)}"
     ssh_authorized_key    = "${var.ssh_authorized_key}"
@@ -63,14 +63,14 @@ data "template_file" "controller_config" {
   }
 }
 
-# Horrible hack to generate a Terraform list of a desired length without dependencies.
-# Ideal ${repeat("etcd", 3) -> ["etcd", "etcd", "etcd"]}
-resource null_resource "repeat" {
-  count = "${var.controller_count}"
+data "template_file" "etcds" {
+  count    = "${var.controller_count}"
+  template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  triggers {
-    name   = "etcd${count.index}"
-    domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+  vars {
+    index = "${count.index}"
+    cluster_name = "${var.cluster_name}"
+    dns_zone = "${var.dns_zone}"
   }
 }
 

--- a/aws/fedora-atomic/kubernetes/controllers.tf
+++ b/aws/fedora-atomic/kubernetes/controllers.tf
@@ -54,7 +54,7 @@ data "template_file" "controller-cloudinit" {
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
 
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
+    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
 
     kubeconfig            = "${indent(6, module.bootkube.kubeconfig)}"
     ssh_authorized_key    = "${var.ssh_authorized_key}"
@@ -63,13 +63,13 @@ data "template_file" "controller-cloudinit" {
   }
 }
 
-# Horrible hack to generate a Terraform list of a desired length without dependencies.
-# Ideal ${repeat("etcd", 3) -> ["etcd", "etcd", "etcd"]}
-resource null_resource "repeat" {
-  count = "${var.controller_count}"
+data "template_file" "etcds" {
+  count    = "${var.controller_count}"
+  template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  triggers {
-    name   = "etcd${count.index}"
-    domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+  vars {
+    index = "${count.index}"
+    cluster_name = "${var.cluster_name}"
+    dns_zone = "${var.dns_zone}"
   }
 }

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -69,20 +69,20 @@ data "template_file" "controller_config" {
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
 
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster  = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
+    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
     k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
   }
 }
 
-# Horrible hack to generate a Terraform list of a desired length without dependencies.
-# Ideal ${repeat("etcd", 3) -> ["etcd", "etcd", "etcd"]}
-resource null_resource "repeat" {
-  count = "${var.controller_count}"
+data "template_file" "etcds" {
+  count    = "${var.controller_count}"
+  template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  triggers {
-    name   = "etcd${count.index}"
-    domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+  vars {
+    index = "${count.index}"
+    cluster_name = "${var.cluster_name}"
+    dns_zone = "${var.dns_zone}"
   }
 }
 

--- a/digital-ocean/fedora-atomic/kubernetes/controllers.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/controllers.tf
@@ -69,7 +69,7 @@ data "template_file" "controller-cloudinit" {
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
 
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
+    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
 
     ssh_authorized_key    = "${var.ssh_authorized_key}"
     k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
@@ -77,13 +77,13 @@ data "template_file" "controller-cloudinit" {
   }
 }
 
-# Horrible hack to generate a Terraform list of a desired length without dependencies.
-# Ideal ${repeat("etcd", 3) -> ["etcd", "etcd", "etcd"]}
-resource null_resource "repeat" {
-  count = "${var.controller_count}"
+data "template_file" "etcds" {
+  count    = "${var.controller_count}"
+  template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  triggers {
-    name   = "etcd${count.index}"
-    domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+  vars {
+    index = "${count.index}"
+    cluster_name = "${var.cluster_name}"
+    dns_zone = "${var.dns_zone}"
   }
 }

--- a/google-cloud/fedora-atomic/kubernetes/controllers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/controllers.tf
@@ -71,7 +71,7 @@ data "template_file" "controller-cloudinit" {
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
 
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
+    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
 
     kubeconfig            = "${indent(6, module.bootkube.kubeconfig)}"
     ssh_authorized_key    = "${var.ssh_authorized_key}"
@@ -80,13 +80,13 @@ data "template_file" "controller-cloudinit" {
   }
 }
 
-# Horrible hack to generate a Terraform list of a desired length without dependencies.
-# Ideal ${repeat("etcd", 3) -> ["etcd", "etcd", "etcd"]}
-resource null_resource "repeat" {
-  count = "${var.controller_count}"
+data "template_file" "etcds" {
+  count    = "${var.controller_count}"
+  template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  triggers {
-    name   = "etcd${count.index}"
-    domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+  vars {
+    index = "${count.index}"
+    cluster_name = "${var.cluster_name}"
+    dns_zone = "${var.dns_zone}"
   }
 }


### PR DESCRIPTION
This renders the value for `etcd_initial_cluster` using a different strategy to help work around a terraform bug. The resulting value is unchanged. I found that the `null_resource` setup that's currently present causes errors with the following (simplified) setup:

```hcl
resource "aws_route53_zone" "cluster" {
  name = "kubernetes.cluster"
}

module "typhoon-aws" {
  source = "git::https://github.com/poseidon/typhoon//aws/container-linux/kubernetes"
  dns_zone = "${aws_route53_zone.cluster.name}"
  dns_zone_id = "${aws_route53_zone.cluster.zone_id}"
}
```

The important distinction here is that the DNS zone name and ID are not available in the plan phase and depend on the creation of another resource. In my project, I'm passing in a zone ID and using the `aws_route53_zone` data source in another module to resolve the name for typhoon.

Using this setup, `terraform plan` fails with the following error:

```
Error: Error running plan: 1 error(s) occurred:

* module.typhoon.data.template_file.controller_config: 2 error(s) occurred:

* module.typhoon.data.template_file.controller_config[1]: Resource 'null_resource.repeat' does not have attribute 'triggers.name' for variable 'null_resource.repeat.*.triggers.name'
* module.typhoon.data.template_file.controller_config[0]: Resource 'null_resource.repeat' does not have attribute 'triggers.domain' for variable 'null_resource.repeat.*.triggers.domain'
```

It appears that triggers are only exported as attributes for a `null_resource` when those values are available synchronously. This seems to be a Terraform bug—I'm adding comments to https://github.com/hashicorp/terraform/issues/17641.

Using a `template_file` data source resolves the error on plan and results in a working project. While it's a little verbose to have to re-specify `vars {}`, I also think it's easier to understand.