### PR TITLE
Nginx ingress addon: remove unused 'health' port in deployment

### DIFF
--- a/addons/nginx-ingress/aws/deployment.yaml
+++ b/addons/nginx-ingress/aws/deployment.yaml
@@ -45,9 +45,6 @@ spec:
             - name: https
               containerPort: 443
               hostPort: 443
-            - name: health
-              containerPort: 10254
-              hostPort: 10254
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/addons/nginx-ingress/azure/deployment.yaml
+++ b/addons/nginx-ingress/azure/deployment.yaml
@@ -45,9 +45,6 @@ spec:
             - name: https
               containerPort: 443
               hostPort: 443
-            - name: health
-              containerPort: 10254
-              hostPort: 10254
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/addons/nginx-ingress/bare-metal/deployment.yaml
+++ b/addons/nginx-ingress/bare-metal/deployment.yaml
@@ -41,8 +41,6 @@ spec:
               containerPort: 80
             - name: https
               containerPort: 443
-            - name: health
-              containerPort: 10254
           livenessProbe:
             httpGet:
               path: /healthz

--- a/addons/nginx-ingress/google-cloud/deployment.yaml
+++ b/addons/nginx-ingress/google-cloud/deployment.yaml
@@ -45,9 +45,6 @@ spec:
             - name: https
               containerPort: 443
               hostPort: 443
-            - name: health
-              containerPort: 10254
-              hostPort: 10254
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
It has no real purpose and it's not defined in the upstream resource
https://github.com/kubernetes/ingress-nginx/blob/master/deploy/with-rbac.yaml
either.
