### PR TITLE
Add ability to load balance TCP applications on AWS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Notable changes between versions.
 
 * Update Calico from v3.6.0 to v3.6.1
 
+#### AWS
+
+* Add ability to load balance TCP applications ([#443](https://github.com/poseidon/typhoon/pull/443))
+  * Output the network load balancer ARN as `nlb_id`
+  * Accept a `worker_target_groups` (ARN) list to which worker instances should be added
+
 #### Google Cloud
 
 * Add ability to load balance TCP/UDP applications ([#442](https://github.com/poseidon/typhoon/pull/442))

--- a/aws/container-linux/kubernetes/outputs.tf
+++ b/aws/container-linux/kubernetes/outputs.tf
@@ -37,6 +37,11 @@ output "kubeconfig" {
 
 # Outputs for custom load balancing
 
+output "nlb_id" {
+  description = "ARN of the Network Load Balancer"
+  value       = "${aws_lb.nlb.id}"
+}
+
 output "worker_target_group_http" {
   description = "ARN of a target group of workers for HTTP traffic"
   value       = "${module.workers.target_group_http}"

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -71,6 +71,12 @@ variable "worker_price" {
   description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
 }
 
+variable "worker_target_groups" {
+  type        = "list"
+  description = "Additional target group ARNs to which worker instances should be added"
+  default     = []
+}
+
 variable "controller_clc_snippets" {
   type        = "list"
   description = "Controller Container Linux Config snippets"

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -11,6 +11,7 @@ module "workers" {
   os_image        = "${var.os_image}"
   disk_size       = "${var.disk_size}"
   spot_price      = "${var.worker_price}"
+  target_groups   = ["${var.worker_target_groups}"]
 
   # configuration
   kubeconfig            = "${module.bootkube.kubeconfig-kubelet}"

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -64,6 +64,12 @@ variable "spot_price" {
   description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
 }
 
+variable "target_groups" {
+  type        = "list"
+  description = "Additional target group ARNs to which instances should be added"
+  default     = []
+}
+
 variable "clc_snippets" {
   type        = "list"
   description = "Container Linux Config snippets"

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -19,6 +19,7 @@ resource "aws_autoscaling_group" "workers" {
   target_group_arns = [
     "${aws_lb_target_group.workers-http.id}",
     "${aws_lb_target_group.workers-https.id}",
+    "${var.target_groups}",
   ]
 
   lifecycle {

--- a/docs/cl/aws.md
+++ b/docs/cl/aws.md
@@ -242,6 +242,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | disk_size | Size of the EBS volume in GB | "40" | "100" |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | "0" (i.e. auto) | "400" |
+| worker_target_groups | Target group ARNs to which worker instances should be added | [] | ["${aws_lb_target_group.app.id}"] |
 | worker_price | Spot price in USD for workers. Leave as default empty string for regular on-demand instances | "" | "0.10" |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |


### PR DESCRIPTION
* Add ability to load balance TCP applications (e.g. NodePort)
* Output the network load balancer ARN as `nlb_id`
* Accept a `worker_target_groups` (ARN) list to which worker instances should be added
* AWS NLBs and target groups don't support UDP

