### PR TITLE
Variable spelling fix

### DIFF
--- a/docs/cl/google-cloud.md
+++ b/docs/cl/google-cloud.md
@@ -227,5 +227,5 @@ Check the list of valid [machine types](https://cloud.google.com/compute/docs/ma
 
 #### Preemption
 
-Add `worker_preemeptible = "true"` to allow worker nodes to be [preempted](https://cloud.google.com/compute/docs/instances/preemptible) at random, but pay [significantly](https://cloud.google.com/compute/pricing) less. Clusters tolerate stopping instances fairly well (reschedules pods, but cannot drain) and preemption provides a nice reward for running fault-tolerant cluster systems.`
+Add `worker_preemptible = "true"` to allow worker nodes to be [preempted](https://cloud.google.com/compute/docs/instances/preemptible) at random, but pay [significantly](https://cloud.google.com/compute/pricing) less. Clusters tolerate stopping instances fairly well (reschedules pods, but cannot drain) and preemption provides a nice reward for running fault-tolerant cluster systems.`
 


### PR DESCRIPTION
High-level description of the change.

* Update doc spelling of worker_preemeptible to match the variable value(worker_preemptible) in one location in the document.

## Testing

Ran terraform plan after trying variable worker_preemeptible and terraform failed asking if I meant worker_preemptible. I updated spelling in my tf to worker_preemptibleand did terraform plan and all was good.

rel: issue number (if applicable)
