### PR TITLE
Use stable IDs for etcd, CoreDNS, and Ngnix dashboards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Notable changes between versions.
 * Update Prometheus from v2.11.0 to [v2.11.2](https://github.com/prometheus/prometheus/releases/tag/v2.11.2)
   * Update kube-state-metrics from v1.7.1 to v1.7.2
 * Update Grafana from v6.2.5 to v6.3.3
+  * Use stable IDs for etcd, CoreDNS, and Nginx Ingress dashboards
 * Update nginx-ingress from v0.25.0 to [v0.25.1](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.25.1)
   * Fix Nginx security advisories
 

--- a/addons/grafana/dashboards-coredns.yaml
+++ b/addons/grafana/dashboards-coredns.yaml
@@ -1029,7 +1029,8 @@ data:
           "30d"
         ]
       },
-      "timezone": "browser",
+      "timezone": "",
       "title": "CoreDNS",
+      "uid": "2f3f749259235f58698ea949170d3bd5",
       "version": 0
     }

--- a/addons/grafana/dashboards-etcd.yaml
+++ b/addons/grafana/dashboards-etcd.yaml
@@ -1224,7 +1224,8 @@ data:
           "30d"
         ]
       },
-      "timezone": "browser",
+      "timezone": "",
       "title": "etcd",
+      "uid": "c2f4e12cdf69feb95caa41a5a1b423d9",
       "version": 215
     }

--- a/addons/grafana/dashboards-nginx-ingress.yaml
+++ b/addons/grafana/dashboards-nginx-ingress.yaml
@@ -1052,7 +1052,8 @@ data:
           "30d"
         ]
       },
-      "timezone": "browser",
+      "timezone": "",
       "title": "Nginx Ingress Controller",
+      "uid": "f4af03eca476c08ecf2b5cf15fd60168",
       "version": 0
     }


### PR DESCRIPTION
* Use unique dashboard ID so that multiple replicas of Grafana serve dashboards with uniform paths
* Fix issue where refreshing a dashboard served by one replica could show a 404 unless the request went to the same replica