### PR TITLE
Update CHANGES and docs for v1.16.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,8 @@ Notable changes between versions.
 
 * Kubernetes [v1.16.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#v1160) ([#543](https://github.com/poseidon/typhoon/pull/543))
   * Read about several Kubernetes API [deprecations](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals)!
-  * Rename `node-role.kubernetes.io` labels for `master` and `node` roles (no longer shown in `kubectl get nodes`)
+  * Remove legacy node role labels (no longer shown in `kubectl get nodes`)
+  * Rename node labels to `node.kubernetes.io/master` and `node.kubernetes.io/node` (migratory)
 * Migrate control plane from self-hosted to static pods ([#536](https://github.com/poseidon/typhoon/pull/536))
   * Run `kube-apiserver`, `kube-scheduler`, and `kube-controller-manager` as static pods on each controller
   * `kubectl` edits to `kube-apiserver`, `kube-scheduler`, and `kube-controller-manager` are no longer possible (change)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Typhoon [![IRC](https://img.shields.io/badge/freenode-%23typhoon-0099ef.svg)]() <img align="right" src="https://storage.googleapis.com/poseidon/typhoon-logo.png">
+# Typhoon <img align="right" src="https://storage.googleapis.com/poseidon/typhoon-logo.png">
 
 Typhoon is a minimal and free Kubernetes distribution.
 
@@ -81,10 +81,10 @@ In 4-8 minutes (varies by platform), the cluster will be ready. This Google Clou
 ```sh
 $ export KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
 $ kubectl get nodes
-NAME                                       ROLES              STATUS  AGE  VERSION
-yavin-controller-0.c.example-com.internal  controller,master  Ready   6m   v1.16.0
-yavin-worker-jrbf.c.example-com.internal   node               Ready   5m   v1.16.0
-yavin-worker-mzdm.c.example-com.internal   node               Ready   5m   v1.16.0
+NAME                                       ROLES    STATUS  AGE  VERSION
+yavin-controller-0.c.example-com.internal  <none>   Ready   6m   v1.16.0
+yavin-worker-jrbf.c.example-com.internal   <none>   Ready   5m   v1.16.0
+yavin-worker-mzdm.c.example-com.internal   <none>   Ready   5m   v1.16.0
 ```
 
 List the pods.

--- a/docs/cl/aws.md
+++ b/docs/cl/aws.md
@@ -134,10 +134,10 @@ In 4-8 minutes, the Kubernetes cluster will be ready.
 ```
 $ export KUBECONFIG=/home/user/.secrets/clusters/tempest/auth/kubeconfig
 $ kubectl get nodes
-NAME           STATUS  ROLES              AGE  VERSION
-ip-10-0-3-155  Ready   controller,master  10m  v1.16.0
-ip-10-0-26-65  Ready   node               10m  v1.16.0
-ip-10-0-41-21  Ready   node               10m  v1.16.0
+NAME           STATUS  ROLES   AGE  VERSION
+ip-10-0-3-155  Ready   <none>  10m  v1.16.0
+ip-10-0-26-65  Ready   <none>  10m  v1.16.0
+ip-10-0-41-21  Ready   <none>  10m  v1.16.0
 ```
 
 List the pods.

--- a/docs/cl/azure.md
+++ b/docs/cl/azure.md
@@ -131,10 +131,10 @@ In 4-8 minutes, the Kubernetes cluster will be ready.
 ```
 $ export KUBECONFIG=/home/user/.secrets/clusters/ramius/auth/kubeconfig
 $ kubectl get nodes
-NAME                  STATUS  ROLES              AGE  VERSION
-ramius-controller-0   Ready   controller,master  24m  v1.16.0
-ramius-worker-000001  Ready   node               25m  v1.16.0
-ramius-worker-000002  Ready   node               24m  v1.16.0
+NAME                  STATUS  ROLES   AGE  VERSION
+ramius-controller-0   Ready   <none>  24m  v1.16.0
+ramius-worker-000001  Ready   <none>  25m  v1.16.0
+ramius-worker-000002  Ready   <none>  24m  v1.16.0
 ```
 
 List the pods.

--- a/docs/cl/bare-metal.md
+++ b/docs/cl/bare-metal.md
@@ -288,10 +288,10 @@ systemd[1]: Started Kubernetes control plane.
 ```
 $ export KUBECONFIG=/home/user/.secrets/clusters/mercury/auth/kubeconfig
 $ kubectl get nodes
-NAME                STATUS  ROLES              AGE  VERSION
-node1.example.com   Ready   controller,master  10m  v1.16.0
-node2.example.com   Ready   node               10m  v1.16.0
-node3.example.com   Ready   node               10m  v1.16.0
+NAME                STATUS  ROLES   AGE  VERSION
+node1.example.com   Ready   <none>  10m  v1.16.0
+node2.example.com   Ready   <none>  10m  v1.16.0
+node3.example.com   Ready   <none>  10m  v1.16.0
 ```
 
 List the pods.

--- a/docs/cl/digital-ocean.md
+++ b/docs/cl/digital-ocean.md
@@ -129,10 +129,10 @@ In 3-6 minutes, the Kubernetes cluster will be ready.
 ```
 $ export KUBECONFIG=/home/user/.secrets/clusters/nemo/auth/kubeconfig
 $ kubectl get nodes
-NAME               STATUS  ROLES              AGE  VERSION
-10.132.110.130     Ready   controller,master  10m  v1.16.0
-10.132.115.81      Ready   node               10m  v1.16.0
-10.132.124.107     Ready   node               10m  v1.16.0
+NAME               STATUS  ROLES   AGE  VERSION
+10.132.110.130     Ready   <none>  10m  v1.16.0
+10.132.115.81      Ready   <none>  10m  v1.16.0
+10.132.124.107     Ready   <none>  10m  v1.16.0
 ```
 
 List the pods.

--- a/docs/cl/google-cloud.md
+++ b/docs/cl/google-cloud.md
@@ -136,10 +136,10 @@ In 4-8 minutes, the Kubernetes cluster will be ready.
 ```
 $ export KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
 $ kubectl get nodes
-NAME                                       ROLES              STATUS  AGE  VERSION
-yavin-controller-0.c.example-com.internal  controller,master  Ready   6m   v1.16.0
-yavin-worker-jrbf.c.example-com.internal   node               Ready   5m   v1.16.0
-yavin-worker-mzdm.c.example-com.internal   node               Ready   5m   v1.16.0
+NAME                                       ROLES    STATUS  AGE  VERSION
+yavin-controller-0.c.example-com.internal  <none>   Ready   6m   v1.16.0
+yavin-worker-jrbf.c.example-com.internal   <none>   Ready   5m   v1.16.0
+yavin-worker-mzdm.c.example-com.internal   <none>   Ready   5m   v1.16.0
 ```
 
 List the pods.

--- a/docs/fedora-coreos/aws.md
+++ b/docs/fedora-coreos/aws.md
@@ -137,10 +137,10 @@ In 4-8 minutes, the Kubernetes cluster will be ready.
 ```
 $ export KUBECONFIG=/home/user/.secrets/clusters/tempest/auth/kubeconfig
 $ kubectl get nodes
-NAME           STATUS  ROLES              AGE  VERSION
-ip-10-0-3-155  Ready   controller,master  10m  v1.16.0
-ip-10-0-26-65  Ready   node               10m  v1.16.0
-ip-10-0-41-21  Ready   node               10m  v1.16.0
+NAME           STATUS  ROLES    AGE  VERSION
+ip-10-0-3-155  Ready   <none>   10m  v1.16.0
+ip-10-0-26-65  Ready   <none>   10m  v1.16.0
+ip-10-0-41-21  Ready   <none>   10m  v1.16.0
 ```
 
 List the pods.

--- a/docs/fedora-coreos/bare-metal.md
+++ b/docs/fedora-coreos/bare-metal.md
@@ -282,10 +282,10 @@ systemd[1]: Started Kubernetes control plane.
 ```
 $ export KUBECONFIG=/home/user/.secrets/clusters/mercury/auth/kubeconfig
 $ kubectl get nodes
-NAME                STATUS  ROLES              AGE  VERSION
-node1.example.com   Ready   controller,master  10m  v1.16.0
-node2.example.com   Ready   node               10m  v1.16.0
-node3.example.com   Ready   node               10m  v1.16.0
+NAME                STATUS  ROLES   AGE  VERSION
+node1.example.com   Ready   <none>  10m  v1.16.0
+node2.example.com   Ready   <none>  10m  v1.16.0
+node3.example.com   Ready   <none>  10m  v1.16.0
 ```
 
 List the pods.

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,10 +79,10 @@ In 4-8 minutes (varies by platform), the cluster will be ready. This Google Clou
 ```
 $ export KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
 $ kubectl get nodes
-NAME                                       ROLES              STATUS  AGE  VERSION
-yavin-controller-0.c.example-com.internal  controller,master  Ready   6m   v1.16.0
-yavin-worker-jrbf.c.example-com.internal   node               Ready   5m   v1.16.0
-yavin-worker-mzdm.c.example-com.internal   node               Ready   5m   v1.16.0
+NAME                                       ROLES    STATUS  AGE  VERSION
+yavin-controller-0.c.example-com.internal  <none>   Ready   6m   v1.16.0
+yavin-worker-jrbf.c.example-com.internal   <none>   Ready   5m   v1.16.0
+yavin-worker-mzdm.c.example-com.internal   <none>   Ready   5m   v1.16.0
 ```
 
 List the pods.


### PR DESCRIPTION
* Clarify the removal of the legacy node roles and the addition of renamed node labels for the convenience of anyone relying on node label selectors (rather than using the default master taints to keep workloads off master nodes)