### PR TITLE
 Raise CoreDNS replica count to at least 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Notable changes between versions.
 * Update Calico from v3.2.1 to v3.2.3
 * On multi-controller clusters, raise scheduler and controller-manager replics to equal the number of controller nodes ([#312](https://github.com/poseidon/typhoon/pull/312))
   * Single-controller clusters continue to run 2 replicas as before
+* Raise default CoreDNS replica count to the larger of 2 or the number of controller nodes ([#313](https://github.com/poseidon/typhoon/pull/313))
+  * Add AntiAffinity preferred rule to favor spreading CoreDNS pods
 
 #### DigitalOcean
 

--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=7797377d50b2f770b59adf6aae43045c43453a8a"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f7c2f8d590dcca0cb9bd4de15d765cad29109455"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/fedora-atomic/kubernetes/bootkube.tf
+++ b/aws/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=7797377d50b2f770b59adf6aae43045c43453a8a"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f7c2f8d590dcca0cb9bd4de15d765cad29109455"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/container-linux/kubernetes/bootkube.tf
+++ b/azure/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=7797377d50b2f770b59adf6aae43045c43453a8a"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f7c2f8d590dcca0cb9bd4de15d765cad29109455"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=7797377d50b2f770b59adf6aae43045c43453a8a"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f7c2f8d590dcca0cb9bd4de15d765cad29109455"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/bare-metal/fedora-atomic/kubernetes/bootkube.tf
+++ b/bare-metal/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=7797377d50b2f770b59adf6aae43045c43453a8a"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f7c2f8d590dcca0cb9bd4de15d765cad29109455"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${var.k8s_domain_name}"]

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=7797377d50b2f770b59adf6aae43045c43453a8a"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f7c2f8d590dcca0cb9bd4de15d765cad29109455"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=7797377d50b2f770b59adf6aae43045c43453a8a"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f7c2f8d590dcca0cb9bd4de15d765cad29109455"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=7797377d50b2f770b59adf6aae43045c43453a8a"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f7c2f8d590dcca0cb9bd4de15d765cad29109455"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/fedora-atomic/kubernetes/bootkube.tf
+++ b/google-cloud/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=7797377d50b2f770b59adf6aae43045c43453a8a"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f7c2f8d590dcca0cb9bd4de15d765cad29109455"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]


### PR DESCRIPTION
* Run at least two replicas of CoreDNS to better support rolling updates (previously, kube-dns had a pod nanny)
* On multi-master clusters, set the CoreDNS replica count to match the number of masters (e.g. a 3-master cluster previously used replicas:1, now replicas:3)
* Add AntiAffinity preferred rule to favor distributing CoreDNS pods across controller nodes nodes