### PR TITLE
Consistify naming for AWS and Digital Ocean Ignition data sources

### DIFF
--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -24,7 +24,7 @@ resource "aws_instance" "controllers" {
   instance_type = "${var.controller_type}"
 
   ami       = "${local.ami_id}"
-  user_data = "${element(data.ct_config.controller_ign.*.rendered, count.index)}"
+  user_data = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
 
   # storage
   root_block_device {
@@ -75,7 +75,7 @@ data "template_file" "etcds" {
   }
 }
 
-data "ct_config" "controller_ign" {
+data "ct_config" "controller-ignitions" {
   count        = "${var.controller_count}"
   content      = "${element(data.template_file.controller_config.*.rendered, count.index)}"
   pretty_print = false

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -46,7 +46,7 @@ resource "aws_launch_configuration" "worker" {
   spot_price        = "${var.spot_price}"
   enable_monitoring = false
 
-  user_data = "${data.ct_config.worker_ign.rendered}"
+  user_data = "${data.ct_config.worker-ignition.rendered}"
 
   # storage
   root_block_device {
@@ -77,7 +77,7 @@ data "template_file" "worker_config" {
   }
 }
 
-data "ct_config" "worker_ign" {
+data "ct_config" "worker-ignition" {
   content      = "${data.template_file.worker_config.rendered}"
   pretty_print = false
   snippets     = ["${var.clc_snippets}"]

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -44,7 +44,7 @@ resource "digitalocean_droplet" "controllers" {
   ipv6               = true
   private_networking = true
 
-  user_data = "${element(data.ct_config.controller_ign.*.rendered, count.index)}"
+  user_data = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
   ssh_keys  = ["${var.ssh_fingerprints}"]
 
   tags = [
@@ -86,7 +86,7 @@ data "template_file" "etcds" {
   }
 }
 
-data "ct_config" "controller_ign" {
+data "ct_config" "controller-ignitions" {
   count        = "${var.controller_count}"
   content      = "${element(data.template_file.controller_config.*.rendered, count.index)}"
   pretty_print = false

--- a/digital-ocean/container-linux/kubernetes/workers.tf
+++ b/digital-ocean/container-linux/kubernetes/workers.tf
@@ -25,7 +25,7 @@ resource "digitalocean_droplet" "workers" {
   ipv6               = true
   private_networking = true
 
-  user_data = "${data.ct_config.worker_ign.rendered}"
+  user_data = "${data.ct_config.worker-ignition.rendered}"
   ssh_keys  = ["${var.ssh_fingerprints}"]
 
   tags = [
@@ -48,7 +48,7 @@ data "template_file" "worker_config" {
   }
 }
 
-data "ct_config" "worker_ign" {
+data "ct_config" "worker-ignition" {
   content      = "${data.template_file.worker_config.rendered}"
   pretty_print = false
   snippets     = ["${var.worker_clc_snippets}"]


### PR DESCRIPTION
Small nitpicks to follow the same data source naming convention for all platforms.

Do unfortunately not have an AWS nor Digitial Ocean setup available for testing, so please verify accordingly before accepting.
