### PR TITLE
Run kube-apiserver with lower privilege user (nobody)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Notable changes between versions.
 ## Latest
 
 * Update Calico from v3.7.3 to [v3.7.4](https://docs.projectcalico.org/v3.7/release-notes/)
+* Run `kube-apiserver` with lower privilege user (nobody) ([#506](https://github.com/poseidon/typhoon/pull/506))
 
 #### Google Cloud
 

--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=95f6fc7fa5f6cedb1a887da3a823b0eeffa40f68"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4caca47776dcff440c9f50445fbc8ec5b11728f4"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/container-linux/kubernetes/bootkube.tf
+++ b/azure/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=95f6fc7fa5f6cedb1a887da3a823b0eeffa40f68"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4caca47776dcff440c9f50445fbc8ec5b11728f4"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=95f6fc7fa5f6cedb1a887da3a823b0eeffa40f68"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4caca47776dcff440c9f50445fbc8ec5b11728f4"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=95f6fc7fa5f6cedb1a887da3a823b0eeffa40f68"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4caca47776dcff440c9f50445fbc8ec5b11728f4"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/container-linux/kubernetes/apiserver.tf
+++ b/google-cloud/container-linux/kubernetes/apiserver.tf
@@ -64,7 +64,7 @@ resource "google_compute_instance_group" "controllers" {
 
   named_port {
     name = "apiserver"
-    port = "443"
+    port = "6443"
   }
 
   # add instances in the zone into the instance group
@@ -87,7 +87,7 @@ resource "google_compute_health_check" "apiserver" {
   unhealthy_threshold = 3
 
   tcp_health_check {
-    port = "443"
+    port = "6443"
   }
 }
 

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=95f6fc7fa5f6cedb1a887da3a823b0eeffa40f68"
+  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=4caca47776dcff440c9f50445fbc8ec5b11728f4"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -15,6 +15,6 @@ module "bootkube" {
   enable_aggregation    = var.enable_aggregation
 
   // temporary
-  apiserver_port = 443
+  external_apiserver_port = 443
 }
 

--- a/google-cloud/container-linux/kubernetes/network.tf
+++ b/google-cloud/container-linux/kubernetes/network.tf
@@ -54,7 +54,7 @@ resource "google_compute_firewall" "allow-apiserver" {
 
   allow {
     protocol = "tcp"
-    ports    = [443]
+    ports    = [6443]
   }
 
   source_ranges = ["0.0.0.0/0"]


### PR DESCRIPTION
* Run kube-apiserver as a non-root user (nobody). User no longer needs to bind low number ports.
* On most platforms, the `kube-apiserver` load balancer listens on 6443 and fronts controllers with kube-apiserver pods using port 6443. Google Cloud TCP proxy load balancers cannot listen on 6443. However, GCP's load balancer can be made to listen on 443, while kube-apiserver uses 6443 across all platforms.

Related: https://github.com/poseidon/terraform-render-bootkube/pull/142 https://github.com/poseidon/terraform-render-bootkube/pull/141