### PR TITLE
Add experimental kube-router CNI provider

### DIFF
--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4021467b7f280ceb54320333690e8574a3bd8d84"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=9d6f0c31d36f8e84e9f7187f5fddf5e344b31f56"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/fedora-atomic/kubernetes/bootkube.tf
+++ b/aws/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4021467b7f280ceb54320333690e8574a3bd8d84"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=9d6f0c31d36f8e84e9f7187f5fddf5e344b31f56"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/container-linux/kubernetes/bootkube.tf
+++ b/azure/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4021467b7f280ceb54320333690e8574a3bd8d84"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=9d6f0c31d36f8e84e9f7187f5fddf5e344b31f56"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4021467b7f280ceb54320333690e8574a3bd8d84"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=9d6f0c31d36f8e84e9f7187f5fddf5e344b31f56"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/bare-metal/fedora-atomic/kubernetes/bootkube.tf
+++ b/bare-metal/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4021467b7f280ceb54320333690e8574a3bd8d84"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=9d6f0c31d36f8e84e9f7187f5fddf5e344b31f56"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${var.k8s_domain_name}"]

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4021467b7f280ceb54320333690e8574a3bd8d84"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=9d6f0c31d36f8e84e9f7187f5fddf5e344b31f56"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4021467b7f280ceb54320333690e8574a3bd8d84"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=9d6f0c31d36f8e84e9f7187f5fddf5e344b31f56"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4021467b7f280ceb54320333690e8574a3bd8d84"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=9d6f0c31d36f8e84e9f7187f5fddf5e344b31f56"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/container-linux/kubernetes/network.tf
+++ b/google-cloud/container-linux/kubernetes/network.tf
@@ -57,12 +57,12 @@ resource "google_compute_firewall" "allow-apiserver" {
   target_tags   = ["${var.cluster_name}-controller"]
 }
 
-# Calico BGP and IPIP
-# https://docs.projectcalico.org/v2.5/reference/public-cloud/gce
-resource "google_compute_firewall" "internal-calico" {
-  count = "${var.networking == "calico" ? 1 : 0}"
+# BGP and IPIP
+# https://docs.projectcalico.org/latest/reference/public-cloud/gce
+resource "google_compute_firewall" "internal-bgp" {
+  count = "${var.networking != "flannel" ? 1 : 0}"
 
-  name    = "${var.cluster_name}-internal-calico"
+  name    = "${var.cluster_name}-internal-bgp"
   network = "${google_compute_network.network.name}"
 
   allow {

--- a/google-cloud/fedora-atomic/kubernetes/bootkube.tf
+++ b/google-cloud/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4021467b7f280ceb54320333690e8574a3bd8d84"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=9d6f0c31d36f8e84e9f7187f5fddf5e344b31f56"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/fedora-atomic/kubernetes/network.tf
+++ b/google-cloud/fedora-atomic/kubernetes/network.tf
@@ -57,12 +57,12 @@ resource "google_compute_firewall" "allow-apiserver" {
   target_tags   = ["${var.cluster_name}-controller"]
 }
 
-# Calico BGP and IPIP
-# https://docs.projectcalico.org/v2.5/reference/public-cloud/gce
-resource "google_compute_firewall" "internal-calico" {
-  count = "${var.networking == "calico" ? 1 : 0}"
+# BGP and IPIP
+# https://docs.projectcalico.org/latest/reference/public-cloud/gce
+resource "google_compute_firewall" "internal-bgp" {
+  count = "${var.networking != "flannel" ? 1 : 0}"
 
-  name    = "${var.cluster_name}-internal-calico"
+  name    = "${var.cluster_name}-internal-bpg"
   network = "${google_compute_network.network.name}"
 
   allow {


### PR DESCRIPTION
* Add kube-router for pod networking and NetworkPolicy as an experiment
* Experiments are not documented or supported in any way, and may be removed without notice. They have known issues and aren't enabled without special options.

## Testing

Functions on bare-metal and AWS. Does not work on Google Cloud.