### PR TITLE
Improve apiserver backend service zone spanning on GCP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Notable changes between versions.
 
 * Update Calico from v3.7.3 to [v3.7.4](https://docs.projectcalico.org/v3.7/release-notes/)
 
+#### Google Cloud
+
+* Allow controller nodes to span more than 3 zones if available in a region ([#504](https://github.com/poseidon/typhoon/pull/504))
+* Eliminate extraneous controller instance groups in single-controller clusters ([#504](https://github.com/poseidon/typhoon/pull/504))
+
 #### Addons
 
 * Update Grafana from v6.2.4 to v6.2.5

--- a/google-cloud/container-linux/kubernetes/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers.tf
@@ -20,9 +20,7 @@ data "google_compute_zones" "all" {
 }
 
 locals {
-  # TCP proxy load balancers require a fixed number of zonal backends. Spread
-  # controllers over up to 3 zones, since all GCP regions have at least 3.
-  zones = slice(data.google_compute_zones.all.names, 0, 3)
+  zones = data.google_compute_zones.all.names
 
   controllers_ipv4_public = google_compute_instance.controllers.*.network_interface.0.access_config.0.nat_ip
 }


### PR DESCRIPTION
* google_compute_backend_services use nested blocks to define backends (instance groups heterogeneous controllers)
* Use Terraform v0.12.x dynamic blocks so the apiserver backend service can refer to (up to zone-many) controller instance groups
* Previously, with Terraform v0.11.x, the apiserver backend service had to list a fixed set of backends to span controller nodes across zones in multi-controller setups. 3 backends were used because each
GCP region offered at least 3 zones. Single-controller clusters had the cosmetic ugliness of unused instance groups
* Allow controllers to span more than 3 zones in a region, if the region offers more than 3 zones (e.g. us-central1)

Related:

* https://www.terraform.io/docs/providers/google/r/compute_backend_service.html
* https://www.terraform.io/docs/configuration/expressions.html#dynamic-blocks