### PR TITLE
Rename worker pool modules' count variable to worker_count

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,22 @@ Notable changes between versions.
   * Add `ready` plugin to improve readinessProbe
 * Fix trailing slash in terraform-render-bootkube version ([#479](https://github.com/poseidon/typhoon/pull/479))
 
+### AWS
+
+* Rename `worker` pool module `count` variable to `worker_count` ([#485](https://github.com/poseidon/typhoon/pull/485)) (action required)
+  * `count` will become a reserved variable name in Terraform v0.12
+
 #### Azure
 
 * Replace `azurerm_autoscale_setting` with `azurerm_monitor_autoscale_setting` ([#482](https://github.com/poseidon/typhoon/pull/482))
   * Require `terraform-provider-azurerm` v1.22+ (action required)
+* Rename `worker` pool module `count` variable to `worker_count` ([#485](https://github.com/poseidon/typhoon/pull/485)) (action required)
+  * `count` will become a reserved variable name in Terraform v0.12
+
+### Google Cloud
+
+* Rename `worker` pool module `count` variable to `worker_count` ([#485](https://github.com/poseidon/typhoon/pull/485)) (action required)
+  * `count` will become a reserved variable name in Terraform v0.12
 
 #### Addons
 

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -6,7 +6,7 @@ module "workers" {
   vpc_id          = "${aws_vpc.network.id}"
   subnet_ids      = ["${aws_subnet.public.*.id}"]
   security_groups = ["${aws_security_group.worker.id}"]
-  count           = "${var.worker_count}"
+  worker_count    = "${var.worker_count}"
   instance_type   = "${var.worker_type}"
   os_image        = "${var.os_image}"
   disk_size       = "${var.disk_size}"

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -22,7 +22,7 @@ variable "security_groups" {
 
 # instances
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of instances"

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -3,9 +3,9 @@ resource "aws_autoscaling_group" "workers" {
   name = "${var.name}-worker ${aws_launch_configuration.worker.name}"
 
   # count
-  desired_capacity          = "${var.count}"
-  min_size                  = "${var.count}"
-  max_size                  = "${var.count + 2}"
+  desired_capacity          = "${var.worker_count}"
+  min_size                  = "${var.worker_count}"
+  max_size                  = "${var.worker_count + 2}"
   default_cooldown          = 30
   health_check_grace_period = 30
 

--- a/azure/container-linux/kubernetes/workers.tf
+++ b/azure/container-linux/kubernetes/workers.tf
@@ -9,7 +9,7 @@ module "workers" {
   security_group_id       = "${azurerm_network_security_group.worker.id}"
   backend_address_pool_id = "${azurerm_lb_backend_address_pool.worker.id}"
 
-  count    = "${var.worker_count}"
+  worker_count    = "${var.worker_count}"
   vm_type  = "${var.worker_type}"
   os_image = "${var.os_image}"
   priority = "${var.worker_priority}"

--- a/azure/container-linux/kubernetes/workers/variables.tf
+++ b/azure/container-linux/kubernetes/workers/variables.tf
@@ -32,7 +32,7 @@ variable "backend_address_pool_id" {
 
 # instances
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of instances"

--- a/azure/container-linux/kubernetes/workers/workers.tf
+++ b/azure/container-linux/kubernetes/workers/workers.tf
@@ -15,7 +15,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
   sku {
     name     = "${var.vm_type}"
     tier     = "standard"
-    capacity = "${var.count}"
+    capacity = "${var.worker_count}"
   }
 
   # boot
@@ -87,9 +87,9 @@ resource "azurerm_monitor_autoscale_setting" "workers" {
     name = "default"
 
     capacity {
-      minimum = "${var.count}"
-      default = "${var.count}"
-      maximum = "${var.count}"
+      minimum = "${var.worker_count}"
+      default = "${var.worker_count}"
+      maximum = "${var.worker_count}"
     }
   }
 }

--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -33,7 +33,7 @@ module "tempest-worker-pool" {
   ssh_authorized_key = "${var.ssh_authorized_key}"
 
   # optional
-  count         = 2
+  worker_count  = 2
   instance_type = "m5.large"
   os_image      = "coreos-beta"
 }
@@ -66,7 +66,7 @@ The AWS internal `workers` module supports a number of [variables](https://githu
 
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
-| count | Number of instances | 1 | 3 |
+| worker_count | Number of instances | 1 | 3 |
 | instance_type | EC2 instance type | "t3.small" | "t3.medium" |
 | os_image | AMI channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha |
 | disk_size | Size of the disk in GB | 40 | 100 |
@@ -101,9 +101,9 @@ module "ramius-worker-pool" {
   ssh_authorized_key = "${var.ssh_authorized_key}"
 
   # optional
-  count    = 2
-  vm_type  = "Standard_F4"
-  priority = "Low"
+  worker_count = 2
+  vm_type      = "Standard_F4"
+  priority     = "Low"
 }
 ```
 
@@ -136,7 +136,7 @@ The Azure internal `workers` module supports a number of [variables](https://git
 
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
-| count | Number of instances | 1 | 3 |
+| worker_count | Number of instances | 1 | 3 |
 | vm_type | Machine type for instances | "Standard_F1" | See below |
 | os_image | Channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha |
 | priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | Regular | Low |
@@ -169,7 +169,7 @@ module "yavin-worker-pool" {
   ssh_authorized_key = "${var.ssh_authorized_key}"
   
   # optional
-  count        = 2
+  worker_count = 2
   machine_type = "n1-standard-16"
   os_image     = "coreos-beta"
   preemptible  = true
@@ -215,7 +215,7 @@ Check the list of regions [docs](https://cloud.google.com/compute/docs/regions-z
 
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
-| count | Number of instances | 1 | 3 |
+| worker_count | Number of instances | 1 | 3 |
 | machine_type | Compute instance machine type | "n1-standard-1" | See below |
 | os_image | Container Linux image for compute instances | "coreos-stable" | "coreos-alpha", "coreos-beta" |
 | disk_size | Size of the disk in GB | 40 | 100 |

--- a/google-cloud/container-linux/kubernetes/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers.tf
@@ -6,7 +6,7 @@ module "workers" {
   # GCE
   region       = "${var.region}"
   network      = "${google_compute_network.network.name}"
-  count        = "${var.worker_count}"
+  worker_count        = "${var.worker_count}"
   machine_type = "${var.worker_type}"
   os_image     = "${var.os_image}"
   disk_size    = "${var.disk_size}"

--- a/google-cloud/container-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/workers/variables.tf
@@ -22,7 +22,7 @@ variable "network" {
 
 # instances
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of worker compute instances the instance group should manage"

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -8,7 +8,7 @@ resource "google_compute_region_instance_group_manager" "workers" {
   instance_template  = "${google_compute_instance_template.worker.self_link}"
   region             = "${var.region}"
 
-  target_size  = "${var.count}"
+  target_size  = "${var.worker_count}"
   target_pools = ["${google_compute_target_pool.workers.self_link}"]
 
   named_port {


### PR DESCRIPTION
* This change affects users who use worker pools on AWS, GCP, or Azure with a Container Linux derivative
* Rename worker pool modules' `count` variable to `worker_count`, because `count` will be a reserved variable name in Terraform v0.12
