### PR TITLE
Update docs and variable types for worker node_labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,18 @@ Notable changes between versions.
 
 ## Latest
 
+#### AWS
+
+* Add `node_labels` variable to internal `workers` module ([#550](https://github.com/poseidon/typhoon/pull/550))
+
+#### Azure
+
+* Add `node_labels` variable to internal `workers` module ([#550](https://github.com/poseidon/typhoon/pull/550))
+
+#### Google Cloud
+
+* Add `node_labels` variable to internal `workers` module ([#550](https://github.com/poseidon/typhoon/pull/550))
+
 #### Bare-Metal
 
 * Fix Terraform missing comma error ([#549](https://github.com/poseidon/typhoon/pull/549))

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -155,8 +155,8 @@ variable "enable_aggregation" {
 }
 
 variable "worker_node_labels" {
-  description = "List of additional labels to add to worker nodes"
-  type = list
+  type = list(string)
+  description = "List of initial worker node labels"
   default = []
 }
 

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -106,7 +106,7 @@ variable "cluster_domain_suffix" {
 }
 
 variable "node_labels" {
-  description = "List of additional labels to add to worker nodes"
-  type = list
+  type = list(string)
+  description = "List of initial node labels"
   default = []
 }

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -155,7 +155,7 @@ variable "enable_aggregation" {
 }
 
 variable "worker_node_labels" {
-  description = "List of additional labels to add to worker nodes"
-  type = list
+  type = list(string)
+  description = "List of initial worker node labels"
   default = []
 }

--- a/aws/fedora-coreos/kubernetes/workers/variables.tf
+++ b/aws/fedora-coreos/kubernetes/workers/variables.tf
@@ -106,7 +106,7 @@ variable "cluster_domain_suffix" {
 }
 
 variable "node_labels" {
-  description = "List of additional labels to add to worker nodes"
-  type = list
+  type = list(string)
+  description = "List of initial node labels"
   default = []
 }

--- a/azure/container-linux/kubernetes/variables.tf
+++ b/azure/container-linux/kubernetes/variables.tf
@@ -136,8 +136,8 @@ variable "enable_aggregation" {
 }
 
 variable "worker_node_labels" {
-  description = "List of additional labels to add to worker nodes"
-  type = list
+  type = list(string)
+  description = "List of initial worker node labels"
   default = []
 }
 

--- a/azure/container-linux/kubernetes/workers/variables.tf
+++ b/azure/container-linux/kubernetes/workers/variables.tf
@@ -92,7 +92,7 @@ variable "cluster_domain_suffix" {
 }
 
 variable "node_labels" {
-  description = "List of additional labels to add to worker nodes"
-  type = list
+  type = list(string)
+  description = "List of initial node labels"
   default = []
 }

--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -65,8 +65,10 @@ The AWS internal `workers` module supports a number of [variables](https://githu
 | os_image | AMI channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | spot_price | Spot price in USD for workers. Leave as default empty string for regular on-demand instances | "" | "0.10" |
+| clc_snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | service_cidr | Must match `service_cidr` of cluster | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | Must match `cluster_domain_suffix` of cluster | "cluster.local" | "k8s.example.com" |
+| node_labels | List of initial node labels | [] | ["worker-pool=foo"] |
 
 Check the list of valid [instance types](https://aws.amazon.com/ec2/instance-types/) or per-region and per-type [spot prices](https://aws.amazon.com/ec2/spot/pricing/).
 
@@ -133,6 +135,7 @@ The Azure internal `workers` module supports a number of [variables](https://git
 | clc_snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
+| node_labels | List of initial node labels | [] | ["worker-pool=foo"] |
 
 Check the list of valid [machine types](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/) and their [specs](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-general). Use `az vm list-skus` to get the identifier.
 
@@ -206,8 +209,10 @@ Check the list of regions [docs](https://cloud.google.com/compute/docs/regions-z
 | os_image | Container Linux image for compute instances | "coreos-stable" | "coreos-alpha", "coreos-beta" |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | preemptible | If true, Compute Engine will terminate instances randomly within 24 hours | false | true |
+| clc_snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | service_cidr | Must match `service_cidr` of cluster | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | Must match `cluster_domain_suffix` of cluster | "cluster.local" | "k8s.example.com" |
+| node_labels | List of initial node labels | [] | ["worker-pool=foo"] |
 
 Check the list of valid [machine types](https://cloud.google.com/compute/docs/machine-types).
 

--- a/docs/cl/aws.md
+++ b/docs/cl/aws.md
@@ -209,6 +209,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | "0" (i.e. auto) | "400" |
 | worker_target_groups | Target group ARNs to which worker instances should be added | [] | ["${aws_lb_target_group.app.id}"] |
+| worker_node_labels | List of initial worker node labels | [] | ["worker-pool=default"] |
 | worker_price | Spot price in USD for workers. Leave as default empty string for regular on-demand instances | "" | "0.10" |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |

--- a/docs/cl/azure.md
+++ b/docs/cl/azure.md
@@ -217,6 +217,7 @@ Reference the DNS zone with `"${azurerm_dns_zone.clusters.name}"` and its resour
 | worker_type | Machine type for workers | "Standard_F1" | See below |
 | os_image | Channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha |
 | disk_size | Size of the disk in GB | "40" | "100" |
+| worker_node_labels | List of initial worker node labels | [] | ["worker-pool=default"] |
 | worker_priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | Regular | Low |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |

--- a/docs/cl/google-cloud.md
+++ b/docs/cl/google-cloud.md
@@ -211,6 +211,7 @@ resource "google_dns_managed_zone" "zone-for-clusters" {
 | worker_type | Machine type for workers | "n1-standard-1" | See below |
 | os_image | Container Linux image for compute instances | "coreos-stable" | "coreos-stable-1632-3-0-v20180215" |
 | disk_size | Size of the disk in GB | 40 | 100 |
+| worker_node_labels | List of initial worker node labels | [] | ["worker-pool=default"] |
 | worker_preemptible | If enabled, Compute Engine will terminate workers randomly within 24 hours | false | true |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |

--- a/docs/fedora-coreos/aws.md
+++ b/docs/fedora-coreos/aws.md
@@ -209,6 +209,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | "0" (i.e. auto) | "400" |
 | worker_target_groups | Target group ARNs to which worker instances should be added | [] | ["${aws_lb_target_group.app.id}"] |
+| worker_node_labels | List of initial worker node labels | [] | ["worker-pool=default"] |
 | worker_price | Spot price in USD for workers. Leave as default empty string for regular on-demand instances | "" | "0.10" |
 | controller_snippets | Controller Fedora CoreOS Config snippets | [] | UNSUPPORTED |
 | worker_clc_snippets | Worker Fedora CoreOS Config snippets | [] | UNSUPPORTED |

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -130,8 +130,8 @@ variable "enable_aggregation" {
 }
 
 variable "worker_node_labels" {
-  description = "List of additional labels to add to worker nodes"
-  type = list
+  type = list(string)
+  description = "List of initial worker node labels"
   default = []
 }
 

--- a/google-cloud/container-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/workers/variables.tf
@@ -52,6 +52,12 @@ variable "preemptible" {
   description = "If enabled, Compute Engine will terminate instances randomly within 24 hours"
 }
 
+variable "clc_snippets" {
+  type = list(string)
+  description = "Container Linux Config snippets"
+  default = []
+}
+
 # configuration
 
 variable "kubeconfig" {
@@ -82,14 +88,8 @@ variable "cluster_domain_suffix" {
 }
 
 variable "node_labels" {
-  description = "List of additional labels to add to worker nodes"
-  type = list
-  default = []
-}
-
-variable "clc_snippets" {
   type = list(string)
-  description = "Container Linux Config snippets"
+  description = "List of initial node labels"
   default = []
 }
 


### PR DESCRIPTION
* Document worker pools `node_labels` variable to set the initial node labels for a homogeneous set of workers
* Document `worker_node_labels` convenience variable to set the initial node labels for default worker nodes