### PR TITLE
Update CoreDNS from v1.2.4 to v1.2.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,8 @@ Notable changes between versions.
 * Improve flannel manifests
   * [Rename](https://github.com/poseidon/terraform-render-bootkube/commit/d045a8e6b8eccfbb9d69bb51953b5a93d23f67f7) `kube-flannel` DaemonSet to `flannel` and `kube-flannel-cfg` ConfigMap to `flannel-config` 
   * [Drop](https://github.com/poseidon/terraform-render-bootkube/commit/39f9afb3360ec642e5b98457c8bd07eda35b6c96) unused mounts and add a CPU resource request
-* Enable CoreDNS `loop` and `loadbalance` plugins ([#340](https://github.com/poseidon/typhoon/pull/340))
+* Update CoreDNS from v1.2.4 to [v1.2.6](https://coredns.io/2018/11/05/coredns-1.2.6-release/)
+  * Enable CoreDNS `loop` and `loadbalance` plugins ([#340](https://github.com/poseidon/typhoon/pull/340))
 * Use kubernetes-incubator/bootkube v0.14.0
 
 #### Addons

--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=39f9afb3360ec642e5b98457c8bd07eda35b6c96"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=3d9f957aecf9c7fb53b9ec07be2ecfa9ea2692f8"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/fedora-atomic/kubernetes/bootkube.tf
+++ b/aws/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=39f9afb3360ec642e5b98457c8bd07eda35b6c96"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=3d9f957aecf9c7fb53b9ec07be2ecfa9ea2692f8"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/container-linux/kubernetes/bootkube.tf
+++ b/azure/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=39f9afb3360ec642e5b98457c8bd07eda35b6c96"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=3d9f957aecf9c7fb53b9ec07be2ecfa9ea2692f8"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=39f9afb3360ec642e5b98457c8bd07eda35b6c96"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=3d9f957aecf9c7fb53b9ec07be2ecfa9ea2692f8"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/bare-metal/fedora-atomic/kubernetes/bootkube.tf
+++ b/bare-metal/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=39f9afb3360ec642e5b98457c8bd07eda35b6c96"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=3d9f957aecf9c7fb53b9ec07be2ecfa9ea2692f8"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${var.k8s_domain_name}"]

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=39f9afb3360ec642e5b98457c8bd07eda35b6c96"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=3d9f957aecf9c7fb53b9ec07be2ecfa9ea2692f8"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=39f9afb3360ec642e5b98457c8bd07eda35b6c96"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=3d9f957aecf9c7fb53b9ec07be2ecfa9ea2692f8"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=39f9afb3360ec642e5b98457c8bd07eda35b6c96"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=3d9f957aecf9c7fb53b9ec07be2ecfa9ea2692f8"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/fedora-atomic/kubernetes/bootkube.tf
+++ b/google-cloud/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=39f9afb3360ec642e5b98457c8bd07eda35b6c96"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=3d9f957aecf9c7fb53b9ec07be2ecfa9ea2692f8"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]


### PR DESCRIPTION
* https://coredns.io/2018/11/05/coredns-1.2.6-release/
