### PR TITLE
Remove Haswell minimum CPU platform requirement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ Notable changes between versions.
 
 ## Latest
 
+#### Google Cloud
+
+* Remove Haswell minimum CPU platform requirement ([#439](https://github.com/poseidon/typhoon/pull/439))
+  * Google Cloud API implements `min_cpu_platform` to mean "use exactly this CPU". Revert [#405](https://github.com/poseidon/typhoon/pull/405) added in v1.13.4.
+  * Fix error creating clusters in new regions without Haswell (e.g. europe-west2) ([#438](https://github.com/poseidon/typhoon/issues/438))
+
 ## v1.13.5
 
 * Kubernetes [v1.13.5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.13.md#v1135)

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -119,8 +119,8 @@ variable "cluster_domain_suffix" {
 }
 
 variable "download_protocol" {
-  type = "string"
-  default = "https"
+  type        = "string"
+  default     = "https"
   description = "Protocol iPXE should use to download the kernel and initrd. Defaults to https, which requires iPXE compiled with crypto support. Unused if cached_install is true."
 }
 

--- a/google-cloud/container-linux/kubernetes/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers.tf
@@ -31,10 +31,9 @@ locals {
 resource "google_compute_instance" "controllers" {
   count = "${var.controller_count}"
 
-  name             = "${var.cluster_name}-controller-${count.index}"
-  zone             = "${element(local.zones, count.index)}"
-  machine_type     = "${var.controller_type}"
-  min_cpu_platform = "Intel Haswell"
+  name         = "${var.cluster_name}-controller-${count.index}"
+  zone         = "${element(local.zones, count.index)}"
+  machine_type = "${var.controller_type}"
 
   metadata = {
     user-data = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -23,10 +23,9 @@ resource "google_compute_region_instance_group_manager" "workers" {
 
 # Worker instance template
 resource "google_compute_instance_template" "worker" {
-  name_prefix      = "${var.name}-worker-"
-  description      = "Worker Instance template"
-  machine_type     = "${var.machine_type}"
-  min_cpu_platform = "Intel Haswell"
+  name_prefix  = "${var.name}-worker-"
+  description  = "Worker Instance template"
+  machine_type = "${var.machine_type}"
 
   metadata = {
     user-data = "${data.ct_config.worker-ignition.rendered}"

--- a/google-cloud/fedora-atomic/kubernetes/controllers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/controllers.tf
@@ -31,10 +31,9 @@ locals {
 resource "google_compute_instance" "controllers" {
   count = "${var.controller_count}"
 
-  name             = "${var.cluster_name}-controller-${count.index}"
-  zone             = "${element(local.zones, count.index)}"
-  machine_type     = "${var.controller_type}"
-  min_cpu_platform = "Intel Haswell"
+  name         = "${var.cluster_name}-controller-${count.index}"
+  zone         = "${element(local.zones, count.index)}"
+  machine_type = "${var.controller_type}"
 
   metadata = {
     user-data = "${element(data.template_file.controller-cloudinit.*.rendered, count.index)}"

--- a/google-cloud/fedora-atomic/kubernetes/workers/workers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/workers/workers.tf
@@ -23,10 +23,9 @@ resource "google_compute_region_instance_group_manager" "workers" {
 
 # Worker instance template
 resource "google_compute_instance_template" "worker" {
-  name_prefix      = "${var.name}-worker-"
-  description      = "Worker Instance template"
-  machine_type     = "${var.machine_type}"
-  min_cpu_platform = "Intel Haswell"
+  name_prefix  = "${var.name}-worker-"
+  description  = "Worker Instance template"
+  machine_type = "${var.machine_type}"
 
   metadata = {
     user-data = "${data.template_file.worker-cloudinit.rendered}"


### PR DESCRIPTION
* Google Cloud API implements `min_cpu_platform` to mean "use exactly this CPU"
* Fix error creating clusters in newer regions lacking Haswell platform (e.g. europe-west2) (#438)
* Reverts #405, added in v1.13.4
* Original goal of ignoring old Ivy/Sandy bridge CPUs in older regions will be achieved shortly anyway. Google Cloud is deprecating those CPUs in April 2019
* https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#how_selecting_a_minimum_cpu_platform_works