### PR TITLE
Adding 'private_key' to Digital Ocean connections.

### DIFF
--- a/digital-ocean/container-linux/kubernetes/ssh.tf
+++ b/digital-ocean/container-linux/kubernetes/ssh.tf
@@ -5,6 +5,7 @@ resource "null_resource" "copy-controller-secrets" {
   connection {
     type    = "ssh"
     host    = "${element(concat(digitalocean_droplet.controllers.*.ipv4_address), count.index)}"
+    private_key = "${var.ssh_fingerprints}"
     user    = "core"
     timeout = "15m"
   }
@@ -73,6 +74,7 @@ resource "null_resource" "copy-worker-secrets" {
   connection {
     type    = "ssh"
     host    = "${element(concat(digitalocean_droplet.workers.*.ipv4_address), count.index)}"
+    private_key = "${var.ssh_fingerprints}"
     user    = "core"
     timeout = "15m"
   }

--- a/digital-ocean/fedora-atomic/kubernetes/ssh.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/ssh.tf
@@ -5,6 +5,7 @@ resource "null_resource" "copy-controller-secrets" {
   connection {
     type    = "ssh"
     host    = "${element(concat(digitalocean_droplet.controllers.*.ipv4_address), count.index)}"
+    private_key = "${var.ssh_fingerprints}"
     user    = "fedora"
     timeout = "15m"
   }
@@ -71,6 +72,7 @@ resource "null_resource" "copy-worker-secrets" {
   connection {
     type    = "ssh"
     host    = "${element(concat(digitalocean_droplet.workers.*.ipv4_address), count.index)}"
+    private_key = "${var.ssh_fingerprints}"
     user    = "fedora"
     timeout = "15m"
   }


### PR DESCRIPTION
## High-level description of the change.

Fixed issue whereby Terraform was unable to SSH successfully into Digital Ocean droplets.

## Testing

Span up a CoreOS and Atomic cluster on Digital Ocean to validate.