### PR TITLE
addons/cluo: update to v0.7.0

### DIFF
--- a/addons/cluo/update-agent.yaml
+++ b/addons/cluo/update-agent.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: update-agent
-        image: quay.io/coreos/container-linux-update-operator:v0.6.0
+        image: quay.io/coreos/container-linux-update-operator:v0.7.0
         command:
         - "/bin/update-agent"
         volumeMounts:

--- a/addons/cluo/update-operator.yaml
+++ b/addons/cluo/update-operator.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: update-operator
-        image: quay.io/coreos/container-linux-update-operator:v0.6.0
+        image: quay.io/coreos/container-linux-update-operator:v0.7.0
         command:
         - "/bin/update-operator"
         env:


### PR DESCRIPTION
New version of CLUO was just released - https://github.com/coreos/container-linux-update-operator/releases/tag/v0.7.0

The new version has support for reboot windows, and won't mark nodes as schedulable unless it was the one that marked them as unschedulable in the first place. 