### PR TITLE
Add an IPv6 address and forwarding rules on Google Cloud

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,12 @@ Notable changes between versions.
 * Add AAAA DNS records resolving to worker nodes ([#333](https://github.com/poseidon/typhoon/pull/333))
   * Hosting IPv6 apps requires editing nginx-ingress with `hostNetwork: true`
 
+#### Google Cloud
+
+* Add an IPv6 address and IPv6 forwarding rules for load balancing IPv6 Ingress 
+  * Add `ingress_static_ipv6` output variable for use in AAAA DNS records
+  * Allow serving IPv6 applications via Kubernetes Ingress
+
 #### Addons
 
 * Configure Heapster to scrape Kubelets with bearer token auth ([#323](https://github.com/poseidon/typhoon/pull/323))

--- a/docs/addons/ingress.md
+++ b/docs/addons/ingress.md
@@ -131,7 +131,7 @@ resource "google_dns_record_set" "some-application" {
 
 ## Google Cloud
 
-On Google Cloud, a TCP Proxy load balancer distributes traffic across a backend service of worker nodes running an Ingress controller deployment. Firewall rules allow traffic to ports 80 and 443. Health check rules ensure only workers with a healthy Ingress controller receive traffic.
+On Google Cloud, a TCP Proxy load balancer distributes IPv4 and IPv6 TCP traffic across a backend service of worker nodes running an Ingress controller deployment. Firewall rules allow traffic to ports 80 and 443. Health check rules ensure only workers with a healthy Ingress controller receive traffic.
 
 Create the Ingress controller deployment, service, RBAC roles, RBAC bindings, default backend, and namespace.
 
@@ -139,7 +139,7 @@ Create the Ingress controller deployment, service, RBAC roles, RBAC bindings, de
 kubectl apply -R -f addons/nginx-ingress/google-cloud
 ```
 
-For each application, add a DNS record resolving to the load balancer's IPv4 address.
+For each application, add DNS A records resolving to the load balancer's IPv4 address and DNS AAAA records resolving to the load balancer's IPv6 address.
 
 ```
 app1.example.com -> 11.22.33.44
@@ -147,10 +147,10 @@ app2.example.com -> 11.22.33.44
 app3.example.com -> 11.22.33.44
 ```
 
-Find the IPv4 address with `gcloud compute addresses list` or use the Typhoon module's output `ingress_static_ipv4`. For example, you might use Terraform to manage a Google Cloud DNS record:
+Find the IPv4 address with `gcloud compute addresses list` or use the Typhoon module's outputs `ingress_static_ipv4` and `ingress_static_ipv6`. For example, you might use Terraform to manage a Google Cloud DNS record:
 
 ```tf
-resource "google_dns_record_set" "some-application" {
+resource "google_dns_record_set" "app-record-a" {
   # DNS zone name
   managed_zone = "example-zone"
 
@@ -159,5 +159,16 @@ resource "google_dns_record_set" "some-application" {
   type    = "A"
   ttl     = 300
   rrdatas = ["${module.google-cloud-yavin.ingress_static_ipv4}"]
+}
+
+resource "google_dns_record_set" "app-record-aaaa" {
+  # DNS zone name
+  managed_zone = "example-zone"
+
+  # DNS record
+  name    = "app.example.com."
+  type    = "AAAA"
+  ttl     = 300
+  rrdatas = ["${module.google-cloud-yavin.ingress_static_ipv6}"]
 }
 ```

--- a/docs/architecture/aws.md
+++ b/docs/architecture/aws.md
@@ -1,0 +1,13 @@
+# AWS
+
+## IPv6
+
+Status of IPv6 on Typhoon AWS clusters.
+
+| IPv6 Feature            | Supported |
+|-------------------------|-----------|
+| Node IPv6 address       | Yes       |
+| Node Outbound IPv6      | Yes       |
+| Kubernetes Ingress IPv6 | No        |
+
+* AWS Network Load Balancers do not support `dualstack`.

--- a/docs/architecture/azure.md
+++ b/docs/architecture/azure.md
@@ -1,0 +1,13 @@
+# Azure
+
+## IPv6
+
+Status of IPv6 on Typhoon Azure clusters.
+
+| IPv6 Feature            | Supported |
+|-------------------------|-----------|
+| Node IPv6 address       | No        |
+| Node Outbound IPv6      | No        |
+| Kubernetes Ingress IPv6 | No        |
+
+* Azure does not allow reserving a static IPv6 address 

--- a/docs/architecture/bare-metal.md
+++ b/docs/architecture/bare-metal.md
@@ -1,0 +1,13 @@
+# Bare-Metal
+
+## IPv6
+
+Status of IPv6 on Typhoon bare-metal clusters.
+
+| IPv6 Feature            | Supported |
+|-------------------------|-----------|
+| Node IPv6 address       | Yes       |
+| Node Outbound IPv6      | Yes       |
+| Kubernetes Ingress IPv6 | Possible  |
+
+IPv6 support depends upon the bare-metal network environment.

--- a/docs/architecture/digitalocean.md
+++ b/docs/architecture/digitalocean.md
@@ -1,0 +1,11 @@
+# AWS
+
+## IPv6
+
+Status of IPv6 on Typhoon DigitalOcean clusters.
+
+| IPv6 Feature            | Supported |
+|-------------------------|-----------|
+| Node IPv6 address       | Yes       |
+| Node Outbound IPv6      | Yes       |
+| Kubernetes Ingress IPv6 | Possible  |

--- a/docs/architecture/google-cloud.md
+++ b/docs/architecture/google-cloud.md
@@ -1,0 +1,11 @@
+# Google Cloud
+
+## IPv6
+
+Status of IPv6 on Typhoon Google Cloud clusters.
+
+| IPv6 Feature            | Supported |
+|-------------------------|-----------|
+| Node IPv6 address       | No        |
+| Node Outbound IPv6      | No        |
+| Kubernetes Ingress IPv6 | Yes       |

--- a/google-cloud/container-linux/kubernetes/ingress.tf
+++ b/google-cloud/container-linux/kubernetes/ingress.tf
@@ -1,13 +1,19 @@
-# Static IPv4 address for the TCP Proxy Load Balancer
+# Static IPv4 address for Ingress Load Balancing
 resource "google_compute_global_address" "ingress-ipv4" {
-  name       = "${var.cluster_name}-ingress-ip"
+  name       = "${var.cluster_name}-ingress-ipv4"
   ip_version = "IPV4"
+}
+
+# Static IPv6 address for Ingress Load Balancing
+resource "google_compute_global_address" "ingress-ipv6" {
+  name       = "${var.cluster_name}-ingress-ipv6"
+  ip_version = "IPV6"
 }
 
 # Forward IPv4 TCP traffic to the HTTP proxy load balancer
 # Google Cloud does not allow TCP proxies for port 80. Must use HTTP proxy.
-resource "google_compute_global_forwarding_rule" "ingress-http" {
-  name        = "${var.cluster_name}-ingress-http"
+resource "google_compute_global_forwarding_rule" "ingress-http-ipv4" {
+  name        = "${var.cluster_name}-ingress-http-ipv4"
   ip_address  = "${google_compute_global_address.ingress-ipv4.address}"
   ip_protocol = "TCP"
   port_range  = "80"
@@ -15,9 +21,28 @@ resource "google_compute_global_forwarding_rule" "ingress-http" {
 }
 
 # Forward IPv4 TCP traffic to the TCP proxy load balancer
-resource "google_compute_global_forwarding_rule" "ingress-https" {
-  name        = "${var.cluster_name}-ingress-https"
+resource "google_compute_global_forwarding_rule" "ingress-https-ipv4" {
+  name        = "${var.cluster_name}-ingress-https-ipv4"
   ip_address  = "${google_compute_global_address.ingress-ipv4.address}"
+  ip_protocol = "TCP"
+  port_range  = "443"
+  target      = "${google_compute_target_tcp_proxy.ingress-https.self_link}"
+}
+
+# Forward IPv6 TCP traffic to the HTTP proxy load balancer
+# Google Cloud does not allow TCP proxies for port 80. Must use HTTP proxy.
+resource "google_compute_global_forwarding_rule" "ingress-http-ipv6" {
+  name        = "${var.cluster_name}-ingress-http-ipv6"
+  ip_address  = "${google_compute_global_address.ingress-ipv6.address}"
+  ip_protocol = "TCP"
+  port_range  = "80"
+  target      = "${google_compute_target_http_proxy.ingress-http.self_link}"
+}
+
+# Forward IPv6 TCP traffic to the TCP proxy load balancer
+resource "google_compute_global_forwarding_rule" "ingress-https-ipv6" {
+  name        = "${var.cluster_name}-ingress-https-ipv6"
+  ip_address  = "${google_compute_global_address.ingress-ipv6.address}"
   ip_protocol = "TCP"
   port_range  = "443"
   target      = "${google_compute_target_tcp_proxy.ingress-https.self_link}"

--- a/google-cloud/container-linux/kubernetes/outputs.tf
+++ b/google-cloud/container-linux/kubernetes/outputs.tf
@@ -5,6 +5,11 @@ output "ingress_static_ipv4" {
   value       = "${google_compute_global_address.ingress-ipv4.address}"
 }
 
+output "ingress_static_ipv6" {
+  description = "Global IPv6 address for proxy load balancing to the nearest Ingress controller"
+  value       = "${google_compute_global_address.ingress-ipv6.address}"
+}
+
 # Outputs for worker pools
 
 output "network_name" {

--- a/google-cloud/fedora-atomic/kubernetes/ingress.tf
+++ b/google-cloud/fedora-atomic/kubernetes/ingress.tf
@@ -1,13 +1,19 @@
-# Static IPv4 address for the TCP Proxy Load Balancer
+# Static IPv4 address for Ingress Load Balancing
 resource "google_compute_global_address" "ingress-ipv4" {
-  name       = "${var.cluster_name}-ingress-ip"
+  name       = "${var.cluster_name}-ingress-ipv4"
   ip_version = "IPV4"
+}
+
+# Static IPv6 address for Ingress Load Balancing
+resource "google_compute_global_address" "ingress-ipv6" {
+  name       = "${var.cluster_name}-ingress-ipv6"
+  ip_version = "IPV6"
 }
 
 # Forward IPv4 TCP traffic to the HTTP proxy load balancer
 # Google Cloud does not allow TCP proxies for port 80. Must use HTTP proxy.
-resource "google_compute_global_forwarding_rule" "ingress-http" {
-  name        = "${var.cluster_name}-ingress-http"
+resource "google_compute_global_forwarding_rule" "ingress-http-ipv4" {
+  name        = "${var.cluster_name}-ingress-http-ipv4"
   ip_address  = "${google_compute_global_address.ingress-ipv4.address}"
   ip_protocol = "TCP"
   port_range  = "80"
@@ -15,9 +21,28 @@ resource "google_compute_global_forwarding_rule" "ingress-http" {
 }
 
 # Forward IPv4 TCP traffic to the TCP proxy load balancer
-resource "google_compute_global_forwarding_rule" "ingress-https" {
-  name        = "${var.cluster_name}-ingress-https"
+resource "google_compute_global_forwarding_rule" "ingress-https-ipv4" {
+  name        = "${var.cluster_name}-ingress-https-ipv4"
   ip_address  = "${google_compute_global_address.ingress-ipv4.address}"
+  ip_protocol = "TCP"
+  port_range  = "443"
+  target      = "${google_compute_target_tcp_proxy.ingress-https.self_link}"
+}
+
+# Forward IPv6 TCP traffic to the HTTP proxy load balancer
+# Google Cloud does not allow TCP proxies for port 80. Must use HTTP proxy.
+resource "google_compute_global_forwarding_rule" "ingress-http-ipv6" {
+  name        = "${var.cluster_name}-ingress-http-ipv6"
+  ip_address  = "${google_compute_global_address.ingress-ipv6.address}"
+  ip_protocol = "TCP"
+  port_range  = "80"
+  target      = "${google_compute_target_http_proxy.ingress-http.self_link}"
+}
+
+# Forward IPv6 TCP traffic to the TCP proxy load balancer
+resource "google_compute_global_forwarding_rule" "ingress-https-ipv6" {
+  name        = "${var.cluster_name}-ingress-https-ipv6"
+  ip_address  = "${google_compute_global_address.ingress-ipv6.address}"
   ip_protocol = "TCP"
   port_range  = "443"
   target      = "${google_compute_target_tcp_proxy.ingress-https.self_link}"

--- a/google-cloud/fedora-atomic/kubernetes/outputs.tf
+++ b/google-cloud/fedora-atomic/kubernetes/outputs.tf
@@ -5,6 +5,11 @@ output "ingress_static_ipv4" {
   value       = "${google_compute_global_address.ingress-ipv4.address}"
 }
 
+output "ingress_static_ipv6" {
+  description = "Global IPv6 address for proxy load balancing to the nearest Ingress controller"
+  value       = "${google_compute_global_address.ingress-ipv6.address}"
+}
+
 # Outputs for worker pools
 
 output "network_name" {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,11 @@ nav:
   - 'Architecture':
     - 'Concepts': 'architecture/concepts.md'
     - 'Operating Systems': 'architecture/operating-systems.md'
+    - 'AWS': 'architecture/aws.md'
+    - 'Azure': 'architecture/azure.md'
+    - 'Bare-Metal': 'architecture/bare-metal.md'
+    - 'DigitalOcean': 'architecture/digitalocean.md'
+    - 'Google Cloud': 'architecture/google-cloud.md'
   - 'Container Linux': 
     - 'AWS': 'cl/aws.md'
     - 'Azure': 'cl/azure.md'


### PR DESCRIPTION
* Allowing serving IPv6 applications via Kubernetes Ingress on Typhoon Google Cloud clusters
* Add `ingress_static_ipv6` output variable for use in AAAA DNS records