### PR TITLE
Use a single format of the admin kubeconfig

### DIFF
--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f5ea389e8c86a4de159ae92742b8665a6f8bede0"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=847ec5929b4b4b3d8b922dbbee4a3ecefd71f597"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -1,5 +1,5 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin-context}"
+  value = "${module.bootkube.kubeconfig-admin}"
 }
 
 # Outputs for Kubernetes Ingress

--- a/aws/fedora-atomic/kubernetes/bootkube.tf
+++ b/aws/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f5ea389e8c86a4de159ae92742b8665a6f8bede0"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=847ec5929b4b4b3d8b922dbbee4a3ecefd71f597"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/fedora-atomic/kubernetes/outputs.tf
+++ b/aws/fedora-atomic/kubernetes/outputs.tf
@@ -1,5 +1,5 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin-context}"
+  value = "${module.bootkube.kubeconfig-admin}"
 }
 
 # Outputs for Kubernetes Ingress

--- a/azure/container-linux/kubernetes/bootkube.tf
+++ b/azure/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f5ea389e8c86a4de159ae92742b8665a6f8bede0"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=847ec5929b4b4b3d8b922dbbee4a3ecefd71f597"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/container-linux/kubernetes/outputs.tf
+++ b/azure/container-linux/kubernetes/outputs.tf
@@ -1,5 +1,5 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin-context}"
+  value = "${module.bootkube.kubeconfig-admin}"
 }
 
 # Outputs for Kubernetes Ingress

--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f5ea389e8c86a4de159ae92742b8665a6f8bede0"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=847ec5929b4b4b3d8b922dbbee4a3ecefd71f597"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/bare-metal/container-linux/kubernetes/outputs.tf
+++ b/bare-metal/container-linux/kubernetes/outputs.tf
@@ -1,3 +1,3 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin-context}"
+  value = "${module.bootkube.kubeconfig-admin}"
 }

--- a/bare-metal/fedora-atomic/kubernetes/bootkube.tf
+++ b/bare-metal/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f5ea389e8c86a4de159ae92742b8665a6f8bede0"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=847ec5929b4b4b3d8b922dbbee4a3ecefd71f597"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${var.k8s_domain_name}"]

--- a/bare-metal/fedora-atomic/kubernetes/outputs.tf
+++ b/bare-metal/fedora-atomic/kubernetes/outputs.tf
@@ -1,3 +1,3 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin-context}"
+  value = "${module.bootkube.kubeconfig-admin}"
 }

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f5ea389e8c86a4de159ae92742b8665a6f8bede0"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=847ec5929b4b4b3d8b922dbbee4a3ecefd71f597"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/digital-ocean/container-linux/kubernetes/outputs.tf
+++ b/digital-ocean/container-linux/kubernetes/outputs.tf
@@ -1,5 +1,5 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.user-kubeconfig}"
+  value = "${module.bootkube.kubeconfig-admin}"
 }
 
 output "controllers_dns" {

--- a/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f5ea389e8c86a4de159ae92742b8665a6f8bede0"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=847ec5929b4b4b3d8b922dbbee4a3ecefd71f597"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/digital-ocean/fedora-atomic/kubernetes/outputs.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/outputs.tf
@@ -1,5 +1,5 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.user-kubeconfig}"
+  value = "${module.bootkube.kubeconfig-admin}"
 }
 
 output "controllers_dns" {

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f5ea389e8c86a4de159ae92742b8665a6f8bede0"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=847ec5929b4b4b3d8b922dbbee4a3ecefd71f597"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/container-linux/kubernetes/outputs.tf
+++ b/google-cloud/container-linux/kubernetes/outputs.tf
@@ -1,5 +1,5 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin-context}"
+  value = "${module.bootkube.kubeconfig-admin}"
 }
 
 # Outputs for Kubernetes Ingress

--- a/google-cloud/fedora-atomic/kubernetes/bootkube.tf
+++ b/google-cloud/fedora-atomic/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=f5ea389e8c86a4de159ae92742b8665a6f8bede0"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=847ec5929b4b4b3d8b922dbbee4a3ecefd71f597"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/fedora-atomic/kubernetes/outputs.tf
+++ b/google-cloud/fedora-atomic/kubernetes/outputs.tf
@@ -1,5 +1,5 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin-context}"
+  value = "${module.bootkube.kubeconfig-admin}"
 }
 
 # Outputs for Kubernetes Ingress


### PR DESCRIPTION
* Use a single admin kubeconfig for initial bootkube bootstrap and for use by a human admin. Previously, an admin kubeconfig without a named context was used for bootstrap and direct usage
with KUBECONFIG=path, while one with a named context was used for `kubectl config use-context` style usage. Confusing.
* Provide the admin kubeconfig via `assets/auth/kubeconfig`, `assets/auth/CLUSTER-config`, or output `kubeconfig-admin`