### PR TITLE
 Increase GCP TCP proxy apiserver backend timeout to 5 minutes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Notable changes between versions.
 
 * Kubernetes [v1.13.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.13.md#v1131)
 
+#### Google Cloud
+
+* Increase TCP proxy apiserver backend service timeout from 1 minute to 5 minutes ([#361](https://github.com/poseidon/typhoon/pull/361))
+  * Align `port-forward` behavior closer to AWS/Azure (no timeout)
+
 #### Addons
 
 * Update Grafana from v5.4.0 to v5.4.2

--- a/google-cloud/container-linux/kubernetes/apiserver.tf
+++ b/google-cloud/container-linux/kubernetes/apiserver.tf
@@ -42,7 +42,7 @@ resource "google_compute_backend_service" "apiserver" {
   protocol         = "TCP"
   port_name        = "apiserver"
   session_affinity = "NONE"
-  timeout_sec      = "60"
+  timeout_sec      = "300"
 
   # controller(s) spread across zonal instance groups
   backend {

--- a/google-cloud/fedora-atomic/kubernetes/apiserver.tf
+++ b/google-cloud/fedora-atomic/kubernetes/apiserver.tf
@@ -42,7 +42,7 @@ resource "google_compute_backend_service" "apiserver" {
   protocol         = "TCP"
   port_name        = "apiserver"
   session_affinity = "NONE"
-  timeout_sec      = "60"
+  timeout_sec      = "300"
 
   # controller(s) spread across zonal instance groups
   backend {


### PR DESCRIPTION
* On GCP, kubectl port-forward connections to pods are closed after a timeout (unlike AWS NLB's or Azure load balancers)
* Increase the GCP apiserver backend service timeout from 1 minute to 5 minutes to be more similar to AWS/Azure LB behavior
