### PR TITLE
Existing vpc support

### DIFF
--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -1,9 +1,13 @@
+locals {
+  dns_zone = "${replace(var.dns_zone, "/[.]$/", "")}"
+}
+
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
   source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=c5bc23ef7a3f5d8e5be976ee60b58dbbfcc3e7c9"
 
   cluster_name          = "${var.cluster_name}"
-  api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
+  api_servers           = ["${format("%s.%s", var.cluster_name, local.dns_zone)}"]
   etcd_servers          = ["${aws_route53_record.etcds.*.fqdn}"]
   asset_dir             = "${var.asset_dir}"
   networking            = "${var.networking}"

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -35,7 +35,7 @@ resource "aws_instance" "controllers" {
 
   # network
   associate_public_ip_address = true
-  subnet_id                   = "${element(aws_subnet.public.*.id, count.index)}"
+  subnet_id                   = "${element(split(":", length(var.public_subnets) > 0 ? join(":", var.public_subnets) : join(":", aws_subnet.public.*.id)), count.index)}"
   vpc_security_group_ids      = ["${aws_security_group.controller.id}"]
 
   lifecycle {

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -5,7 +5,7 @@ resource "aws_route53_record" "etcds" {
   # DNS Zone where record should be created
   zone_id = "${var.dns_zone_id}"
 
-  name = "${format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)}"
+  name = "${format("%s-etcd%d.%s.", var.cluster_name, count.index, local.dns_zone)}"
   type = "A"
   ttl  = 300
 
@@ -63,7 +63,7 @@ data "template_file" "controller-configs" {
   vars = {
     # Cannot use cyclic dependencies on controllers or their DNS records
     etcd_name   = "etcd${count.index}"
-    etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+    etcd_domain = "${var.cluster_name}-etcd${count.index}.${local.dns_zone}"
 
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
     etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
@@ -82,6 +82,6 @@ data "template_file" "etcds" {
   vars {
     index        = "${count.index}"
     cluster_name = "${var.cluster_name}"
-    dns_zone     = "${var.dns_zone}"
+    dns_zone     = "${local.dns_zone}"
   }
 }

--- a/aws/container-linux/kubernetes/nlb.tf
+++ b/aws/container-linux/kubernetes/nlb.tf
@@ -2,7 +2,7 @@
 resource "aws_route53_record" "apiserver" {
   zone_id = "${var.dns_zone_id}"
 
-  name = "${format("%s.%s.", var.cluster_name, var.dns_zone)}"
+  name = "${format("%s.%s.", var.cluster_name, local.dns_zone)}"
   type = "A"
 
   # AWS recommends their special "alias" records for NLBs

--- a/aws/container-linux/kubernetes/nlb.tf
+++ b/aws/container-linux/kubernetes/nlb.tf
@@ -19,7 +19,7 @@ resource "aws_lb" "nlb" {
   load_balancer_type = "network"
   internal           = false
 
-  subnets = ["${aws_subnet.public.*.id}"]
+  subnets = ["${split(":", length(var.public_subnets) > 0 ? join(":", var.public_subnets) : join(":", aws_subnet.public.*.id))}"]
 
   enable_cross_zone_load_balancing = true
 }
@@ -63,7 +63,7 @@ resource "aws_lb_listener" "ingress-https" {
 # Target group of controllers
 resource "aws_lb_target_group" "controllers" {
   name        = "${var.cluster_name}-controllers"
-  vpc_id      = "${aws_vpc.network.id}"
+  vpc_id      = "${local.manage_vpc ? join("", aws_vpc.network.*.id) : var.vpc_id}"
   target_type = "instance"
 
   protocol = "TCP"

--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -17,12 +17,13 @@ output "ingress_zone_id" {
 # Outputs for worker pools
 
 output "vpc_id" {
-  value       = "${aws_vpc.network.id}"
+  value       = "${local.manage_vpc ? join("", aws_vpc.network.*.id) : var.vpc_id}"
   description = "ID of the VPC for creating worker instances"
 }
 
 output "subnet_ids" {
-  value       = ["${aws_subnet.public.*.id}"]
+  # work around for https://github.com/hashicorp/terraform/issues/18259
+  value       = ["${split(":", length(var.public_subnets) > 0 ? join(":", var.public_subnets) : join(":", aws_subnet.public.*.id))}"]
   description = "List of subnet IDs for creating worker instances"
 }
 
@@ -33,6 +34,14 @@ output "worker_security_groups" {
 
 output "kubeconfig" {
   value = "${module.bootkube.kubeconfig-kubelet}"
+}
+
+output "server" {
+  value = "${module.bootkube.server}"
+}
+
+output "ca_cert" {
+  value = "${module.bootkube.ca_cert}"
 }
 
 # Outputs for custom load balancing

--- a/aws/container-linux/kubernetes/security.tf
+++ b/aws/container-linux/kubernetes/security.tf
@@ -6,7 +6,7 @@ resource "aws_security_group" "controller" {
   name        = "${var.cluster_name}-controller"
   description = "${var.cluster_name} controller security group"
 
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = "${local.manage_vpc ? join("", aws_vpc.network.*.id) : var.vpc_id}"
 
   tags = "${map("Name", "${var.cluster_name}-controller")}"
 }
@@ -181,7 +181,7 @@ resource "aws_security_group" "worker" {
   name        = "${var.cluster_name}-worker"
   description = "${var.cluster_name} worker security group"
 
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = "${local.manage_vpc ? join("", aws_vpc.network.*.id) : var.vpc_id}"
 
   tags = "${map("Name", "${var.cluster_name}-worker")}"
 }

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -140,3 +140,21 @@ variable "enable_reporting" {
   description = "Enable usage or analytics reporting to upstreams (Calico)"
   default     = "false"
 }
+
+# Variables that control things for an existing VPC
+
+variable "vpc_id" {
+  type        = "string"
+  description = "Deploy into an existing vpc"
+  default     = ""
+}
+
+variable "public_subnets" {
+  description = "List of existing public subnet IDs"
+  type        = "list"
+  default     = []
+}
+
+locals {
+  manage_vpc = "${var.vpc_id == "" ? 1 : 0}"
+}

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -3,8 +3,8 @@ module "workers" {
   name   = "${var.cluster_name}"
 
   # AWS
-  vpc_id          = "${aws_vpc.network.id}"
-  subnet_ids      = ["${aws_subnet.public.*.id}"]
+  vpc_id          = "${local.manage_vpc ? join("", aws_vpc.network.*.id) : var.vpc_id}"
+  subnet_ids      = ["${split(":", length(var.public_subnets) > 0 ? join(":", var.public_subnets) : join(":", aws_subnet.public.*.id))}"]
   security_groups = ["${aws_security_group.worker.id}"]
   count           = "${var.worker_count}"
   instance_type   = "${var.worker_type}"


### PR DESCRIPTION
Support existing vpc.

By passing in a `vpc_id` and a list of subnet ids in `public_subnets` the choices will be made properly to deploy there instead of creating all the network layer things.

* Optional support for provisioning in an existing vpc (aws/container-linux)
* sanitize the dns_zone variable because if zones come in from other Route53 data sources they will usually have trailing dots.
* TODO: the other stacks
* TODO: support for both public and private subnets
* TODO: support a choice for tying the API and worker NLBs to either public or private subnets.

## Testing

Launched functional clusters in both "modes".

rel: #392 