### PR TITLE
Set cpu/memory resources requests/limits for some addons

### DIFF
--- a/addons/cluo/update-agent.yaml
+++ b/addons/cluo/update-agent.yaml
@@ -18,34 +18,41 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
-      containers:
-      - name: update-agent
-        image: quay.io/coreos/container-linux-update-operator:v0.7.0
-        command:
-        - "/bin/update-agent"
-        volumeMounts:
-          - mountPath: /var/run/dbus
-            name: var-run-dbus
-          - mountPath: /etc/coreos
-            name: etc-coreos
-          - mountPath: /usr/share/coreos
-            name: usr-share-coreos
-          - mountPath: /etc/os-release
-            name: etc-os-release
-        env:
-        # read by update-agent as the node name to manage reboots for
-        - name: UPDATE_AGENT_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
       tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: update-agent
+          image: quay.io/coreos/container-linux-update-operator:v0.7.0
+          command:
+            - "/bin/update-agent"
+          env:
+            # read by update-agent as the node name to manage reboots for
+            - name: UPDATE_AGENT_NODE
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+            limits:
+              cpu: 20m
+              memory: 40Mi
+          volumeMounts:
+            - mountPath: /var/run/dbus
+              name: var-run-dbus
+            - mountPath: /etc/coreos
+              name: etc-coreos
+            - mountPath: /usr/share/coreos
+              name: usr-share-coreos
+            - mountPath: /etc/os-release
+              name: etc-os-release
       volumes:
       - name: var-run-dbus
         hostPath:

--- a/addons/cluo/update-operator.yaml
+++ b/addons/cluo/update-operator.yaml
@@ -15,17 +15,25 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
-      containers:
-      - name: update-operator
-        image: quay.io/coreos/container-linux-update-operator:v0.7.0
-        command:
-        - "/bin/update-operator"
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      containers:
+        - name: update-operator
+          image: quay.io/coreos/container-linux-update-operator:v0.7.0
+          command:
+            - "/bin/update-operator"
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+            limits:
+              cpu: 20m
+              memory: 40Mi
+

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -32,11 +32,11 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              memory: 100Mi
               cpu: 100m
+              memory: 100Mi
             limits:
-              memory: 200Mi
               cpu: 200m
+              memory: 200Mi
           volumeMounts:
             - name: config
               mountPath: /etc/grafana

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -28,6 +28,10 @@ spec:
           ports:
             - name: web
               containerPort: 9090
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
           volumeMounts:
             - name: config
               mountPath: /etc/prometheus


### PR DESCRIPTION
* Set resource requests and limits for Grafana and CLUO
* Set resource requests for Prometheus, but allow usage to grow since needs vary widely
* Leave nginx without resource requests/limits for now, its typically well behaved
