### PR TITLE
Update Prometheus from v2.10.0 to v2.11.0-rc.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Notable changes between versions.
 
 #### Addons
 
+* Update Prometheus from v2.10.0 to v2.11.0-rc.0
 * Update Grafana from v6.2.4 to v6.2.5
 
 ## v1.15.0

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: quay.io/prometheus/prometheus:v2.10.0
+          image: quay.io/prometheus/prometheus:v2.11.0-rc.0
           args:
             - --web.listen-address=0.0.0.0:9090
             - --config.file=/etc/prometheus/prometheus.yaml


### PR DESCRIPTION
* https://github.com/prometheus/prometheus/releases/tag/v2.11.0-rc.0
