### PR TITLE
Set the Google Cloud minimum CPU platform to Intel Haswell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@ Notable changes between versions.
 
 * Recommend updating [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) plugin from v0.2.2 to [v0.2.3](https://github.com/coreos/terraform-provider-matchbox/releases/tag/v0.2.3) ([#402](https://github.com/poseidon/typhoon/pull/402))
 
+#### Google Cloud
+
+* Set the minimum CPU platform to Intel Haswell ([#405](https://github.com/poseidon/typhoon/pull/405))
+  * Haswell or better is available in every zone (no price change)
+  * A few zones still default to Sandy/Ivy Bridge (shifts in April 2019)
+
 #### Addons
 
 * Improve Prometheus rules and alerts ([#404](https://github.com/poseidon/typhoon/pull/404))

--- a/google-cloud/container-linux/kubernetes/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers.tf
@@ -31,9 +31,10 @@ locals {
 resource "google_compute_instance" "controllers" {
   count = "${var.controller_count}"
 
-  name         = "${var.cluster_name}-controller-${count.index}"
-  zone         = "${element(local.zones, count.index)}"
-  machine_type = "${var.controller_type}"
+  name             = "${var.cluster_name}-controller-${count.index}"
+  zone             = "${element(local.zones, count.index)}"
+  machine_type     = "${var.controller_type}"
+  min_cpu_platform = "Intel Haswell"
 
   metadata {
     user-data = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -23,9 +23,10 @@ resource "google_compute_region_instance_group_manager" "workers" {
 
 # Worker instance template
 resource "google_compute_instance_template" "worker" {
-  name_prefix  = "${var.name}-worker-"
-  description  = "Worker Instance template"
-  machine_type = "${var.machine_type}"
+  name_prefix      = "${var.name}-worker-"
+  description      = "Worker Instance template"
+  machine_type     = "${var.machine_type}"
+  min_cpu_platform = "Intel Haswell"
 
   metadata {
     user-data = "${data.ct_config.worker-ignition.rendered}"

--- a/google-cloud/fedora-atomic/kubernetes/controllers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/controllers.tf
@@ -31,9 +31,10 @@ locals {
 resource "google_compute_instance" "controllers" {
   count = "${var.controller_count}"
 
-  name         = "${var.cluster_name}-controller-${count.index}"
-  zone         = "${element(local.zones, count.index)}"
-  machine_type = "${var.controller_type}"
+  name             = "${var.cluster_name}-controller-${count.index}"
+  zone             = "${element(local.zones, count.index)}"
+  machine_type     = "${var.controller_type}"
+  min_cpu_platform = "Intel Haswell"
 
   metadata {
     user-data = "${element(data.template_file.controller-cloudinit.*.rendered, count.index)}"

--- a/google-cloud/fedora-atomic/kubernetes/workers/workers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/workers/workers.tf
@@ -23,9 +23,10 @@ resource "google_compute_region_instance_group_manager" "workers" {
 
 # Worker instance template
 resource "google_compute_instance_template" "worker" {
-  name_prefix  = "${var.name}-worker-"
-  description  = "Worker Instance template"
-  machine_type = "${var.machine_type}"
+  name_prefix      = "${var.name}-worker-"
+  description      = "Worker Instance template"
+  machine_type     = "${var.machine_type}"
+  min_cpu_platform = "Intel Haswell"
 
   metadata {
     user-data = "${data.template_file.worker-cloudinit.rendered}"


### PR DESCRIPTION
* Intel Haswell or better is available in every zone around the world
* Neither Kubernetes nor Typhoon have a particular minimum processor family. However, a few Google Cloud zones still default to Sandy/Ivy bridge (scheduled to shift April 2019). Price is only based on machine type so it is beneficial to opt for the next processor family
* Intel Haswell is a suitable minimum since it still allows plenty of liberty in choosing any region or machine type
* Likely a slight increase to preemption probability in a few zones, but any lower probability on Sandy/Ivy bridge is due to lower desirability as they're phased out
* https://cloud.google.com/compute/docs/regions-zones/