### PR TITLE
TF 0.12: module source: explicit usage of relative path

### DIFF
--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -1,5 +1,5 @@
 module "workers" {
-  source = "workers"
+  source = "./workers"
   name   = "${var.cluster_name}"
 
   # AWS

--- a/aws/fedora-atomic/kubernetes/workers.tf
+++ b/aws/fedora-atomic/kubernetes/workers.tf
@@ -1,5 +1,5 @@
 module "workers" {
-  source = "workers"
+  source = "./workers"
   name   = "${var.cluster_name}"
 
   # AWS

--- a/azure/container-linux/kubernetes/workers.tf
+++ b/azure/container-linux/kubernetes/workers.tf
@@ -1,5 +1,5 @@
 module "workers" {
-  source = "workers"
+  source = "./workers"
   name   = "${var.cluster_name}"
 
   # Azure

--- a/google-cloud/container-linux/kubernetes/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers.tf
@@ -1,5 +1,5 @@
 module "workers" {
-  source       = "workers"
+  source       = "./workers"
   name         = "${var.cluster_name}"
   cluster_name = "${var.cluster_name}"
 

--- a/google-cloud/fedora-atomic/kubernetes/workers.tf
+++ b/google-cloud/fedora-atomic/kubernetes/workers.tf
@@ -1,5 +1,5 @@
 module "workers" {
-  source       = "workers"
+  source       = "./workers"
   name         = "${var.cluster_name}"
   cluster_name = "${var.cluster_name}"
 


### PR DESCRIPTION
With TF 0.11 it is strongly encouraged to use "./" prefix in module
path to indicate that the address is a relative filesystem
path. See [1]

With TF 0.12 this is now required. See [2].

This patch adds the "./" prefix where needed to ensure compatibility
with TF 0.12.

[1] https://www.terraform.io/docs/modules/sources.html#local-paths
[2] https://github.com/hashicorp/terraform/issues/19745