### PR TITLE
Revert "Update kube-state-metrics from v1.5.0 to v1.6.0-rc.0"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@ Notable changes between versions.
 
 #### Addons
 
-* Update kube-state-metrics from v1.5.0 to v1.6.0-rc.0 ([#449](https://github.com/poseidon/typhoon/pull/449))
 * Update Grafana from v6.1.1 to v6.1.3
+
 
 ## v1.14.0
 

--- a/addons/prometheus/exporters/kube-state-metrics/cluster-role.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/cluster-role.yaml
@@ -27,7 +27,6 @@ rules:
   - daemonsets
   - deployments
   - replicasets
-  - ingresses
   verbs:
   - list
   - watch

--- a/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.6.0-rc.0
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         ports:
           - name: metrics
             containerPort: 8080


### PR DESCRIPTION
* This reverts commit 6e5d66cf666a2700ad3e540698a6e243651b96d9
* kube-state-metrics v1.6.0-rc.0 fires KubeDeploymentReplicasMismatch alerts where its own Deployment doesn't have replicas available, (kube_deployment_status_replicas_available) even though all replicas are available according to kubectl inspection
* This problem was present even with the CSR ClusterRole fix (https://github.com/kubernetes/kube-state-metrics/pull/717)