### PR TITLE
Update Fedora Atomic from 27 to 28 on DigitalOcean

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@ Notable changes between versions.
   * Allow [alternative](https://docs.projectcalico.org/v3.1/reference/node/configuration#ip-autodetection-methods) methods for multi NIC nodes, like can-reach=IP or interface=REGEX
 * Deprecate `container_linux_oem` variable
 
+#### DigitalOcean
+
+* Update Fedora Atomic module to use Fedora Atomic 28 ([#225](https://github.com/poseidon/typhoon/pull/225))
+  * Fedora Atomic 27 images disappeared from DigitalOcean and forced this early update
+
 #### Addons
 
 * Fix Prometheus data directory location ([#203](https://github.com/poseidon/typhoon/pull/203))

--- a/digital-ocean/fedora-atomic/kubernetes/variables.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/variables.tf
@@ -43,8 +43,8 @@ variable "worker_type" {
 
 variable "image" {
   type        = "string"
-  default     = "fedora-27-x64-atomic"
-  description = "OS image from which to initialize the disk (e.g. fedora-27-x64-atomic)"
+  default     = "fedora-28-x64-atomic"
+  description = "OS image from which to initialize the disk (e.g. fedora-28-x64-atomic)"
 }
 
 # configuration


### PR DESCRIPTION
* Fedora Atomic 27 images disappeared from DigitalOcean and forced this early update (there are known bugs)

Fixes #223 