### PR TITLE
added region variable to require.tf

### DIFF
--- a/aws/container-linux/kubernetes/require.tf
+++ b/aws/container-linux/kubernetes/require.tf
@@ -6,6 +6,7 @@ terraform {
 
 provider "aws" {
   version = "~> 1.13"
+	region  = "${var.region}"
 }
 
 provider "local" {


### PR DESCRIPTION
High level description of the change.

added region as a variable in `require.tf`

## Testing

Describe your work to validate the change works.
 1. Copied variables/Makefile to kubernetes directory 
 2. Ran the build without prompts:
    ```bash
    terraform plan \                                                           
        -var-file="build.tfvars" \                                         
        -out=/tmp/kubes.plan 2>&1 | tee /tmp/kubes.out
    ```
3. Testing is fun again.

rel: #233 
