### PR TITLE
Relax terraform-provider-ct version constraint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Notable changes between versions.
 * Upgrade Calico from v3.7.3 to [v3.8.0](https://docs.projectcalico.org/v3.8/release-notes/)
   * Enable CNI `bandwidth` plugin for [traffic shaping](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-traffic-shaping)
 * Run `kube-apiserver` with lower privilege user (nobody) ([#506](https://github.com/poseidon/typhoon/pull/506))
+* Relax `terraform-provider-ct` version constraint (v0.3.2+)
+  * Allow provider versions below v1.0.0 (e.g. upgrading to v0.4)
 
 #### Google Cloud
 

--- a/aws/container-linux/kubernetes/versions.tf
+++ b/aws/container-linux/kubernetes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = "~> 0.12.0"
   required_providers {
     aws      = "~> 2.7"
-    ct       = "~> 0.3.2"
+    ct       = "~> 0.3"
     template = "~> 2.1"
     null     = "~> 2.1"
   }

--- a/azure/container-linux/kubernetes/versions.tf
+++ b/azure/container-linux/kubernetes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = "~> 0.12.0"
   required_providers {
     azurerm  = "~> 1.27"
-    ct       = "~> 0.3.2"
+    ct       = "~> 0.3"
     template = "~> 2.1"
     null     = "~> 2.1"
   }

--- a/bare-metal/container-linux/kubernetes/versions.tf
+++ b/bare-metal/container-linux/kubernetes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = "~> 0.12.0"
   required_providers {
     matchbox = "~> 0.3.0"
-    ct       = "~> 0.3.2"
+    ct       = "~> 0.3"
     template = "~> 2.1"
     null     = "~> 2.1"
   }

--- a/digital-ocean/container-linux/kubernetes/versions.tf
+++ b/digital-ocean/container-linux/kubernetes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = "~> 0.12.0"
   required_providers {
     digitalocean = "~> 1.3"
-    ct           = "~> 0.3.2"
+    ct           = "~> 0.3"
     template     = "~> 2.1"
     null         = "~> 2.1"
   }

--- a/google-cloud/container-linux/kubernetes/versions.tf
+++ b/google-cloud/container-linux/kubernetes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = "~> 0.12.0"
   required_providers {
     google       = "~> 2.5"
-    ct           = "~> 0.3.2"
+    ct           = "~> 0.3"
     template     = "~> 2.1"
     null         = "~> 2.1"
   }


### PR DESCRIPTION
* Allow updating terraform-provider-ct to any release beyond v0.3.2, but below v1.0. This relaxes the prior constraint that allowed only v0.3.y provider versions