### PR TITLE
Change DO worker_type default from s-1vcpu-1gb to s-1vcpu-2gb

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Notable changes between versions.
 #### DigitalOcean
 
 * Require `terraform-provider-digitalocean` v1.3+ to support Terraform v0.12 (action required)
+* Change the default `worker_type` from `s-1vcpu1-1gb` to `s-1vcpu-2gb`
 
 #### Google Cloud
 

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -37,8 +37,8 @@ variable "controller_type" {
 
 variable "worker_type" {
   type        = string
-  default     = "s-1vcpu-1gb"
-  description = "Droplet type for workers (e.g. s-1vcpu-1gb, s-1vcpu-2gb, s-2vcpu-2gb)"
+  default     = "s-1vcpu-2gb"
+  description = "Droplet type for workers (e.g. s-1vcpu-2gb, s-2vcpu-2gb)"
 }
 
 variable "image" {

--- a/docs/cl/digital-ocean.md
+++ b/docs/cl/digital-ocean.md
@@ -220,7 +220,7 @@ Digital Ocean requires the SSH public key be uploaded to your account, so you ma
 | controller_count | Number of controllers (i.e. masters) | 1 | 1 |
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | Droplet type for controllers | s-2vcpu-2gb | s-2vcpu-2gb, s-2vcpu-4gb, s-4vcpu-8gb, ... |
-| worker_type | Droplet type for workers | s-1vcpu-1gb | s-1vcpu-1gb, s-1vcpu-2gb, s-2vcpu-2gb, ... |
+| worker_type | Droplet type for workers | s-1vcpu-2gb | s-1vcpu-2gb, s-2vcpu-2gb, ... |
 | image | Container Linux image for instances | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |


### PR DESCRIPTION
* On DigitalOcean, `s-1vcpu-1gb` worker nodes have 1GB of RAM, which is too small as a default, even for most cost constrained developers