### PR TITLE
Fix section title in architecture docs

### DIFF
--- a/docs/architecture/digitalocean.md
+++ b/docs/architecture/digitalocean.md
@@ -1,4 +1,4 @@
-# AWS
+# DigitalOcean
 
 ## IPv6
 


### PR DESCRIPTION
I was reading the docs and found an `AWS` title for a `DigitalOcean` section.

## Testing

Go to https://typhoon.psdn.io/architecture/digitalocean/ check title is not `AWS` anymore.
