### PR TITLE
Fix race condition in DigitalOcean cluster create

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@ Notable changes between versions.
 
 * Only set internal VXLAN rules when `networking` is flannel (default: calico)
 
+#### DigitalOcean
+
+* Add explicit ordering between firewall rule creation and secure copying Kubelet credentials ([#469](https://github.com/poseidon/typhoon/pull/469))
+  * Fix race scenario if copies to nodes were before rule creation, blocking cluster creation
+
 #### Addons
 
 * Update Prometheus from v2.8.1 to v2.9.2

--- a/digital-ocean/container-linux/kubernetes/ssh.tf
+++ b/digital-ocean/container-linux/kubernetes/ssh.tf
@@ -1,6 +1,9 @@
 # Secure copy etcd TLS assets and kubeconfig to controllers. Activates kubelet.service
 resource "null_resource" "copy-controller-secrets" {
   count = "${var.controller_count}"
+  depends_on = [
+    "digitalocean_firewall.rules",
+  ]
 
   connection {
     type    = "ssh"

--- a/digital-ocean/fedora-atomic/kubernetes/ssh.tf
+++ b/digital-ocean/fedora-atomic/kubernetes/ssh.tf
@@ -1,6 +1,9 @@
 # Secure copy etcd TLS assets and kubeconfig to controllers. Activates kubelet.service
 resource "null_resource" "copy-controller-secrets" {
   count = "${var.controller_count}"
+  depends_on = [
+    "digitalocean_firewall.rules",
+  ]
 
   connection {
     type    = "ssh"


### PR DESCRIPTION
* DigitalOcean clusters must secure copy a kubeconfig to worker nodes, but Terraform could decide to try copying before firewall rules have been added to allow SSH access.
* Add an explicit dependency on adding firewall rules first
