### PR TITLE
Disable AWS detailed monitoring on worker nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Notable changes between versions.
   * Listen for apiserver traffic on port 6443 and forward to controllers (with healthy apiserver)
   * Listen for ingress traffic on ports 80/443 and forward to workers (with healthy ingress controller)
 * Worker pools (advanced) no longer include an extraneous load balancer
+* Disable detailed (paid) monitoring on worker nodes ([#251](https://github.com/poseidon/typhoon/pull/251))
+  * Favor Prometheus for cloud-agnostic metrics, aggregation, alerting, and visualization
 
 #### Bare-Metal
 

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -41,9 +41,10 @@ resource "aws_autoscaling_group" "workers" {
 
 # Worker template
 resource "aws_launch_configuration" "worker" {
-  image_id      = "${local.ami_id}"
-  instance_type = "${var.instance_type}"
-  spot_price    = "${var.spot_price}"
+  image_id          = "${local.ami_id}"
+  instance_type     = "${var.instance_type}"
+  spot_price        = "${var.spot_price}"
+  enable_monitoring = false
 
   user_data = "${data.ct_config.worker_ign.rendered}"
 

--- a/aws/fedora-atomic/kubernetes/workers/workers.tf
+++ b/aws/fedora-atomic/kubernetes/workers/workers.tf
@@ -41,9 +41,10 @@ resource "aws_autoscaling_group" "workers" {
 
 # Worker template
 resource "aws_launch_configuration" "worker" {
-  image_id      = "${data.aws_ami.fedora.image_id}"
-  instance_type = "${var.instance_type}"
-  spot_price    = "${var.spot_price}"
+  image_id          = "${data.aws_ami.fedora.image_id}"
+  instance_type     = "${var.instance_type}"
+  spot_price        = "${var.spot_price}"
+  enable_monitoring = false
 
   user_data = "${data.template_file.worker-cloudinit.rendered}"
 


### PR DESCRIPTION
* Basic monitoring (free) is sufficient for casual console browsing
* Detailed monitoring (paid) is not leveraged for CloudWatch anyway
* Favor Prometheus for cloud-agnostic metrics, aggregation, and alerting

For context here, detailed monitoring was only ever enabled on workers because its defaulted to on in launch configurations. Its never been enabled for controllers. While the additional fees are modest, there's simply not a justification for it.