### PR TITLE
Fix firewall to allow etcd client traffic between controllers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ Notable changes between versions.
 
 #### Google Cloud
 
+* Fix firewall to allow etcd client port 2379 traffic between controller nodes ([#287](https://github.com/poseidon/typhoon/pull/287))
+  * kube-apiservers were only able to connect to their node's local etcd peer. While master node outages were tolerated, reaching a healthy peer took longer than neccessary in some cases
+  * Reduce time needed to bootstrap the cluster
 * Remove firewall rule allowing workers to access Nginx Ingress health check ([#284](https://github.com/poseidon/typhoon/pull/284))
   * Nginx Ingress addon no longer uses hostNetwork, Prometheus scrapes via CNI network
 

--- a/docs/topics/performance.md
+++ b/docs/topics/performance.md
@@ -9,7 +9,7 @@ Provisioning times vary based on the operating system and platform. Sampling the
 | AWS           | 6 min | 5 min   |
 | Bare-Metal    | 10-15 min | NA  |
 | Digital Ocean | 3 min 30 sec | 20 sec |
-| Google Cloud  | 10 min | 4 min 30 sec |
+| Google Cloud  | 6 min | 4 min 30 sec |
 
 Notes:
 

--- a/google-cloud/container-linux/kubernetes/network.tf
+++ b/google-cloud/container-linux/kubernetes/network.tf
@@ -23,7 +23,7 @@ resource "google_compute_firewall" "internal-etcd" {
 
   allow {
     protocol = "tcp"
-    ports    = [2380]
+    ports    = [2379, 2380]
   }
 
   source_tags = ["${var.cluster_name}-controller"]

--- a/google-cloud/fedora-atomic/kubernetes/network.tf
+++ b/google-cloud/fedora-atomic/kubernetes/network.tf
@@ -23,7 +23,7 @@ resource "google_compute_firewall" "internal-etcd" {
 
   allow {
     protocol = "tcp"
-    ports    = [2380]
+    ports    = [2379, 2380]
   }
 
   source_tags = ["${var.cluster_name}-controller"]


### PR DESCRIPTION
* Broaden internal-etcd firewall rule to allow etcd client traffic (2379) from other controller nodes
* Previously, kube-apiservers were only able to connect to their node's local etcd peer. While master node outages were tolerated, reaching a healthy peer took longer than necessary in some cases
* Reduce time needed to bootstrap a cluster