### PR TITLE
Disable Grafana login form, admin user can't be disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between versions.
 
 ## Latest
 
+#### Addons
+
+* Disable Grafana login form, since admin user can't be disabled ([#352](https://github.com/poseidon/typhoon/pull/352))
+  * Example manifests aim to provide a read-only dashboard view
+
 ## v1.12.3
 
 * Kubernetes [v1.12.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md#v1123)

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -29,6 +29,8 @@ spec:
               value: "8080"
             - name: GF_AUTH_BASIC_ENABLED
               value: "false"
+            - name: GF_AUTH_DISABLE_LOGIN_FORM
+              value: "true"
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "true"
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE


### PR DESCRIPTION
* Example manifests aim to provide a read-only dashboard visible to any users with network access (i.e. kubectl port-forward, LAN)
* Problem: Grafana always has an admin user, even with the user
management system disabled
* Disable the login form to prevent admin login