### PR TITLE
Support adding data disks to workers in Azure.

### DIFF
--- a/azure/container-linux/kubernetes/variables.tf
+++ b/azure/container-linux/kubernetes/variables.tf
@@ -58,6 +58,23 @@ variable "disk_size" {
   description = "Size of the disk in GB"
 }
 
+variable "worker_data_disks" {
+  type        = list(object({
+    disk_size      = number
+    disk_type      = string
+    mount_path     = string
+  }))
+  default     = []
+  description = <<EOD
+A list of maps describing data disks to add to the worker VMs. Disk size in GB. E.g.:
+[{
+  disk_size  = 50
+  disk_type  = "StandardSSD_LRS"
+  mount_path = "/media/foo"
+}]
+EOD
+}
+
 variable "worker_priority" {
   type        = string
   default     = "Regular"

--- a/azure/container-linux/kubernetes/workers.tf
+++ b/azure/container-linux/kubernetes/workers.tf
@@ -20,5 +20,5 @@ module "workers" {
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
   clc_snippets          = var.worker_clc_snippets
+  data_disks            = var.worker_data_disks
 }
-

--- a/azure/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/azure/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -79,7 +79,30 @@ systemd:
         ExecStop=/etc/kubernetes/delete-node
         [Install]
         WantedBy=multi-user.target
+%{ for i in range(length(data_disks)) ~}
+    - name: ${join("-", compact(split("/", data_disks[i].mount_path)))}.mount
+      enable: true
+      contents: |
+        [Unit]
+        Before=local-fs.target
+        [Mount]
+        What=/dev/disk/azure/scsi1/lun${i}
+        Where=${data_disks[i].mount_path}
+        Type=ext4
+        [Install]
+        WantedBy=local-fs.target
+%{ endfor ~}
+
 storage:
+%{ if length(data_disks) != 0 ~}
+  filesystems:
+%{for i in range(length(data_disks)) ~}
+    - name: datadisk${i}
+      mount:
+        device: /dev/disk/azure/scsi1/lun${i}
+        format: ext4
+%{ endfor ~}
+%{ endif ~}
   files:
     - path: /etc/kubernetes/kubeconfig
       filesystem: root

--- a/azure/container-linux/kubernetes/workers/variables.tf
+++ b/azure/container-linux/kubernetes/workers/variables.tf
@@ -91,3 +91,19 @@ variable "cluster_domain_suffix" {
   default = "cluster.local"
 }
 
+variable "data_disks" {
+  type        = list(object({
+    disk_size      = number
+    disk_type      = string
+    mount_path     = string
+  }))
+  default     = []
+  description = <<EOD
+A list of maps describing data disks to add to the worker VMs. Disk size in GB. E.g.:
+[{
+  disk_size  = 50
+  disk_type  = "StandardSSD_LRS"
+  mount_path = "/media/foo"
+}]
+EOD
+}

--- a/docs/cl/azure.md
+++ b/docs/cl/azure.md
@@ -221,6 +221,7 @@ Reference the DNS zone with `"${azurerm_dns_zone.clusters.name}"` and its resour
 | worker_type | Machine type for workers | "Standard_F1" | See below |
 | os_image | Channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha |
 | disk_size | Size of the disk in GB | "40" | "100" |
+| worker_data_disks | Extra disks to mount in workers | [] | See below |
 | worker_priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | Regular | Low |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
@@ -229,6 +230,19 @@ Reference the DNS zone with `"${azurerm_dns_zone.clusters.name}"` and its resour
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
+
+Adding extra data disks to workers requires a list of maps like this:
+
+    module "azure-monitoring-low-priority-pool" {
+      source = "git::https://github.com/poseidon/typhoon//azure/container-linux/kubernetes/workers?ref=v1.15.1"
+      ...
+
+      data_disks = [{
+        disk_size  = 500
+        disk_type  = "StandardSSD_LRS"
+        mount_path = "/media/volume"
+      }]
+    }
 
 Check the list of valid [machine types](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/) and their [specs](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-general). Use `az vm list-skus` to get the identifier.
 


### PR DESCRIPTION
When using local storage, or something like [StorageOS](https://storageos.com),
there might be a need to add one or more data disks to the workers. With this patch
the `azure/container-linux/kubernetes/workers/` module supports a new variable
`data_disks` which allows for one or more volumes to be mounted in the worker
like this:

    module "azure-monitoring-low-priority-pool" {
      source = "git::https://github.com/poseidon/typhoon//azure/container-linux/kubernetes/workers?ref=v1.15.1"
      ...

      data_disks = [{
        disk_size  = 500
        disk_type  = "StandardSSD_LRS"
        mount_path = "/media/volume"
      }]
    }

The list can also be passed via the top level azure module as `worker_data_disks`.

## Testing

I've created a functional clusters in Azure, with zero, one or multiple entries in `worker_data_disks` and verified disks are properly mounted.