### PR TITLE
Harden internal firewall rules on DigitalOcean

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@ Notable changes between versions.
   * Output the network load balancer ARN as `nlb_id`
   * Accept a `worker_target_groups` (ARN) list to which worker instances should be added
 
+#### DigitalOcean
+
+* Harden internal (node-to-node) firewall rules to align with other platforms
+* Output `controller_tag` and `worker_tag` to simplify custom firewall rule creation
+
 #### Google Cloud
 
 * Add ability to load balance TCP/UDP applications ([#442](https://github.com/poseidon/typhoon/pull/442))

--- a/digital-ocean/container-linux/kubernetes/network.tf
+++ b/digital-ocean/container-linux/kubernetes/network.tf
@@ -3,7 +3,7 @@ resource "digitalocean_firewall" "rules" {
 
   tags = ["${var.cluster_name}-controller", "${var.cluster_name}-worker"]
 
-  # allow ssh, apiserver, http/https ingress, and peer-to-peer traffic
+  # allow ssh, internal flannel, internal node-exporter, internal kubelet
   inbound_rule = [
     {
       protocol         = "tcp"
@@ -11,28 +11,18 @@ resource "digitalocean_firewall" "rules" {
       source_addresses = ["0.0.0.0/0", "::/0"]
     },
     {
-      protocol         = "tcp"
-      port_range       = "80"
-      source_addresses = ["0.0.0.0/0", "::/0"]
-    },
-    {
-      protocol         = "tcp"
-      port_range       = "443"
-      source_addresses = ["0.0.0.0/0", "::/0"]
-    },
-    {
-      protocol         = "tcp"
-      port_range       = "6443"
-      source_addresses = ["0.0.0.0/0", "::/0"]
-    },
-    {
       protocol    = "udp"
-      port_range  = "1-65535"
+      port_range  = "8472"
       source_tags = ["${digitalocean_tag.controllers.name}", "${digitalocean_tag.workers.name}"]
     },
     {
       protocol    = "tcp"
-      port_range  = "1-65535"
+      port_range  = "9100"
+      source_tags = ["${digitalocean_tag.workers.name}"]
+    },
+    {
+      protocol    = "tcp"
+      port_range  = "10250"
       source_tags = ["${digitalocean_tag.controllers.name}", "${digitalocean_tag.workers.name}"]
     },
   ]
@@ -56,3 +46,54 @@ resource "digitalocean_firewall" "rules" {
     },
   ]
 }
+
+resource "digitalocean_firewall" "controllers" {
+  name = "${var.cluster_name}-controllers"
+
+  tags = ["${var.cluster_name}-controller"]
+
+  # etcd, kube-apiserver, kubelet
+  inbound_rule = [
+    {
+      protocol         = "tcp"
+      port_range       = "2379-2380"
+      source_tags = ["${digitalocean_tag.controllers.name}"]
+    },
+    {
+      protocol         = "tcp"
+      port_range       = "2381"
+      source_tags = ["${digitalocean_tag.workers.name}"]
+    },
+    {
+      protocol         = "tcp"
+      port_range       = "6443"
+      source_addresses = ["0.0.0.0/0", "::/0"]
+    },
+  ]
+}
+
+resource "digitalocean_firewall" "workers" {
+  name = "${var.cluster_name}-workers"
+
+  tags = ["${var.cluster_name}-worker"]
+
+  # allow HTTP/HTTPS ingress
+  inbound_rule = [
+    {
+      protocol         = "tcp"
+      port_range       = "80"
+      source_addresses = ["0.0.0.0/0", "::/0"]
+    },
+    {
+      protocol         = "tcp"
+      port_range       = "443"
+      source_addresses = ["0.0.0.0/0", "::/0"]
+    },
+    {
+      protocol = "tcp"
+      port_range = "10254"
+      source_addresses = ["0.0.0.0/0"]
+    },
+  ]
+}
+

--- a/digital-ocean/container-linux/kubernetes/outputs.tf
+++ b/digital-ocean/container-linux/kubernetes/outputs.tf
@@ -26,3 +26,16 @@ output "workers_ipv4" {
 output "workers_ipv6" {
   value = ["${digitalocean_droplet.workers.*.ipv6_address}"]
 }
+
+# Outputs for custom firewalls
+
+output "controller_tag" {
+  description = "Tag applied to controller droplets"
+  value = "${digitalocean_tag.controllers.name}"
+}
+
+output "worker_tag" {
+  description = "Tag applied to worker droplets"
+  value = "${digitalocean_tag.workers.name}"
+}
+


### PR DESCRIPTION
* Define firewall rules on DO to match rules used on AWS, GCP, Azure
* Output `controller_tag` and `worker_tag` to simplify custom firewall rule creation
