### PR TITLE
Support Container Linux Config snippets on bare-metal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,15 @@ Notable changes between versions.
 
 ## Latest
 
+#### Bare-Metal
+
+* Introduce [Container Linux Config snippets](https://typhoon.psdn.io/advanced/customization/#container-linux) on bare-metal
+  * Validate and additively merge custom Container Linux Configs during terraform plan
+  * Define files, systemd units, dropins, networkd configs, mounts, users, and more
+  * [Require](https://typhoon.psdn.io/cl/bare-metal/#terraform-setup) `terraform-provider-ct` plugin v0.2.1 (action required!)
+
+## v1.11.1
+
 * Kubernetes [v1.11.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#v1111)
 
 #### Addons

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -118,8 +118,17 @@ resource "matchbox_profile" "flatcar-install" {
 resource "matchbox_profile" "controllers" {
   count                  = "${length(var.controller_names)}"
   name                   = "${format("%s-controller-%s", var.cluster_name, element(var.controller_names, count.index))}"
-  container_linux_config = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  raw_ignition = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
 }
+
+data "ct_config" "controller-ignitions" {
+  count = "${length(var.controller_names)}"
+  content = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  pretty_print = false
+  # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
+  snippets = ["${local.controller_clc_map[element(var.controller_names, count.index)]}"]
+}
+
 
 data "template_file" "controller-configs" {
   count = "${length(var.controller_names)}"
@@ -143,7 +152,16 @@ data "template_file" "controller-configs" {
 resource "matchbox_profile" "workers" {
   count                  = "${length(var.worker_names)}"
   name                   = "${format("%s-worker-%s", var.cluster_name, element(var.worker_names, count.index))}"
-  container_linux_config = "${element(data.template_file.worker-configs.*.rendered, count.index)}"
+  raw_ignition = "${element(data.ct_config.worker-ignitions.*.rendered, count.index)}"
+}
+
+
+data "ct_config" "worker-ignitions" {
+  count = "${length(var.worker_names)}"
+  content = "${element(data.template_file.worker-configs.*.rendered, count.index)}"
+  pretty_print = false
+  # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
+  snippets = ["${local.worker_clc_map[element(var.worker_names, count.index)]}"]
 }
 
 data "template_file" "worker-configs" {
@@ -161,3 +179,26 @@ data "template_file" "worker-configs" {
     networkd_content = "${length(var.worker_networkds) == 0 ? "" : element(concat(var.worker_networkds, list("")), count.index)}"
   }
 }
+
+locals {
+  # Hack to workaround https://github.com/hashicorp/terraform/issues/17251
+  # Default CLC snippets map every worker to list("\n") so all lookups succeed
+  controller_clc_default = "${zipmap(var.controller_names, chunklist(data.template_file.controller-clc-snippets.*.rendered, 1))}"
+  worker_clc_default = "${zipmap(var.worker_names, chunklist(data.template_file.worker-clc-snippets.*.rendered, 1))}"
+  # Union of the default and user specific snippets, later overrides prior.
+  controller_clc_map = "${merge(local.controller_clc_default, var.controller_clc_snippets)}"
+  worker_clc_map = "${merge(local.worker_clc_default, var.worker_clc_snippets)}"
+}
+
+// Horrible hack to generate a Terraform list of controller count length
+data "template_file" "controller-clc-snippets" {
+  count = "${length(var.controller_names)}"
+  template = "\n"
+}
+
+// Horrible hack to generate a Terraform list of worker count length
+data "template_file" "worker-clc-snippets" {
+  count = "${length(var.worker_names)}"
+  template = "\n"
+}
+

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -25,26 +25,44 @@ variable "os_version" {
 
 variable "controller_names" {
   type = "list"
+  description = "Ordered list of controller names (e.g. [node1])"
 }
 
 variable "controller_macs" {
   type = "list"
+  description = "Ordered list of controller identifying MAC addresses (e.g. [52:54:00:a1:9c:ae])"
 }
 
 variable "controller_domains" {
   type = "list"
+  description = "Ordered list of controller FQDNs (e.g. [node1.example.com])"
+}
+
+variable "controller_clc_snippets" {
+  type = "map"
+  description = "Map from controller names to a lists of Container Linux Config snippets"
+  default = {}
 }
 
 variable "worker_names" {
   type = "list"
+  description = "Ordered list of worker names (e.g. [node2, node3])"
 }
 
 variable "worker_macs" {
   type = "list"
+  description = "Ordered list of worker identifying MAC addresses (e.g. [52:54:00:b2:2f:86, 52:54:00:c3:61:77])"
 }
 
 variable "worker_domains" {
   type = "list"
+  description = "Ordered list of worker FQDNs (e.g. [node2.example.com, node3.example.com])"
+}
+
+variable "worker_clc_snippets" {
+  type = "map"
+  description = "Map from worker names to a lists of Container Linux Config snippets"
+  default = {}
 }
 
 # configuration

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -38,12 +38,6 @@ variable "controller_domains" {
   description = "Ordered list of controller FQDNs (e.g. [node1.example.com])"
 }
 
-variable "controller_clc_snippets" {
-  type = "map"
-  description = "Map from controller names to a lists of Container Linux Config snippets"
-  default = {}
-}
-
 variable "worker_names" {
   type = "list"
   description = "Ordered list of worker names (e.g. [node2, node3])"
@@ -59,9 +53,9 @@ variable "worker_domains" {
   description = "Ordered list of worker FQDNs (e.g. [node2.example.com, node3.example.com])"
 }
 
-variable "worker_clc_snippets" {
+variable "clc_snippets" {
   type = "map"
-  description = "Map from worker names to a lists of Container Linux Config snippets"
+  description = "Map from machine names to lists of Container Linux Config snippets"
   default = {}
 }
 

--- a/docs/advanced/customization.md
+++ b/docs/advanced/customization.md
@@ -89,16 +89,17 @@ module "digital-ocean-nemo" {
 }
 ```
 
-Bare-Metal clusters allow different Container Linux snippets to be used for each node (since hardware may be heterogeneous). Define the optional `controller_clc_snippets` and `worker_clc_snippets` map variables using controller or worker keys.
+Bare-Metal clusters allow different Container Linux snippets to be used for each node (since hardware may be heterogeneous). Populate the optional `clc_snippets` map variable with any controller or worker name keys and lists of snippets.
 
 ```
 module "bare-metal-mercury" {
   ...
+  controller_names = ["node1"]
   worker_names = [
     "node2",
     "node3",
   ]
-  worker_clc_snippets = {
+  clc_snippets = {
     "node2" = [
       "${file("./units/hello.yaml")}"
     ]

--- a/docs/advanced/customization.md
+++ b/docs/advanced/customization.md
@@ -69,7 +69,7 @@ View the Container Linux Config [format](https://coreos.com/os/docs/1576.4.0/con
 
 Write Container Linux Configs *snippets* as files in the repository where you keep Terraform configs for clusters (perhaps in a `clc` or `snippets` subdirectory). You may organize snippets in multiple files as desired, provided they are each valid.
 
-Define an [AWS](https://typhoon.psdn.io/aws/#cluster), [Google Cloud](https://typhoon.psdn.io/google-cloud/#cluster), or [Digital Ocean](https://typhoon.psdn.io/digital-ocean/#cluster) cluster and fill in the optional `controller_clc_snippets` or `worker_clc_snippets` fields.
+For [AWS](https://typhoon.psdn.io/aws/#cluster), [Google Cloud](https://typhoon.psdn.io/google-cloud/#cluster), or [Digital Ocean](https://typhoon.psdn.io/digital-ocean/#cluster) clusters, define the optional `controller_clc_snippets` or `worker_clc_snippets` list variables.
 
 ```
 module "digital-ocean-nemo" {
@@ -85,6 +85,28 @@ module "digital-ocean-nemo" {
     "${file("./custom-files")}",
     "${file("./custom-units")}",
   ]
+  ...
+}
+```
+
+Bare-Metal clusters allow different Container Linux snippets to be used for each node (since hardware may be heterogeneous). Define the optional `controller_clc_snippets` and `worker_clc_snippets` map variables using controller or worker keys.
+
+```
+module "bare-metal-mercury" {
+  ...
+  worker_names = [
+    "node2",
+    "node3",
+  ]
+  worker_clc_snippets = {
+    "node2" = [
+      "${file("./units/hello.yaml")}"
+    ]
+    "node3" = [
+      "${file("./units/world.yaml")}",
+      "${file("./units/hello.yaml")}",
+    ]
+  }
   ...
 }
 ```

--- a/docs/cl/bare-metal.md
+++ b/docs/cl/bare-metal.md
@@ -381,8 +381,7 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/bare-me
 | install_disk | Disk device where Container Linux should be installed | "/dev/sda" | "/dev/sdb" |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | network_mtu | CNI interface MTU (calico-only) | 1480 | - | 
-| controller_clc_snippets | Map from controller names to lists of Container Linux Config snippets | {} | |
-| worker_clc_snippets | Map from worker names to lists of Container Linux Config snippets | {} | |
+| clc_snippets | Map from machine names to lists of Container Linux Config snippets | {} | [example](/advanced/customization/#usage) |
 | network_ip_autodetection_method | Method to detect host IPv4 address (calico-only) | first-found | can-reach=10.0.0.1 |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |

--- a/docs/cl/bare-metal.md
+++ b/docs/cl/bare-metal.md
@@ -12,7 +12,7 @@ Controllers are provisioned to run an `etcd-member` peer and a `kubelet` service
 * PXE-enabled [network boot](https://coreos.com/matchbox/docs/latest/network-setup.html) environment
 * Matchbox v0.6+ deployment with API enabled
 * Matchbox credentials `client.crt`, `client.key`, `ca.crt`
-* Terraform v0.11.x and [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) installed locally
+* Terraform v0.11.x, [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox), and [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) installed locally
 
 ## Machines
 
@@ -119,6 +119,14 @@ Add the [terraform-provider-matchbox](https://github.com/coreos/terraform-provid
 wget https://github.com/coreos/terraform-provider-matchbox/releases/download/v0.2.2/terraform-provider-matchbox-v0.2.2-linux-amd64.tar.gz
 tar xzf terraform-provider-matchbox-v0.2.2-linux-amd64.tar.gz
 sudo mv terraform-provider-matchbox-v0.2.2-linux-amd64/terraform-provider-matchbox /usr/local/bin/
+```
+
+Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system.
+
+```sh
+wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.2.1/terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
+sudo mv terraform-provider-ct-v0.2.1-linux-amd64/terraform-provider-ct /usr/local/bin/
 ```
 
 Add the plugin to your `~/.terraformrc`.
@@ -373,6 +381,8 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/bare-me
 | install_disk | Disk device where Container Linux should be installed | "/dev/sda" | "/dev/sdb" |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | network_mtu | CNI interface MTU (calico-only) | 1480 | - | 
+| controller_clc_snippets | Map from controller names to lists of Container Linux Config snippets | {} | |
+| worker_clc_snippets | Map from worker names to lists of Container Linux Config snippets | {} | |
 | network_ip_autodetection_method | Method to detect host IPv4 address (calico-only) | first-found | can-reach=10.0.0.1 |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |


### PR DESCRIPTION
Introduce [Container Linux Config snippets](https://typhoon.psdn.io/advanced/customization/#container-linux) on bare-metal. These were introduced for AWS/Google/DO previously.
  * Validate and additively merge custom Container Linux Configs during terraform plan
  * Define files, systemd units, dropins, networkd configs, mounts, users, and more
  * [Require](https://typhoon.psdn.io/cl/bare-metal/#terraform-setup) `terraform-provider-ct` plugin v0.2.1 (action required!)

Container Linux config snippets provide a mechanism for adding host customizations and enforcing those customizations merge to produce valid Ignition. It also eliminates advanced use cases that previously required forking (just to name a few from my own clusters - custom RAID setups, bonded NICs, custom mount units). The actual snippets are passed as raw string contents, meaning they can be read from files or prepared by the user in some way they see fit (its not a Typhoon concern).

## Usage

Bare-Metal clusters allow different Container Linux snippets to be used for each node (since hardware may be heterogeneous). Define the optional `clc_snippets` map variable using controller or worker keys.

```
# EDITED
module "bare-metal-mercury" {
  ...
  controller_names = ["node1"]
  worker_names = [
    "node2",
    "node3",
  ]
  clc_snippets = {
    "node2" = [
      "${file("./hello.yaml")}"
    ]
    "node3" = [
      "${file("./world.yaml")}",
      "${file("./hello.yaml")}",
    ]
  }
  ...
}
```

```
storage:
  files:
    - path: /opt/hello
      filesystem: root
      contents:
        inline: |
          Hello World
      mode: 0644
```

Edge case: If you wish to define snippets for just a few machines, only add mappings for those machines. There is **no need** to do `"node3" = []` for example, just leave it out. Empty list is not the right default due to some complicated defaulting choices forced by HCL constraints.

### Tradeoffs

* Unfortunately, this means every bare-metal user will need to install the terraform-provider-ct plugin. Even if they don't intend to use the Container Linux config snippet advanced feature. I'm not thrilled doing this, but at the same time, that plugin is required for all the cloud variants of Typhoon. So maybe its not too unreasonable.
* Users who do need to apply the exact same snippet to all machines will need to use a map with a key for each machine to a list containing that snippet. Its repetitive, but I think this is acceptable to abilities to control snippets per-machine.

### Followups

Bare-Metal variables `controller_networkds` and `worker_networkds` that were marked as "unofficial, undocumented, unsupported, temporary" can be deleted.

Closes #140 #245 
