### PR TITLE
Avoid creating extraneous GCE controller instance groups

### DIFF
--- a/google-cloud/container-linux/kubernetes/apiserver.tf
+++ b/google-cloud/container-linux/kubernetes/apiserver.tf
@@ -57,7 +57,7 @@ resource "google_compute_backend_service" "apiserver" {
 
 # Instance group of heterogeneous (unmanged) controller instances
 resource "google_compute_instance_group" "controllers" {
-  count = length(local.zones)
+  count = min(var.controller_count, length(local.zones))
 
   name = format("%s-controllers-%s", var.cluster_name, element(local.zones, count.index))
   zone = element(local.zones, count.index)


### PR DESCRIPTION
* Intended as part of #504 improvement
* Single controller clusters only require one controller instance group (previously created zone-many)
* Multi-controller clusters must "wrap" controllers over zonal heterogeneous instance groups. For example, 5 controllers over 3 zones (no change)
