### PR TITLE
Require terraform-provider-digitalocean plugin ~> 1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Notable changes between versions.
 * Update CoreDNS from 1.1.3 to 1.2.2
 * Update Calico from v3.2.1 to v3.2.3
 
+#### DigitalOcean
+
+* Require terraform-provider-digitalocean plugin 1.0 (or higher but < 2.0)
+
 #### Addons
 
 * Update Prometheus from v2.3.2 to v2.4.2

--- a/digital-ocean/container-linux/kubernetes/require.tf
+++ b/digital-ocean/container-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "digitalocean" {
-  version = "~> 0.1.2"
+  version = "~> 1.0"
 }
 
 provider "local" {

--- a/digital-ocean/fedora-atomic/kubernetes/require.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "digitalocean" {
-  version = "~> 0.1.2"
+  version = "~> 1.0"
 }
 
 provider "local" {

--- a/docs/atomic/digital-ocean.md
+++ b/docs/atomic/digital-ocean.md
@@ -45,7 +45,7 @@ Configure the DigitalOcean provider to use your token in a `providers.tf` file.
 
 ```tf
 provider "digitalocean" {
-  version = "0.1.3"
+  version = "1.0.0"
   token = "${chomp(file("~/.config/digital-ocean/token"))}"
   alias = "default"
 }

--- a/docs/cl/digital-ocean.md
+++ b/docs/cl/digital-ocean.md
@@ -58,7 +58,7 @@ Configure the DigitalOcean provider to use your token in a `providers.tf` file.
 
 ```tf
 provider "digitalocean" {
-  version = "0.1.3"
+  version = "1.0.0"
   token = "${chomp(file("~/.config/digital-ocean/token"))}"
   alias = "default"
 }


### PR DESCRIPTION
* Require a terraform-provider-digitalocean plugin version of 1.0 or higher within the same major version (e.g. allow 1.1 but not 2.0)
* Without this change, using the new digitalocean [1.0](https://github.com/terraform-providers/terraform-provider-digitalocean/blob/master/CHANGELOG.md#100-september-27-2018) provider wouldn't be allowed since its the next major version

Note: I'm intentionally not using `>= 0.1.2` since that would allow using a 2.0. When the next digitalocean major version is released, we'll re-validate and alter the constraint.

## Testing

I've tested with the digitalocean 1.0 plugin and it creates the resources for a Typhoon Kubernetes cluster as before.