### PR TITLE
aws: support separate dns provider

### DIFF
--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -1,6 +1,7 @@
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "aws_route53_record" "etcds" {
-  count = "${var.controller_count}"
+  provider = "aws.dns"
+  count    = "${var.controller_count}"
 
   # DNS Zone where record should be created
   zone_id = "${var.dns_zone_id}"

--- a/aws/container-linux/kubernetes/nlb.tf
+++ b/aws/container-linux/kubernetes/nlb.tf
@@ -1,5 +1,7 @@
 # Network Load Balancer DNS Record
 resource "aws_route53_record" "apiserver" {
+  provider = "aws.dns"
+
   zone_id = "${var.dns_zone_id}"
 
   name = "${format("%s.%s.", var.cluster_name, var.dns_zone)}"

--- a/aws/container-linux/kubernetes/require.tf
+++ b/aws/container-linux/kubernetes/require.tf
@@ -8,6 +8,11 @@ provider "aws" {
   version = "~> 1.13"
 }
 
+provider "aws" {
+  alias   = "dns"
+  version = "~> 1.13"
+}
+
 provider "local" {
   version = "~> 1.0"
 }

--- a/aws/fedora-atomic/kubernetes/controllers.tf
+++ b/aws/fedora-atomic/kubernetes/controllers.tf
@@ -1,5 +1,7 @@
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "aws_route53_record" "etcds" {
+  provider = "aws.dns"
+
   count = "${var.controller_count}"
 
   # DNS Zone where record should be created

--- a/aws/fedora-atomic/kubernetes/nlb.tf
+++ b/aws/fedora-atomic/kubernetes/nlb.tf
@@ -1,5 +1,7 @@
 # Network Load Balancer DNS Record
 resource "aws_route53_record" "apiserver" {
+  provider = "aws.dns"
+
   zone_id = "${var.dns_zone_id}"
 
   name = "${format("%s.%s.", var.cluster_name, var.dns_zone)}"


### PR DESCRIPTION
You may want to be able to deploy clusters in AWS accounts which are separate from the accounts where you have your Route53 zone or zones.

* Support a `aws.dns` provider to be supplied. For when you have DNS in one AWS account and the clusters are to be setup in a separate account.

## Testing

Deployed clusters using the same aws providers (accounts) as well as two separate ones.

