### PR TITLE
google-cloud/fedora-atomic/kubernetes: bgp typo

### DIFF
--- a/google-cloud/fedora-atomic/kubernetes/network.tf
+++ b/google-cloud/fedora-atomic/kubernetes/network.tf
@@ -62,7 +62,7 @@ resource "google_compute_firewall" "allow-apiserver" {
 resource "google_compute_firewall" "internal-bgp" {
   count = "${var.networking != "flannel" ? 1 : 0}"
 
-  name    = "${var.cluster_name}-internal-bpg"
+  name    = "${var.cluster_name}-internal-bgp"
   network = "${google_compute_network.network.name}"
 
   allow {


### PR DESCRIPTION
This commit fixes a minor typo that was introduced in 76d993cdaefc2d6b88bc524bdec69ffc152d974b.
