### PR TITLE
Update pod-checkpointer image to query Kubelet secure API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Notable changes between versions.
 * Update CoreDNS from v1.2.4 to [v1.2.6](https://coredns.io/2018/11/05/coredns-1.2.6-release/)
   * Enable CoreDNS `loop` and `loadbalance` plugins ([#340](https://github.com/poseidon/typhoon/pull/340))
 * Add `enable_reporting` variable (default "false") to provide upstreams with usage data ([#345](https://github.com/poseidon/typhoon/pull/345))
+* Fix pod-checkpointer detection for new checkpointable pods and log noise ([#346](https://github.com/poseidon/typhoon/pull/346))
 * Use kubernetes-incubator/bootkube v0.14.0
 
 #### Azure

--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dbf67da1cbd4c3036e3b551850d3a51b5fc4ee7c"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=bffb5d5d2313e34eff9f304e77dc4c3a3ccff816"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/fedora-atomic/kubernetes/bootkube.tf
+++ b/aws/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dbf67da1cbd4c3036e3b551850d3a51b5fc4ee7c"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=bffb5d5d2313e34eff9f304e77dc4c3a3ccff816"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/container-linux/kubernetes/bootkube.tf
+++ b/azure/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dbf67da1cbd4c3036e3b551850d3a51b5fc4ee7c"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=bffb5d5d2313e34eff9f304e77dc4c3a3ccff816"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dbf67da1cbd4c3036e3b551850d3a51b5fc4ee7c"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=bffb5d5d2313e34eff9f304e77dc4c3a3ccff816"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/bare-metal/fedora-atomic/kubernetes/bootkube.tf
+++ b/bare-metal/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dbf67da1cbd4c3036e3b551850d3a51b5fc4ee7c"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=bffb5d5d2313e34eff9f304e77dc4c3a3ccff816"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${var.k8s_domain_name}"]

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dbf67da1cbd4c3036e3b551850d3a51b5fc4ee7c"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=bffb5d5d2313e34eff9f304e77dc4c3a3ccff816"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dbf67da1cbd4c3036e3b551850d3a51b5fc4ee7c"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=bffb5d5d2313e34eff9f304e77dc4c3a3ccff816"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dbf67da1cbd4c3036e3b551850d3a51b5fc4ee7c"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=bffb5d5d2313e34eff9f304e77dc4c3a3ccff816"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/fedora-atomic/kubernetes/bootkube.tf
+++ b/google-cloud/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=dbf67da1cbd4c3036e3b551850d3a51b5fc4ee7c"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=bffb5d5d2313e34eff9f304e77dc4c3a3ccff816"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]


### PR DESCRIPTION
* Updates pod-checkpointer to prefer the Kubelet secure API (before falling back to the Kubelet read-only API that is disabled on Typhoon clusters since https://github.com/poseidon/typhoon/pull/324)
* Previously, pod-checkpointer checkpointed an initial set of pods during bootstrapping so recovery from power cycling clusters was unaffected, but logs were noisy
* https://github.com/poseidon/terraform-render-bootkube/pull/91

Related:

* https://github.com/kubernetes-incubator/bootkube/pull/1027
* https://github.com/kubernetes-incubator/bootkube/pull/1025
