### PR TITLE
Increase GCP network deletion timeout from 4m to 6m

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Notable changes between versions.
 
 * Allow controller nodes to span more than 3 zones if available in a region ([#504](https://github.com/poseidon/typhoon/pull/504))
 * Eliminate extraneous controller instance groups in single-controller clusters ([#504](https://github.com/poseidon/typhoon/pull/504))
+* Raise network deletion timeout from 4m to 6m ([#505](https://github.com/poseidon/typhoon/pull/505))
 
 #### Addons
 

--- a/google-cloud/container-linux/kubernetes/network.tf
+++ b/google-cloud/container-linux/kubernetes/network.tf
@@ -2,6 +2,10 @@ resource "google_compute_network" "network" {
   name                    = var.cluster_name
   description             = "Network for the ${var.cluster_name} cluster"
   auto_create_subnetworks = true
+
+  timeouts {
+    delete = "6m"
+  }
 }
 
 resource "google_compute_firewall" "allow-ssh" {


### PR DESCRIPTION
* Raise the network deletion timeout to 6m to ensure apply only needs to be run once to remove a cluster. Removal of a Google Cloud cluster often required 2 runs of `terraform apply` because network resource deletes timeout after 4m. 
* Fix a GCP errata item https://github.com/poseidon/typhoon/wiki/Errata
