### PR TITLE
Fix implicit map assignments to be explicit

### DIFF
--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -79,7 +79,7 @@ data "template_file" "etcds" {
   count    = "${var.controller_count}"
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  vars {
+  vars = {
     index        = "${count.index}"
     cluster_name = "${var.cluster_name}"
     dns_zone     = "${var.dns_zone}"

--- a/aws/fedora-atomic/kubernetes/controllers.tf
+++ b/aws/fedora-atomic/kubernetes/controllers.tf
@@ -71,7 +71,7 @@ data "template_file" "etcds" {
   count    = "${var.controller_count}"
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  vars {
+  vars = {
     index        = "${count.index}"
     cluster_name = "${var.cluster_name}"
     dns_zone     = "${var.dns_zone}"

--- a/azure/container-linux/kubernetes/controllers.tf
+++ b/azure/container-linux/kubernetes/controllers.tf
@@ -160,7 +160,7 @@ data "template_file" "etcds" {
   count    = "${var.controller_count}"
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  vars {
+  vars = {
     index        = "${count.index}"
     cluster_name = "${var.cluster_name}"
     dns_zone     = "${var.dns_zone}"

--- a/bare-metal/container-linux/kubernetes/groups.tf
+++ b/bare-metal/container-linux/kubernetes/groups.tf
@@ -5,7 +5,7 @@ resource "matchbox_group" "install" {
 
   profile = "${local.flavor == "flatcar" ? var.cached_install == "true" ? element(matchbox_profile.cached-flatcar-linux-install.*.name, count.index) : element(matchbox_profile.flatcar-install.*.name, count.index) : var.cached_install == "true" ? element(matchbox_profile.cached-container-linux-install.*.name, count.index) : element(matchbox_profile.container-linux-install.*.name, count.index)}"
 
-  selector {
+  selector = {
     mac = "${element(concat(var.controller_macs, var.worker_macs), count.index)}"
   }
 }
@@ -15,7 +15,7 @@ resource "matchbox_group" "controller" {
   name    = "${format("%s-%s", var.cluster_name, element(var.controller_names, count.index))}"
   profile = "${element(matchbox_profile.controllers.*.name, count.index)}"
 
-  selector {
+  selector = {
     mac = "${element(var.controller_macs, count.index)}"
     os  = "installed"
   }
@@ -26,7 +26,7 @@ resource "matchbox_group" "worker" {
   name    = "${format("%s-%s", var.cluster_name, element(var.worker_names, count.index))}"
   profile = "${element(matchbox_profile.workers.*.name, count.index)}"
 
-  selector {
+  selector = {
     mac = "${element(var.worker_macs, count.index)}"
     os  = "installed"
   }

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -34,7 +34,7 @@ data "template_file" "container-linux-install-configs" {
 
   template = "${file("${path.module}/cl/install.yaml.tmpl")}"
 
-  vars {
+  vars = {
     os_flavor           = "${local.flavor}"
     os_channel          = "${local.channel}"
     os_version          = "${var.os_version}"
@@ -77,7 +77,7 @@ data "template_file" "cached-container-linux-install-configs" {
 
   template = "${file("${path.module}/cl/install.yaml.tmpl")}"
 
-  vars {
+  vars = {
     os_flavor           = "${local.flavor}"
     os_channel          = "${local.channel}"
     os_version          = "${var.os_version}"
@@ -159,7 +159,7 @@ data "template_file" "controller-configs" {
 
   template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
 
-  vars {
+  vars = {
     domain_name            = "${element(var.controller_domains, count.index)}"
     etcd_name              = "${element(var.controller_names, count.index)}"
     etcd_initial_cluster   = "${join(",", formatlist("%s=https://%s:2380", var.controller_names, var.controller_domains))}"
@@ -190,7 +190,7 @@ data "template_file" "worker-configs" {
 
   template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
 
-  vars {
+  vars = {
     domain_name            = "${element(var.worker_domains, count.index)}"
     cluster_dns_service_ip = "${module.bootkube.cluster_dns_service_ip}"
     cluster_domain_suffix  = "${var.cluster_domain_suffix}"

--- a/bare-metal/fedora-atomic/kubernetes/groups.tf
+++ b/bare-metal/fedora-atomic/kubernetes/groups.tf
@@ -5,11 +5,11 @@ resource "matchbox_group" "install" {
   name    = "${format("fedora-install-%s", element(concat(var.controller_names, var.worker_names), count.index))}"
   profile = "${element(matchbox_profile.cached-fedora-install.*.name, count.index)}"
 
-  selector {
+  selector = {
     mac = "${element(concat(var.controller_macs, var.worker_macs), count.index)}"
   }
 
-  metadata {
+  metadata = {
     ssh_authorized_key = "${var.ssh_authorized_key}"
   }
 }
@@ -19,7 +19,7 @@ resource "matchbox_group" "controller" {
   name    = "${format("%s-%s", var.cluster_name, element(var.controller_names, count.index))}"
   profile = "${element(matchbox_profile.controllers.*.name, count.index)}"
 
-  selector {
+  selector = {
     mac = "${element(var.controller_macs, count.index)}"
     os  = "installed"
   }
@@ -30,7 +30,7 @@ resource "matchbox_group" "worker" {
   name    = "${format("%s-%s", var.cluster_name, element(var.worker_names, count.index))}"
   profile = "${element(matchbox_profile.workers.*.name, count.index)}"
 
-  selector {
+  selector = {
     mac = "${element(var.worker_macs, count.index)}"
     os  = "installed"
   }

--- a/bare-metal/fedora-atomic/kubernetes/profiles.tf
+++ b/bare-metal/fedora-atomic/kubernetes/profiles.tf
@@ -33,7 +33,7 @@ data "template_file" "install-kickstarts" {
 
   template = "${file("${path.module}/kickstart/fedora-atomic.ks.tmpl")}"
 
-  vars {
+  vars = {
     matchbox_http_endpoint = "${var.matchbox_http_endpoint}"
     atomic_assets_endpoint = "${local.atomic_assets_endpoint}"
     mac                    = "${element(concat(var.controller_macs, var.worker_macs), count.index)}"
@@ -54,7 +54,7 @@ data "template_file" "controller-configs" {
 
   template = "${file("${path.module}/cloudinit/controller.yaml.tmpl")}"
 
-  vars {
+  vars = {
     domain_name            = "${element(var.controller_domains, count.index)}"
     etcd_name              = "${element(var.controller_names, count.index)}"
     etcd_initial_cluster   = "${join(",", formatlist("%s=https://%s:2380", var.controller_names, var.controller_domains))}"
@@ -78,7 +78,7 @@ data "template_file" "worker-configs" {
 
   template = "${file("${path.module}/cloudinit/worker.yaml.tmpl")}"
 
-  vars {
+  vars = {
     domain_name            = "${element(var.worker_domains, count.index)}"
     cluster_dns_service_ip = "${module.bootkube.cluster_dns_service_ip}"
     cluster_domain_suffix  = "${var.cluster_domain_suffix}"

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -93,7 +93,7 @@ data "template_file" "etcds" {
   count    = "${var.controller_count}"
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  vars {
+  vars = {
     index        = "${count.index}"
     cluster_name = "${var.cluster_name}"
     dns_zone     = "${var.dns_zone}"

--- a/digital-ocean/fedora-atomic/kubernetes/controllers.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/controllers.tf
@@ -87,7 +87,7 @@ data "template_file" "etcds" {
   count    = "${var.controller_count}"
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  vars {
+  vars = {
     index        = "${count.index}"
     cluster_name = "${var.cluster_name}"
     dns_zone     = "${var.dns_zone}"

--- a/google-cloud/container-linux/kubernetes/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers.tf
@@ -36,7 +36,7 @@ resource "google_compute_instance" "controllers" {
   machine_type     = "${var.controller_type}"
   min_cpu_platform = "Intel Haswell"
 
-  metadata {
+  metadata = {
     user-data = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
   }
 
@@ -99,7 +99,7 @@ data "template_file" "etcds" {
   count    = "${var.controller_count}"
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  vars {
+  vars = {
     index        = "${count.index}"
     cluster_name = "${var.cluster_name}"
     dns_zone     = "${var.dns_zone}"

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -28,7 +28,7 @@ resource "google_compute_instance_template" "worker" {
   machine_type     = "${var.machine_type}"
   min_cpu_platform = "Intel Haswell"
 
-  metadata {
+  metadata = {
     user-data = "${data.ct_config.worker-ignition.rendered}"
   }
 

--- a/google-cloud/fedora-atomic/kubernetes/controllers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/controllers.tf
@@ -36,7 +36,7 @@ resource "google_compute_instance" "controllers" {
   machine_type     = "${var.controller_type}"
   min_cpu_platform = "Intel Haswell"
 
-  metadata {
+  metadata = {
     user-data = "${element(data.template_file.controller-cloudinit.*.rendered, count.index)}"
   }
 
@@ -91,7 +91,7 @@ data "template_file" "etcds" {
   count    = "${var.controller_count}"
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  vars {
+  vars = {
     index        = "${count.index}"
     cluster_name = "${var.cluster_name}"
     dns_zone     = "${var.dns_zone}"

--- a/google-cloud/fedora-atomic/kubernetes/workers/workers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/workers/workers.tf
@@ -28,7 +28,7 @@ resource "google_compute_instance_template" "worker" {
   machine_type     = "${var.machine_type}"
   min_cpu_platform = "Intel Haswell"
 
-  metadata {
+  metadata = {
     user-data = "${data.template_file.worker-cloudinit.rendered}"
   }
 


### PR DESCRIPTION
* Terraform v0.11 allows explicit or implicit map assignments. In some cases, a mix has been used.
* Terraform v0.12 will require map assignments be explicit (e.g. `key = {}`)