### PR TITLE
Template etcd_servers list to replace null_resource.repeat

### DIFF
--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -4,7 +4,7 @@ module "bootkube" {
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers          = ["${null_resource.repeat.*.triggers.domain}"]
+  etcd_servers          = ["${google_dns_record_set.etcds.*.name}"]
   asset_dir             = "${var.asset_dir}"
   networking            = "${var.networking}"
   network_mtu           = 1440

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -28,7 +28,7 @@ resource "google_compute_instance_template" "worker" {
   machine_type = "${var.machine_type}"
 
   metadata {
-    user-data = "${data.ct_config.worker_ign.rendered}"
+    user-data = "${data.ct_config.worker-ignition.rendered}"
   }
 
   scheduling {
@@ -64,8 +64,15 @@ resource "google_compute_instance_template" "worker" {
   }
 }
 
-# Worker Container Linux Config
-data "template_file" "worker_config" {
+# Worker Ignition config
+data "ct_config" "worker-ignition" {
+  content      = "${data.template_file.worker-config.rendered}"
+  pretty_print = false
+  snippets     = ["${var.clc_snippets}"]
+}
+
+# Worker Container Linux config
+data "template_file" "worker-config" {
   template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
 
   vars = {
@@ -74,10 +81,4 @@ data "template_file" "worker_config" {
     k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
   }
-}
-
-data "ct_config" "worker_ign" {
-  content      = "${data.template_file.worker_config.rendered}"
-  pretty_print = false
-  snippets     = ["${var.clc_snippets}"]
 }

--- a/google-cloud/fedora-atomic/kubernetes/bootkube.tf
+++ b/google-cloud/fedora-atomic/kubernetes/bootkube.tf
@@ -4,7 +4,7 @@ module "bootkube" {
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers          = ["${null_resource.repeat.*.triggers.domain}"]
+  etcd_servers          = ["${google_dns_record_set.etcds.*.name}"]
   asset_dir             = "${var.asset_dir}"
   networking            = "${var.networking}"
   network_mtu           = 1440

--- a/google-cloud/fedora-atomic/kubernetes/controllers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/controllers.tf
@@ -71,7 +71,7 @@ data "template_file" "controller-cloudinit" {
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
 
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", null_resource.repeat.*.triggers.name, null_resource.repeat.*.triggers.domain))}"
+    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
 
     kubeconfig            = "${indent(6, module.bootkube.kubeconfig)}"
     ssh_authorized_key    = "${var.ssh_authorized_key}"
@@ -80,13 +80,13 @@ data "template_file" "controller-cloudinit" {
   }
 }
 
-# Horrible hack to generate a Terraform list of a desired length without dependencies.
-# Ideal ${repeat("etcd", 3) -> ["etcd", "etcd", "etcd"]}
-resource null_resource "repeat" {
-  count = "${var.controller_count}"
+data "template_file" "etcds" {
+  count    = "${var.controller_count}"
+  template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  triggers {
-    name   = "etcd${count.index}"
-    domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+  vars {
+    index        = "${count.index}"
+    cluster_name = "${var.cluster_name}"
+    dns_zone     = "${var.dns_zone}"
   }
 }


### PR DESCRIPTION
* Remove the last usage of `null_resource.repeat`, which has always been an eyesore for creating the etcd server list
* Originally, #224 switched to templating the etcd_servers list for all clouds, but had to revert on GCP in #237