### PR TITLE
Upgrade terraform-provider-ct to v0.3.0 to provide ignition schema v2.2.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Notable changes between versions.
 
+* [Recommend](https://typhoon.psdn.io/cl/bare-metal/#terraform-setup) updating `terraform-provider-ct` plugin from v0.2.1 to [v0.3.0](https://github.com/coreos/terraform-provider-ct/releases/tag/v0.3.0) (action recommended)
+
 ## v1.11.2
 
 * Kubernetes [v1.11.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#v1112)

--- a/docs/cl/aws.md
+++ b/docs/cl/aws.md
@@ -24,9 +24,9 @@ Terraform v0.11.1
 Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system.
 
 ```sh
-wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.2.1/terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-sudo mv terraform-provider-ct-v0.2.1-linux-amd64/terraform-provider-ct /usr/local/bin/
+wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.3.0/terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
+sudo mv terraform-provider-ct-v0.3.0-linux-amd64/terraform-provider-ct /usr/local/bin/
 ```
 
 Add the plugin to your `~/.terraformrc`.

--- a/docs/cl/bare-metal.md
+++ b/docs/cl/bare-metal.md
@@ -124,9 +124,9 @@ sudo mv terraform-provider-matchbox-v0.2.2-linux-amd64/terraform-provider-matchb
 Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system.
 
 ```sh
-wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.2.1/terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-sudo mv terraform-provider-ct-v0.2.1-linux-amd64/terraform-provider-ct /usr/local/bin/
+wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.3.0/terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
+sudo mv terraform-provider-ct-v0.3.0-linux-amd64/terraform-provider-ct /usr/local/bin/
 ```
 
 Add the plugin to your `~/.terraformrc`.

--- a/docs/cl/digital-ocean.md
+++ b/docs/cl/digital-ocean.md
@@ -24,9 +24,9 @@ Terraform v0.11.1
 Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system.
 
 ```sh
-wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.2.1/terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-sudo mv terraform-provider-ct-v0.2.1-linux-amd64/terraform-provider-ct /usr/local/bin/
+wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.3.0/terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
+sudo mv terraform-provider-ct-v0.3.0-linux-amd64/terraform-provider-ct /usr/local/bin/
 ```
 
 Add the plugin to your `~/.terraformrc`.

--- a/docs/cl/google-cloud.md
+++ b/docs/cl/google-cloud.md
@@ -24,9 +24,9 @@ Terraform v0.11.1
 Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system.
 
 ```sh
-wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.2.1/terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-sudo mv terraform-provider-ct-v0.2.1-linux-amd64/terraform-provider-ct /usr/local/bin/
+wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.3.0/terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
+sudo mv terraform-provider-ct-v0.3.0-linux-amd64/terraform-provider-ct /usr/local/bin/
 ```
 
 Add the plugin to your `~/.terraformrc`.


### PR DESCRIPTION
## Warning

It is **not safe** to upgrade the terraform-provider-ct plugin between
minor versions on existing managed clusters. Minor version upgrades of this
plugin **will re-provision your cluster** because the Ignition config output has
changed.

However Typhoon explicitly [encourages using a replacement strategy rather than inplace upgrades](https://typhoon.psdn.io/topics/maintenance/#upgrades), which could make it acceptable to upgrade the terraform-provider-ct plugin with a proper warning in documentation.


## Changes

Upgraded documentation. The user must upgrade the plugin manually by overwriting the old plugin.


## Testing

terraform-provider-ct [v0.3.0](https://github.com/coreos/terraform-provider-ct/releases/tag/v0.3.0) is upgraded to using container-linux-config-transpiler [v0.8.0](https://github.com/coreos/container-linux-config-transpiler/releases/tag/v0.8.0). Ran the config transpiler on the raw cl templates, and got the following warnings. The errors in bare-metal is due to the transpiler not understanding the terraform template language (the plugin passes the result from a rendered template to the transpiler.) 

```
./aws/container-linux/kubernetes/cl/controller.yaml.tmpl
warning at line 126, column 7
mode unspecified for file, defaulting to 0644

./aws/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
warning at line 96, column 7
mode unspecified for file, defaulting to 0644

./bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
error: yaml: unmarshal errors:
  line 167: cannot unmarshal !!str `${netwo...` into types.Networkd
Failed to parse config

./bare-metal/container-linux/kubernetes/cl/install.yaml.tmpl
./bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
error: yaml: unmarshal errors:
  line 100: cannot unmarshal !!str `${netwo...` into types.Networkd
Failed to parse config

./digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
warning at line 132, column 7
mode unspecified for file, defaulting to 0644

./digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
warning at line 102, column 7
mode unspecified for file, defaulting to 0644

./google-cloud/container-linux/kubernetes/cl/controller.yaml.tmpl
warning at line 127, column 7
mode unspecified for file, defaulting to 0644

./google-cloud/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
warning at line 97, column 7
mode unspecified for file, defaulting to 0644
```

Removing the terraform variable also renders the rest of the bare-metal cl templates without errors.
```
./bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
warning at line 133, column 7
mode unspecified for file, defaulting to 0644

./bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
warning at line 94, column 7
mode unspecified for file, defaulting to 0644
```
