### PR TITLE
docs/cl/bare-metal: Install providers to Terraform 3rd party plugin directory

### DIFF
--- a/docs/cl/bare-metal.md
+++ b/docs/cl/bare-metal.md
@@ -113,28 +113,20 @@ $ terraform version
 Terraform v0.11.7
 ```
 
-Add the [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) plugin binary for your system.
+Add the [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) plugin binary for your system to your `~/.terraform.d/plugins` directory.
 
 ```sh
 wget https://github.com/coreos/terraform-provider-matchbox/releases/download/v0.2.2/terraform-provider-matchbox-v0.2.2-linux-amd64.tar.gz
 tar xzf terraform-provider-matchbox-v0.2.2-linux-amd64.tar.gz
-sudo mv terraform-provider-matchbox-v0.2.2-linux-amd64/terraform-provider-matchbox /usr/local/bin/
+sudo mv terraform-provider-matchbox-v0.2.2-linux-amd64/terraform-provider-matchbox ~/.terraform.d/plugins/terraform-provider-matchbox_v0.2.2
 ```
 
-Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system.
+Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system to your `~/.terraform.d/plugins` directory.
 
 ```sh
 wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.2.1/terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
 tar xzf terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-sudo mv terraform-provider-ct-v0.2.1-linux-amd64/terraform-provider-ct /usr/local/bin/
-```
-
-Add the plugin to your `~/.terraformrc`.
-
-```
-providers {
-  matchbox = "/usr/local/bin/terraform-provider-matchbox"
-}
+sudo mv terraform-provider-ct-v0.2.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.2.1
 ```
 
 Read [concepts](/architecture/concepts.md) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -149,10 +141,17 @@ Configure the Matchbox provider to use your Matchbox API endpoint and client cer
 
 ```tf
 provider "matchbox" {
+  version = "~> 0.2"
+  alias = "default"
   endpoint    = "matchbox.example.com:8081"
   client_cert = "${file("~/.config/matchbox/client.crt")}"
   client_key  = "${file("~/.config/matchbox/client.key")}"
   ca          = "${file("~/.config/matchbox/ca.crt")}"
+}
+
+provider "ct" {
+  version = "~> 0.2"
+  alias = "default"
 }
 
 provider "local" {


### PR DESCRIPTION
Listing providers in `~/.terraformrc` has been deprecated: https://www.terraform.io/docs/commands/cli-config.html#deprecated-settings

They should be installed into the 3rd party plugins directory instead: https://www.terraform.io/docs/configuration/providers.html#third-party-plugins

Terraform strongly suggests to also name the desired plugin version in the provider configuration.

## Testing

```
$ ls ~/.terraform.d/plugins/
terraform-provider-ct_v0.2.1*  terraform-provider-ct_v0.3.0*  terraform-provider-matchbox_v0.2.2*
$ git clone https://github.com/poseidon/typhoon.git
$ cd typhoon/bare-metal/container-linux/kubernetes/
$ terraform init
Initializing modules...
- module.bootkube
  Getting source "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=5378e166ef7ec44e69fbc2d879dbf048a45a0d09"

Initializing provider plugins...
- Checking for available provider plugins on https://releases.hashicorp.com...
- Downloading plugin for provider "local" (1.1.0)...
- Downloading plugin for provider "null" (1.0.0)...
- Downloading plugin for provider "tls" (1.2.0)...
- Downloading plugin for provider "template" (1.0.0)...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

$ terraform providers
.
├── provider.ct ~> 0.2
├── provider.local ~> 1.0
├── provider.local.default ~> 1.0
├── provider.matchbox ~> 0.2
├── provider.null ~> 1.0
├── provider.null.default ~> 1.0
├── provider.template ~> 1.0
├── provider.template.default ~> 1.0
├── provider.tls ~> 1.0
├── provider.tls.default ~> 1.0
└── module.bootkube
    ├── provider.local (inherited)
    ├── provider.template (inherited)
    └── provider.tls (inherited)
```