### PR TITLE
Update Grafana from v6.2.1 to v6.2.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,10 @@ Notable changes between versions.
 
 * Require `terraform-provider-google` v2.5+ to support Terraform v0.12 (action required)
 
+#### Addons
+
+* Update Grafana from v6.2.1 to v6.2.2
+
 ## v1.14.3
 
 * Kubernetes [v1.14.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#v1143)

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:6.2.1
+          image: grafana/grafana:6.2.2
           env:
             - name: GF_PATHS_CONFIG
               value: "/etc/grafana/custom.ini"


### PR DESCRIPTION
* https://github.com/grafana/grafana/releases/tag/v6.2.2
