### PR TITLE
Change AWS default type from t2.small to t3.small

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between versions.
 
 ## Latest
 
+#### AWS
+
+* Change `controller_type` and `worker_type` default from t2.small to t3.small
+  * t3.small is cheaper, provides 2 vCPU (instead of 1), and 5 Gbps of pod-to-pod bandwidth!
+
 ## v1.13.1
 
 * Kubernetes [v1.13.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.13.md#v1131)

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -31,13 +31,13 @@ variable "worker_count" {
 
 variable "controller_type" {
   type        = "string"
-  default     = "t2.small"
+  default     = "t3.small"
   description = "EC2 instance type for controllers"
 }
 
 variable "worker_type" {
   type        = "string"
-  default     = "t2.small"
+  default     = "t3.small"
   description = "EC2 instance type for workers"
 }
 

--- a/aws/fedora-atomic/kubernetes/variables.tf
+++ b/aws/fedora-atomic/kubernetes/variables.tf
@@ -31,13 +31,13 @@ variable "worker_count" {
 
 variable "controller_type" {
   type        = "string"
-  default     = "t2.small"
+  default     = "t3.small"
   description = "EC2 instance type for controllers"
 }
 
 variable "worker_type" {
   type        = "string"
-  default     = "t2.small"
+  default     = "t3.small"
   description = "EC2 instance type for workers"
 }
 

--- a/docs/atomic/aws.md
+++ b/docs/atomic/aws.md
@@ -224,8 +224,8 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 |:-----|:------------|:--------|:--------|
 | controller_count | Number of controllers (i.e. masters) | 1 | 1 |
 | worker_count | Number of workers | 1 | 3 |
-| controller_type | EC2 instance type for controllers | "t2.small" | See below |
-| worker_type | EC2 instance type for workers | "t2.small" | See below |
+| controller_type | EC2 instance type for controllers | "t3.small" | See below |
+| worker_type | EC2 instance type for workers | "t3.small" | See below |
 | disk_size | Size of the EBS volume in GB | "40" | "100" |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | "0" (i.e. auto) | "400" |

--- a/docs/cl/aws.md
+++ b/docs/cl/aws.md
@@ -236,8 +236,8 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 |:-----|:------------|:--------|:--------|
 | controller_count | Number of controllers (i.e. masters) | 1 | 1 |
 | worker_count | Number of workers | 1 | 3 |
-| controller_type | EC2 instance type for controllers | "t2.small" | See below |
-| worker_type | EC2 instance type for workers | "t2.small" | See below |
+| controller_type | EC2 instance type for controllers | "t3.small" | See below |
+| worker_type | EC2 instance type for workers | "t3.small" | See below |
 | os_image | AMI channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha |
 | disk_size | Size of the EBS volume in GB | "40" | "100" |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |

--- a/docs/topics/performance.md
+++ b/docs/topics/performance.md
@@ -6,7 +6,7 @@ Provisioning times vary based on the operating system and platform. Sampling the
 
 | Platform      | Apply | Destroy |
 |---------------|-------|---------|
-| AWS           | 6 min | 5 min   |
+| AWS           | 6 min | 4 min   |
 | Azure         | 7 min | 7 min   |
 | Bare-Metal    | 10-15 min | NA  |
 | Digital Ocean | 3 min 30 sec | 20 sec |
@@ -24,12 +24,12 @@ Network performance varies based on the platform and CNI plugin. `iperf` was use
 
 | Platform / Plugin          | Theory | Host to Host | Pod to Pod   |
 |----------------------------|-------:|-------------:|-------------:|
-| AWS (flannel)              | Varies | 976 Mb/s     | 900-999 Mb/s |
-| AWS (calico, MTU 1480)     | Varies | 976 Mb/s     | 100-350 Mb/s |
-| AWS (calico, MTU 8981)     | Varies | 976 Mb/s     | 900-999 Mb/s |
-| Azure (flannel)            | Varies | 749 Mb/s     | 680 Mb/s     |
-| Bare-Metal (flannel)       | 1 Gb/s | ~940 Mb/s    | 903 Mb/s     |
-| Bare-Metal (calico)        | 1 Gb/s | ~940 Mb/s    | 931 Mb/s     |
+| AWS (flannel)              | 5 Gb/s | 4.94 Gb/s    | 4.89 Gb/s    |
+| AWS (calico, MTU 1480)     | 5 Gb/s | 4.94 Gb/s    | 4.42 Gb/s    |
+| AWS (calico, MTU 8981)     | 5 Gb/s | 4.94 Gb/s    | 4.75 Gb/s    |
+| Azure (flannel)            | Varies |  749 Mb/s    | 680 Mb/s     |
+| Bare-Metal (flannel)       | 1 Gb/s |  940 Mb/s    | 903 Mb/s     |
+| Bare-Metal (calico)        | 1 Gb/s |  940 Mb/s    | 931 Mb/s     |
 | Bare-Metal (flannel, bond) | 3 Gb/s |  2.3 Gb/s    | 1.17 Gb/s    |
 | Bare-Metal (calico, bond)  | 3 Gb/s |  2.3 Gb/s    | 1.17 Gb/s    |
 | Digital Ocean              | 2 Gb/s | 1.97 Gb/s    | 1.64 Gb/s    |


### PR DESCRIPTION
T3 is the next generation general purpose burstable instance type. Compared with t2.small, the t3.small is cheaper, has 2 vCPU (instead of 1) and provides 5 Gbps of pod-to-pod bandwidth (instead of 1 Gbps)

references:
* https://aws.amazon.com/ec2/instance-types/
* https://aws.amazon.com/ec2/pricing/on-demand/