### PR TITLE
Update kube-state-metrics from v1.5.0 to v1.6.0-rc.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@ Notable changes between versions.
 
 #### Addons
 
+* Update kube-state-metrics from v1.5.0 to v1.6.0-rc.0 ([#449](https://github.com/poseidon/typhoon/pull/449))
 * Update Grafana from v6.1.1 to v6.1.3
-
 
 ## v1.14.0
 

--- a/addons/prometheus/exporters/kube-state-metrics/cluster-role.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/cluster-role.yaml
@@ -27,6 +27,7 @@ rules:
   - daemonsets
   - deployments
   - replicasets
+  - ingresses
   verbs:
   - list
   - watch

--- a/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0-rc.0
         ports:
           - name: metrics
             containerPort: 8080


### PR DESCRIPTION
* Adds a metrics collector for Ingress resources and other improvements
* https://github.com/kubernetes/kube-state-metrics/pull/640
* https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.6.0-rc.0

