### PR TITLE
Switch kube-proxy from iptables mode to ipvs mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Notable changes between versions.
 
 ## Latest
 
+* Switch kube-proxy from iptables mode to ipvs mode
 * Fix CoreDNS AntiAffinity spec to prefer spreading replicas
 * Disable Kubelet read-only port ([#324](https://github.com/poseidon/typhoon/pull/324))
 

--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=79065baa8cb93e2102e91d143dcee557e2634701"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dd3a7be063a350c1c5b7779ca986f8f868dad091"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/fedora-atomic/kubernetes/bootkube.tf
+++ b/aws/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=79065baa8cb93e2102e91d143dcee557e2634701"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dd3a7be063a350c1c5b7779ca986f8f868dad091"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/container-linux/kubernetes/bootkube.tf
+++ b/azure/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=79065baa8cb93e2102e91d143dcee557e2634701"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dd3a7be063a350c1c5b7779ca986f8f868dad091"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=79065baa8cb93e2102e91d143dcee557e2634701"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dd3a7be063a350c1c5b7779ca986f8f868dad091"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/bare-metal/fedora-atomic/kubernetes/bootkube.tf
+++ b/bare-metal/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=79065baa8cb93e2102e91d143dcee557e2634701"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dd3a7be063a350c1c5b7779ca986f8f868dad091"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${var.k8s_domain_name}"]

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=79065baa8cb93e2102e91d143dcee557e2634701"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dd3a7be063a350c1c5b7779ca986f8f868dad091"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=79065baa8cb93e2102e91d143dcee557e2634701"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dd3a7be063a350c1c5b7779ca986f8f868dad091"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=79065baa8cb93e2102e91d143dcee557e2634701"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dd3a7be063a350c1c5b7779ca986f8f868dad091"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/fedora-atomic/kubernetes/bootkube.tf
+++ b/google-cloud/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=79065baa8cb93e2102e91d143dcee557e2634701"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dd3a7be063a350c1c5b7779ca986f8f868dad091"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]


### PR DESCRIPTION
Kubernetes v1.11 marked `kube-proxy` IPVS mode as GA. Evalute its readiness

* https://github.com/poseidon/terraform-render-bootkube/pull/84
* [Kubernetes blog](https://kubernetes.io/blog/2018/07/09/ipvs-based-in-cluster-load-balancing-deep-dive/)
* Calico v3.2 [IPVS support](https://docs.projectcalico.org/v3.2/usage/enabling-ipvs)