### PR TITLE
Enable AWS root block device encryption by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between versions.
 
 ## Latest
 
+#### AWS
+
+* Enable root block device encryption by default ([#527](https://github.com/poseidon/typhoon/pull/527))
+  * Require `terraform-provider-aws` v2.23+ (**action required**)
+
 #### Addons
 
 * Update kube-state-metrics from v1.7.1 to v1.7.2

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -31,6 +31,7 @@ resource "aws_instance" "controllers" {
     volume_type = var.disk_type
     volume_size = var.disk_size
     iops        = var.disk_iops
+    encrypted   = true
   }
 
   # network

--- a/aws/container-linux/kubernetes/versions.tf
+++ b/aws/container-linux/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = "~> 0.12.0"
   required_providers {
-    aws      = "~> 2.7"
+    aws      = "~> 2.23"
     ct       = "~> 0.3"
     template = "~> 2.1"
     null     = "~> 2.1"

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -56,6 +56,7 @@ resource "aws_launch_configuration" "worker" {
     volume_type = var.disk_type
     volume_size = var.disk_size
     iops        = var.disk_iops
+    encrypted   = true
   }
 
   # network

--- a/aws/fedora-coreos/kubernetes/controllers.tf
+++ b/aws/fedora-coreos/kubernetes/controllers.tf
@@ -31,6 +31,7 @@ resource "aws_instance" "controllers" {
     volume_type = var.disk_type
     volume_size = var.disk_size
     iops        = var.disk_iops
+    encrypted   = true
   }
 
   # network

--- a/aws/fedora-coreos/kubernetes/versions.tf
+++ b/aws/fedora-coreos/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = "~> 0.12.0"
   required_providers {
-    aws      = "~> 2.7"
+    aws      = "~> 2.23"
     ct       = "~> 0.4"
     template = "~> 2.1"
     null     = "~> 2.1"

--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -56,6 +56,7 @@ resource "aws_launch_configuration" "worker" {
     volume_type = var.disk_type
     volume_size = var.disk_size
     iops        = var.disk_iops
+    encrypted   = true
   }
 
   # network


### PR DESCRIPTION
* terraform-provider-aws v2.23.0 allows AWS root block devices to enable encryption by default
  * Require updating terraform-provider-aws to v2.23.0 or higher (**action required**)
  * Enable root EBS device encryption by default for controller instances and worker instances in auto-scaling groups

For comparison:

* Google Cloud persistent disks have been encrypted by default for years
* Azure managed disk encryption is not ready yet (terraform-provider-azurerm#486)