### PR TITLE
Fix to add all Azure controller nodes to address pool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@ Notable changes between versions.
 * Relax `terraform-provider-ct` version constraint (v0.3.2+)
   * Allow provider versions below v1.0.0 (e.g. upgrading to v0.4)
 
+#### Azure
+
+* Fix to add all controller nodes to the apiserver load balancer backend address pool ([#518](https://github.com/poseidon/typhoon/pull/518))
+  * kube-apiserver availability relied on the 0th controller
+
 #### Google Cloud
 
 * Allow controller nodes to span more than 3 zones if available in a region ([#504](https://github.com/poseidon/typhoon/pull/504))

--- a/azure/container-linux/kubernetes/controllers.tf
+++ b/azure/container-linux/kubernetes/controllers.tf
@@ -114,7 +114,9 @@ resource "azurerm_network_interface" "controllers" {
 
 # Add controller NICs to the controller backend address pool
 resource "azurerm_network_interface_backend_address_pool_association" "controllers" {
-  network_interface_id    = azurerm_network_interface.controllers[0].id
+  count = var.controller_count
+
+  network_interface_id    = azurerm_network_interface.controllers[count.index].id
   ip_configuration_name   = "ip0"
   backend_address_pool_id = azurerm_lb_backend_address_pool.controller.id
 }


### PR DESCRIPTION
* Add all Azure controllers to the apiserver load balancer backend address pool
* Previously, kube-apiserver availability relied on the 0th controller being up. Multi-controller was just providing etcd data redundancy