### PR TITLE
Remove unofficial bare-metal *_networkds variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 Notable changes between versions.
 
+## Latest
+
+#### Bare-Metal
+
+* Remove `controller_networkds` and `worker_networkds` variables. Use Container Linux Config snippets [#277](https://github.com/poseidon/typhoon/pull/277)
+
 ## v1.11.2
 
 * Kubernetes [v1.11.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#v1112)

--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -163,8 +163,6 @@ storage:
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"
-networkd:
-  ${networkd_content}
 passwd:
   users:
     - name: core

--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -96,8 +96,6 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
-networkd:
-  ${networkd_content}
 passwd:
   users:
     - name: core

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -142,9 +142,6 @@ data "template_file" "controller-configs" {
     k8s_dns_service_ip    = "${module.bootkube.kube_dns_service_ip}"
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
     ssh_authorized_key    = "${var.ssh_authorized_key}"
-
-    # Terraform evaluates both sides regardless and element cannot be used on 0 length lists
-    networkd_content = "${length(var.controller_networkds) == 0 ? "" : element(concat(var.controller_networkds, list("")), count.index)}"
   }
 }
 
@@ -174,9 +171,6 @@ data "template_file" "worker-configs" {
     k8s_dns_service_ip    = "${module.bootkube.kube_dns_service_ip}"
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
     ssh_authorized_key    = "${var.ssh_authorized_key}"
-
-    # Terraform evaluates both sides regardless and element cannot be used on 0 length lists
-    networkd_content = "${length(var.worker_networkds) == 0 ? "" : element(concat(var.worker_networkds, list("")), count.index)}"
   }
 }
 

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -141,17 +141,3 @@ variable "kernel_args" {
   type        = "list"
   default     = []
 }
-
-# unofficial, undocumented, unsupported, temporary
-
-variable "controller_networkds" {
-  type        = "list"
-  description = "Controller Container Linux config networkd section"
-  default     = []
-}
-
-variable "worker_networkds" {
-  type        = "list"
-  description = "Worker Container Linux config networkd section"
-  default     = []
-}


### PR DESCRIPTION
* Remove controller_networkds and worker_networkds variables. These variables were always listed as experimental, unsupported, and excluded from documentation in anticipation of Container Linux Config snippets
* Use Container Linux Config snippets on bare-metal instead. They provide safer, more powerful, and more elegant host customization