### PR TITLE
Remove GCP firewall rule allowing Nginx Ingress health

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ Notable changes between versions.
 
 * Remove `controller_networkds` and `worker_networkds` variables. Use Container Linux Config snippets [#277](https://github.com/poseidon/typhoon/pull/277)
 
+#### Google Cloud
+
+* Remove firewall rule allowing workers to access Nginx Ingress health check
+  * Nginx Ingress addon no longer uses hostNetwork, Prometheus scrapes via CNI network
+
 ## v1.11.2
 
 * Kubernetes [v1.11.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#v1112)

--- a/google-cloud/container-linux/kubernetes/network.tf
+++ b/google-cloud/container-linux/kubernetes/network.tf
@@ -124,20 +124,6 @@ resource "google_compute_firewall" "internal-kubelet" {
   target_tags = ["${var.cluster_name}-controller", "${var.cluster_name}-worker"]
 }
 
-# Allow Prometheus to scrape ingress-controller
-resource "google_compute_firewall" "ingress-health" {
-  name    = "${var.cluster_name}-ingress-health"
-  network = "${google_compute_network.network.name}"
-
-  allow {
-    protocol = "tcp"
-    ports    = [10254]
-  }
-
-  source_tags = ["${var.cluster_name}-worker"]
-  target_tags = ["${var.cluster_name}-worker"]
-}
-
 # Allow heapster / metrics-server to scrape kubelet read-only
 resource "google_compute_firewall" "internal-kubelet-readonly" {
   name    = "${var.cluster_name}-internal-kubelet-readonly"

--- a/google-cloud/fedora-atomic/kubernetes/network.tf
+++ b/google-cloud/fedora-atomic/kubernetes/network.tf
@@ -124,20 +124,6 @@ resource "google_compute_firewall" "internal-kubelet" {
   target_tags = ["${var.cluster_name}-controller", "${var.cluster_name}-worker"]
 }
 
-# Allow Prometheus to scrape ingress-controller
-resource "google_compute_firewall" "ingress-health" {
-  name    = "${var.cluster_name}-ingress-health"
-  network = "${google_compute_network.network.name}"
-
-  allow {
-    protocol = "tcp"
-    ports    = [10254]
-  }
-
-  source_tags = ["${var.cluster_name}-worker"]
-  target_tags = ["${var.cluster_name}-worker"]
-}
-
 # Allow heapster / metrics-server to scrape kubelet read-only
 resource "google_compute_firewall" "internal-kubelet-readonly" {
   name    = "${var.cluster_name}-internal-kubelet-readonly"


### PR DESCRIPTION
* Nginx Ingress addon no longer uses hostNework so Prometheus may scrape port 10254 via the CNI network, rather than via the host address

rel: https://github.com/poseidon/typhoon/commit/2eaf04c68b3d469aeded276a0dc37d377451d61b
