### PR TITLE
Adds variable for cloud provider in bootkube

### DIFF
--- a/aws/container-linux/kubernetes/bootkube.tf
+++ b/aws/container-linux/kubernetes/bootkube.tf
@@ -13,5 +13,6 @@ module "bootkube" {
   cluster_domain_suffix = var.cluster_domain_suffix
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
+  cloud_provider        = var.cloud_provider
 }
 

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -154,3 +154,8 @@ variable "enable_aggregation" {
   default = "false"
 }
 
+variable "cloud_provider" {
+  description = "The provider for cloud services (empty string for no provider)"
+  type        = string
+  default     = "aws"
+}

--- a/azure/container-linux/kubernetes/bootkube.tf
+++ b/azure/container-linux/kubernetes/bootkube.tf
@@ -19,5 +19,6 @@ module "bootkube" {
   cluster_domain_suffix = var.cluster_domain_suffix
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
+  cloud_provider        = var.cloud_provider
 }
 

--- a/azure/container-linux/kubernetes/variables.tf
+++ b/azure/container-linux/kubernetes/variables.tf
@@ -135,3 +135,8 @@ variable "enable_aggregation" {
   default = "false"
 }
 
+variable "cloud_provider" {
+  description = "The provider for cloud services (empty string for no provider)"
+  type        = string
+  default     = "azure"
+}

--- a/bare-metal/container-linux/kubernetes/bootkube.tf
+++ b/bare-metal/container-linux/kubernetes/bootkube.tf
@@ -14,5 +14,6 @@ module "bootkube" {
   cluster_domain_suffix           = var.cluster_domain_suffix
   enable_reporting                = var.enable_reporting
   enable_aggregation              = var.enable_aggregation
+  cloud_provider                  = var.cloud_provider
 }
 

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -161,3 +161,8 @@ variable "enable_aggregation" {
   default = "false"
 }
 
+variable "cloud_provider" {
+  description = "The provider for cloud services (empty string for no provider)"
+  type        = string
+  default     = ""
+}

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -18,5 +18,6 @@ module "bootkube" {
   cluster_domain_suffix = var.cluster_domain_suffix
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
+  cloud_provider        = var.cloud_provider
 }
 

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -112,3 +112,8 @@ variable "enable_aggregation" {
   default = "false"
 }
 
+variable "cloud_provider" {
+  description = "The provider for cloud services (empty string for no provider)"
+  type        = string
+  default     = "digital-ocean"
+}

--- a/google-cloud/container-linux/kubernetes/bootkube.tf
+++ b/google-cloud/container-linux/kubernetes/bootkube.tf
@@ -13,6 +13,7 @@ module "bootkube" {
   cluster_domain_suffix = var.cluster_domain_suffix
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
+  cloud_provider        = var.cloud_provider
 
   // temporary
   external_apiserver_port = 443

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -129,3 +129,8 @@ variable "enable_aggregation" {
   default = "false"
 }
 
+variable "cloud_provider" {
+  description = "The provider for cloud services (empty string for no provider)"
+  type        = string
+  default     = "gcp"
+}


### PR DESCRIPTION
High level description of the change.

The variable for cloud provider was not there on bootkube. This is resulting in blank value of cloud provider for bootkube because of the default value given in: https://github.com/poseidon/terraform-render-bootkube/blob/master/variables.tf#L21


This PR just gives the user flexibility to add the same. 

## Testing

Describe your work to validate the change works.

Have tested the same fro AWS and it is working fine. The kubelet gets the cloud provider as aws. 
