### PR TITLE
Upgrade to support terraform-provider-google v2.0+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Notable changes between versions.
 
 * Update etcd from v3.3.11 to [v3.3.12](https://github.com/etcd-io/etcd/releases/tag/v3.3.12)
 * Update Calico from v3.5.0 to v3.5.1
-* Assign priorityClassNames to critical cluster and node components
+* Assign priorityClassNames to critical cluster and node components ([#406](https://github.com/poseidon/typhoon/pull/406))
   * Informs node out-of-resource eviction and scheduler preemption and ordering
 
 #### Bare-Metal
@@ -15,6 +15,8 @@ Notable changes between versions.
 
 #### Google Cloud
 
+* Support `terraform-provider-google` v2.0+ ([#407](https://github.com/poseidon/typhoon/pull/407))
+  * Require `terraform-provider-google` v1.19+ (action required)
 * Set the minimum CPU platform to Intel Haswell ([#405](https://github.com/poseidon/typhoon/pull/405))
   * Haswell or better is available in every zone (no price change)
   * A few zones still default to Sandy/Ivy Bridge (shifts in April 2019)

--- a/docs/atomic/google-cloud.md
+++ b/docs/atomic/google-cloud.md
@@ -45,7 +45,7 @@ Configure the Google Cloud provider to use your service account key, project-id,
 
 ```tf
 provider "google" {
-  version = "1.6"
+  version = "2.0.0"
   alias   = "default"
 
   credentials = "${file("~/.config/google-cloud/terraform.json")}"

--- a/docs/cl/google-cloud.md
+++ b/docs/cl/google-cloud.md
@@ -49,7 +49,7 @@ Configure the Google Cloud provider to use your service account key, project-id,
 
 ```tf
 provider "google" {
-  version = "1.6"
+  version = "2.0.0"
   alias   = "default"
 
   credentials = "${file("~/.config/google-cloud/terraform.json")}"

--- a/google-cloud/container-linux/kubernetes/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers.tf
@@ -11,7 +11,7 @@ resource "google_dns_record_set" "etcds" {
   ttl  = 300
 
   # private IPv4 address for etcd
-  rrdatas = ["${element(google_compute_instance.controllers.*.network_interface.0.address, count.index)}"]
+  rrdatas = ["${element(google_compute_instance.controllers.*.network_interface.0.network_ip, count.index)}"]
 }
 
 # Zones in the region
@@ -24,7 +24,7 @@ locals {
   # controllers over up to 3 zones, since all GCP regions have at least 3.
   zones = "${slice(data.google_compute_zones.all.names, 0, 3)}"
 
-  controllers_ipv4_public = ["${google_compute_instance.controllers.*.network_interface.0.access_config.0.assigned_nat_ip}"]
+  controllers_ipv4_public = ["${google_compute_instance.controllers.*.network_interface.0.access_config.0.nat_ip}"]
 }
 
 # Controller instances

--- a/google-cloud/container-linux/kubernetes/require.tf
+++ b/google-cloud/container-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 1.6"
+  version = ">= 1.19, < 3.0"
 }
 
 provider "local" {

--- a/google-cloud/fedora-atomic/kubernetes/controllers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/controllers.tf
@@ -11,7 +11,7 @@ resource "google_dns_record_set" "etcds" {
   ttl  = 300
 
   # private IPv4 address for etcd
-  rrdatas = ["${element(google_compute_instance.controllers.*.network_interface.0.address, count.index)}"]
+  rrdatas = ["${element(google_compute_instance.controllers.*.network_interface.0.network_ip, count.index)}"]
 }
 
 # Zones in the region
@@ -24,7 +24,7 @@ locals {
   # controllers over up to 3 zones, since all GCP regions have at least 3.
   zones = "${slice(data.google_compute_zones.all.names, 0, 3)}"
 
-  controllers_ipv4_public = ["${google_compute_instance.controllers.*.network_interface.0.access_config.0.assigned_nat_ip}"]
+  controllers_ipv4_public = ["${google_compute_instance.controllers.*.network_interface.0.access_config.0.nat_ip}"]
 }
 
 # Controller instances

--- a/google-cloud/fedora-atomic/kubernetes/require.tf
+++ b/google-cloud/fedora-atomic/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 1.6"
+  version = ">= 1.19, < 3.0"
 }
 
 provider "local" {


### PR DESCRIPTION
* Support terraform-provider-google v1.19.0, v1.19.1, v1.20.0 and v2.0+ (and allow for future 2.x.y releases)
* Require terraform-provider-google v1.19.0 or newer. v1.19.0 introduced `network_interface` fields `network_ip` and `nat_ip` to deprecate `address` and `assigned_nat_ip`. Those deprecated fields are removed in terraform-provider-google v2.0
* https://github.com/terraform-providers/terraform-provider-google/releases/tag/v2.0.0