### PR TITLE
Add node_labels variable to aws/container-linux/kubernetes/

### DIFF
--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -154,3 +154,9 @@ variable "enable_aggregation" {
   default = "false"
 }
 
+variable "worker_node_labels" {
+  description = "List of additional labels to add to worker nodes"
+  type = list
+  default = []
+}
+

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -19,5 +19,6 @@ module "workers" {
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
   clc_snippets          = var.worker_clc_snippets
+  node_labels           = var.worker_node_labels
 }
 

--- a/aws/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/aws/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -61,6 +61,9 @@ systemd:
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
           --node-labels=node.kubernetes.io/node \
+          %{ for label in split(",", node_labels) }
+          --node-labels=${label} \
+          %{ endfor ~}
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -105,3 +105,8 @@ variable "cluster_domain_suffix" {
   default = "cluster.local"
 }
 
+variable "node_labels" {
+  description = "List of additional labels to add to worker nodes"
+  type = list
+  default = []
+}

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -86,6 +86,7 @@ data "template_file" "worker-config" {
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     cluster_domain_suffix  = var.cluster_domain_suffix
     cgroup_driver          = local.flavor == "flatcar" && local.channel == "edge" ? "systemd" : "cgroupfs"
+    node_labels            = join(",", var.node_labels)
   }
 }
 

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -154,3 +154,8 @@ variable "enable_aggregation" {
   default = "false"
 }
 
+variable "worker_node_labels" {
+  description = "List of additional labels to add to worker nodes"
+  type = list
+  default = []
+}

--- a/aws/fedora-coreos/kubernetes/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers.tf
@@ -19,5 +19,6 @@ module "workers" {
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
   snippets              = var.worker_snippets
+  node_labels           = var.worker_node_labels
 }
 

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -66,6 +66,9 @@ systemd:
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
           --node-labels=node.kubernetes.io/node \
+          %{ for label in split(",", node_labels) }
+          --node-labels=${label} \
+          %{ endfor ~}
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/aws/fedora-coreos/kubernetes/workers/variables.tf
+++ b/aws/fedora-coreos/kubernetes/workers/variables.tf
@@ -105,3 +105,8 @@ variable "cluster_domain_suffix" {
   default = "cluster.local"
 }
 
+variable "node_labels" {
+  description = "List of additional labels to add to worker nodes"
+  type = list
+  default = []
+}

--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -85,6 +85,7 @@ data "template_file" "worker-config" {
     ssh_authorized_key     = var.ssh_authorized_key
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     cluster_domain_suffix  = var.cluster_domain_suffix
+    node_labels            = join(",", var.node_labels)
   }
 }
 

--- a/azure/container-linux/kubernetes/variables.tf
+++ b/azure/container-linux/kubernetes/variables.tf
@@ -135,3 +135,9 @@ variable "enable_aggregation" {
   default = "false"
 }
 
+variable "worker_node_labels" {
+  description = "List of additional labels to add to worker nodes"
+  type = list
+  default = []
+}
+

--- a/azure/container-linux/kubernetes/workers.tf
+++ b/azure/container-linux/kubernetes/workers.tf
@@ -20,5 +20,6 @@ module "workers" {
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
   clc_snippets          = var.worker_clc_snippets
+  node_labels           = var.worker_node_labels
 }
 

--- a/azure/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/azure/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -59,6 +59,9 @@ systemd:
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
           --node-labels=node.kubernetes.io/node \
+          %{ for label in split(",", node_labels) }
+          --node-labels=${label} \
+          %{ endfor ~}
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/azure/container-linux/kubernetes/workers/variables.tf
+++ b/azure/container-linux/kubernetes/workers/variables.tf
@@ -91,3 +91,8 @@ variable "cluster_domain_suffix" {
   default = "cluster.local"
 }
 
+variable "node_labels" {
+  description = "List of additional labels to add to worker nodes"
+  type = list
+  default = []
+}

--- a/azure/container-linux/kubernetes/workers/workers.tf
+++ b/azure/container-linux/kubernetes/workers/workers.tf
@@ -111,6 +111,7 @@ data "template_file" "worker-config" {
     ssh_authorized_key     = var.ssh_authorized_key
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     cluster_domain_suffix  = var.cluster_domain_suffix
+    node_labels            = join(",", var.node_labels)
   }
 }
 

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -129,3 +129,9 @@ variable "enable_aggregation" {
   default = "false"
 }
 
+variable "worker_node_labels" {
+  description = "List of additional labels to add to worker nodes"
+  type = list
+  default = []
+}
+

--- a/google-cloud/container-linux/kubernetes/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers.tf
@@ -18,5 +18,6 @@ module "workers" {
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
   clc_snippets          = var.worker_clc_snippets
+  node_labels           = var.worker_node_labels
 }
 

--- a/google-cloud/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/google-cloud/container-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -60,6 +60,9 @@ systemd:
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
           --node-labels=node.kubernetes.io/node \
+          %{ for label in split(",", node_labels) }
+          --node-labels=${label} \
+          %{ endfor ~}
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/google-cloud/container-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/workers/variables.tf
@@ -81,6 +81,12 @@ variable "cluster_domain_suffix" {
   default = "cluster.local"
 }
 
+variable "node_labels" {
+  description = "List of additional labels to add to worker nodes"
+  type = list
+  default = []
+}
+
 variable "clc_snippets" {
   type = list(string)
   description = "Container Linux Config snippets"

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -82,6 +82,7 @@ data "template_file" "worker-config" {
     ssh_authorized_key     = var.ssh_authorized_key
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     cluster_domain_suffix  = var.cluster_domain_suffix
+    node_labels            = join(",", var.node_labels)
   }
 }
 


### PR DESCRIPTION
High level description of the change.

* Add `node_labels` variable to kubernetes module (currently only for aws/container-linux)

## Testing

Launched a new cluster with extra labels that were successfully applied on the worker nodes.

----

This is a quick fix I needed for dedicated worker pools and nodeSelector. I guess that for this to be merged it'd require uniformity across all cloud/distro variants.

I'm submitting it just to see if this would be an acceptable feature. If so, I can add it to the rest of the platforms/distros.

Thanks!
