### PR TITLE
Nginx RBAC: sync role definition with upstream

### DIFF
--- a/addons/nginx-ingress/aws/rbac/role.yaml
+++ b/addons/nginx-ingress/aws/rbac/role.yaml
@@ -37,5 +37,3 @@ rules:
       - endpoints
     verbs:
       - get
-      - create
-      - update

--- a/addons/nginx-ingress/azure/rbac/role.yaml
+++ b/addons/nginx-ingress/azure/rbac/role.yaml
@@ -37,5 +37,3 @@ rules:
       - endpoints
     verbs:
       - get
-      - create
-      - update

--- a/addons/nginx-ingress/bare-metal/rbac/role.yaml
+++ b/addons/nginx-ingress/bare-metal/rbac/role.yaml
@@ -37,5 +37,3 @@ rules:
       - endpoints
     verbs:
       - get
-      - create
-      - update

--- a/addons/nginx-ingress/digital-ocean/rbac/role.yaml
+++ b/addons/nginx-ingress/digital-ocean/rbac/role.yaml
@@ -37,5 +37,3 @@ rules:
       - endpoints
     verbs:
       - get
-      - create
-      - update

--- a/addons/nginx-ingress/google-cloud/rbac/role.yaml
+++ b/addons/nginx-ingress/google-cloud/rbac/role.yaml
@@ -37,5 +37,3 @@ rules:
       - endpoints
     verbs:
       - get
-      - create
-      - update


### PR DESCRIPTION
The "Ingress" role doesn't need to create/update endpoints as per
the upstream definition [1]. See also this commit [2]

[1]: https://github.com/kubernetes/ingress-nginx/blob/master/deploy/mandatory.yaml#L147
[2]: https://github.com/kubernetes/ingress-nginx/commit/a9168f276e97e2922ebefb5a8a476aef659abd6a#diff-ed87be01cf41ec539ce3a7542634323aL104