### PR TITLE
Replace deprecated `azurerm_autoscale_setting`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Notable changes between versions.
 
 * Fix trailing slash in terraform-render-bootkube version ([#479](https://github.com/poseidon/typhoon/pull/479))
 
+#### Azure
+
+* Replace `azurerm_autoscale_setting` with `azurerm_monitor_autoscale_setting` ([#482](https://github.com/poseidon/typhoon/pull/482))
+  * Require `terraform-provider-azurerm` v1.22+ (action required)
+
 #### Addons
 
 * Update Prometheus from v2.9.2 to v2.10.0

--- a/azure/container-linux/kubernetes/require.tf
+++ b/azure/container-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "azurerm" {
-  version = "~> 1.21"
+  version = "~> 1.22"
 }
 
 provider "local" {

--- a/azure/container-linux/kubernetes/workers/workers.tf
+++ b/azure/container-linux/kubernetes/workers/workers.tf
@@ -73,7 +73,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
 }
 
 # Scale up or down to maintain desired number, tolerating deallocations.
-resource "azurerm_autoscale_setting" "workers" {
+resource "azurerm_monitor_autoscale_setting" "workers" {
   resource_group_name = "${var.resource_group_name}"
 
   name     = "${var.name}-maintain-desired"


### PR DESCRIPTION
* Fix Terraform provider azure warning about `azurerm_autoscale_setting`
* Require terraform-provider-azure v1.22+ version that introduces the new `azurerm_monitor_autoscale_setting` resource
* https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/CHANGELOG.md#1220-february-11-2019