### PR TITLE
Configure etcd on Digital Ocean to listen on private IPv4 address only

### DIFF
--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -1,4 +1,22 @@
 ---
+etcd:
+  version: "3.3.12"
+  name: "${etcd_name}"
+  advertise_client_urls: "https://${etcd_domain}:2379"
+  initial_advertise_peer_urls: "https://${etcd_domain}:2380"
+  listen_client_urls: "https://{PRIVATE_IPV4}:2379"
+  listen_peer_urls: "https://{PRIVATE_IPV4}:2380"
+  listen_metrics_urls: "http://{PRIVATE_IPV4}:2381"
+  initial_cluster: "${etcd_initial_cluster}"
+  strict_reconfig_check: true
+  trusted_ca_file: "/etc/ssl/certs/etcd/server-ca.crt"
+  cert_file: "/etc/ssl/certs/etcd/server.crt"
+  key_file: "/etc/ssl/certs/etcd/server.key"
+  client_cert_auth: true
+  peer_trusted_ca_file: "/etc/ssl/certs/etcd/peer-ca.crt"
+  peer_cert_file: "/etc/ssl/certs/etcd/peer.crt"
+  peer_key_file: "/etc/ssl/certs/etcd/peer.key"
+  peer_client_cert_auth: true
 systemd:
   units:
     - name: etcd-member.service
@@ -7,24 +25,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.3.12"
-            Environment="ETCD_NAME=${etcd_name}"
-            Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
-            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"
-            Environment="ETCD_LISTEN_CLIENT_URLS=https://0.0.0.0:2379"
-            Environment="ETCD_LISTEN_PEER_URLS=https://0.0.0.0:2380"
-            Environment="ETCD_LISTEN_METRICS_URLS=http://0.0.0.0:2381"
-            Environment="ETCD_INITIAL_CLUSTER=${etcd_initial_cluster}"
-            Environment="ETCD_STRICT_RECONFIG_CHECK=true"
             Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-            Environment="ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/server-ca.crt"
-            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd/server.crt"
-            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd/server.key"
-            Environment="ETCD_CLIENT_CERT_AUTH=true"
-            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/peer-ca.crt"
-            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
-            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
-            Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
     - name: docker.service
       enable: true
     - name: locksmithd.service

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -67,6 +67,7 @@ resource "digitalocean_tag" "controllers" {
 data "ct_config" "controller-ignitions" {
   count        = "${var.controller_count}"
   content      = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  platform     = "digitalocean"
   pretty_print = false
   snippets     = ["${var.controller_clc_snippets}"]
 }


### PR DESCRIPTION
This is supposed to slightly improve security.

Since we do not yet know the IP address of the machine when rendering the
template in Terraform, we use Container Linux Config's support for CoreOS
Metadata to resolve it during installation.  This requires that we use the
Container Linux Config `etcd` structure instead of manipulating the
`etcd-member.service` directly, because the Container Linux Config transpiler
will only interpolate `{}` statements in that section, but not in `systemd`
units.

Since the Container Linux Config transpiler currently provides no way to set
the `ETCD_SSL_DIR` which `/usr/lib/coreos/etcd-wrapper` will mount into the
container, we still need to override this environment variable in
`etcd-member.service` ourselves.

See-also: https://github.com/coreos/bugs/issues/2565
Signed-off-by: Dennis Schridde <devurandom@gmx.net>

---

## Testing

I deployed a new Kubernetes cluster on Digital Ocean and saw that:
* `/etc/systemd/system/etcd-member.service.d/20-clct-etcd-member.conf` on the target machine was created as expected, with `--listen-peer-urls="https://${COREOS_DIGITALOCEAN_IPV4_PRIVATE_0}:2380"` and similar
* `netstat -nptul` on that machine shows that `etcd` is listening on the private address only
* the Kubernetes cluster was actually starting according to the system journal
* `kubectl --kubeconfig=assets/auth/kubeconfig get all` on the host used to deploy the cluster outputs `service/kubernetes   ClusterIP   10.3.0.1     <none>        443/TCP   ...` and hence confirms that the cluster is healthy.

---

If the chances of this PR getting merged are good, I could port this change to the other cloud providers.