### PR TITLE
Add stricter types for AWS modules and update docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Notable changes between versions.
 
 #### AWS
 
+* Add Terraform v0.12 variables types ([#553](https://github.com/poseidon/typhoon/pull/553))
 * Add `node_labels` variable to internal `workers` module ([#550](https://github.com/poseidon/typhoon/pull/550))
 
 #### Azure

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -18,57 +18,57 @@ variable "dns_zone_id" {
 # instances
 
 variable "controller_count" {
-  type        = string
-  default     = "1"
+  type        = number
   description = "Number of controllers (i.e. masters)"
+  default     = 1
 }
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
   description = "Number of workers"
+  default     = 1
 }
 
 variable "controller_type" {
   type        = string
-  default     = "t3.small"
   description = "EC2 instance type for controllers"
+  default     = "t3.small"
 }
 
 variable "worker_type" {
   type        = string
-  default     = "t3.small"
   description = "EC2 instance type for workers"
+  default     = "t3.small"
 }
 
 variable "os_image" {
   type        = string
-  default     = "coreos-stable"
   description = "AMI channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge)"
+  default     = "coreos-stable"
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
   description = "Size of the EBS volume in GB"
+  default     = 40
 }
 
 variable "disk_type" {
   type        = string
-  default     = "gp2"
   description = "Type of the EBS volume (e.g. standard, gp2, io1)"
+  default     = "gp2"
 }
 
 variable "disk_iops" {
-  type        = string
-  default     = "0"
+  type        = number
   description = "IOPS of the EBS volume (e.g. 100)"
+  default     = 0
 }
 
 variable "worker_price" {
-  type        = string
-  default     = ""
-  description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
+  type        = number
+  description = "Spot price in USD for worker instances or 0 to use on-demand instances"
+  default     = 0
 }
 
 variable "worker_target_groups" {
@@ -97,66 +97,66 @@ variable "ssh_authorized_key" {
 }
 
 variable "asset_dir" {
-  description = "Path to a directory where generated assets should be placed (contains secrets)"
   type        = string
+  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
 }
 
 variable "networking" {
-  description = "Choice of networking provider (calico or flannel)"
   type        = string
+  description = "Choice of networking provider (calico or flannel)"
   default     = "calico"
 }
 
 variable "network_mtu" {
+  type        = number
   description = "CNI interface MTU (applies to calico only). Use 8981 if using instances types with Jumbo frames."
-  type        = string
-  default     = "1480"
+  default     = 1480
 }
 
 variable "host_cidr" {
-  description = "CIDR IPv4 range to assign to EC2 nodes"
   type        = string
+  description = "CIDR IPv4 range to assign to EC2 nodes"
   default     = "10.0.0.0/16"
 }
 
 variable "pod_cidr" {
-  description = "CIDR IPv4 range to assign Kubernetes pods"
   type        = string
+  description = "CIDR IPv4 range to assign Kubernetes pods"
   default     = "10.2.0.0/16"
 }
 
 variable "service_cidr" {
+  type = string
   description = <<EOD
 CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
-
-
-  type = string
   default = "10.3.0.0/16"
 }
 
-variable "cluster_domain_suffix" {
-  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type = string
-  default = "cluster.local"
-}
-
 variable "enable_reporting" {
-  type = string
+  type = bool
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default = "false"
+  default = false
 }
 
 variable "enable_aggregation" {
+  type = bool
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type = string
-  default = "false"
+  default = false
 }
 
 variable "worker_node_labels" {
   type = list(string)
   description = "List of initial worker node labels"
   default = []
+}
+
+# unofficial, undocumented, unsupported
+
+variable "cluster_domain_suffix" {
+  type = string
+  description = "Queries for domains with the suffix will be answered by CoreDNS. Default is cluster.local (e.g. foo.default.svc.cluster.local)"
+  default = "cluster.local"
 }
 

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -23,45 +23,45 @@ variable "security_groups" {
 # instances
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
   description = "Number of instances"
+  default     = 1
 }
 
 variable "instance_type" {
   type        = string
-  default     = "t3.small"
   description = "EC2 instance type"
+  default     = "t3.small"
 }
 
 variable "os_image" {
   type        = string
-  default     = "coreos-stable"
   description = "AMI channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge)"
+  default     = "coreos-stable"
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
   description = "Size of the EBS volume in GB"
+  default     = 40
 }
 
 variable "disk_type" {
   type        = string
-  default     = "gp2"
   description = "Type of the EBS volume (e.g. standard, gp2, io1)"
+  default     = "gp2"
 }
 
 variable "disk_iops" {
-  type        = string
-  default     = "0"
+  type        = number
   description = "IOPS of the EBS volume (required for io1)"
+  default     = 0
 }
 
 variable "spot_price" {
-  type        = string
-  default     = ""
-  description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
+  type        = number
+  description = "Spot price in USD for worker instances or 0 to use on-demand instances"
+  default     = 0
 }
 
 variable "target_groups" {
@@ -89,19 +89,17 @@ variable "ssh_authorized_key" {
 }
 
 variable "service_cidr" {
+  type = string
   description = <<EOD
 CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
-
-
-  type = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
-  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   type = string
+  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   default = "cluster.local"
 }
 

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -46,7 +46,7 @@ resource "aws_autoscaling_group" "workers" {
 resource "aws_launch_configuration" "worker" {
   image_id          = local.ami_id
   instance_type     = var.instance_type
-  spot_price        = var.spot_price
+  spot_price        = var.spot_price > 0 ? var.spot_price : null
   enable_monitoring = false
 
   user_data = data.ct_config.worker-ignition.rendered

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -18,57 +18,57 @@ variable "dns_zone_id" {
 # instances
 
 variable "controller_count" {
-  type        = string
-  default     = "1"
+  type        = number
   description = "Number of controllers (i.e. masters)"
+  default     = 1
 }
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
   description = "Number of workers"
+  default     = 1
 }
 
 variable "controller_type" {
   type        = string
-  default     = "t3.small"
   description = "EC2 instance type for controllers"
+  default     = "t3.small"
 }
 
 variable "worker_type" {
   type        = string
-  default     = "t3.small"
   description = "EC2 instance type for workers"
+  default     = "t3.small"
 }
 
 variable "os_image" {
   type        = string
-  default     = "coreos-stable"
   description = "AMI channel for Fedora CoreOS (not yet used)"
+  default     = "coreos-stable"
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
   description = "Size of the EBS volume in GB"
+  default     = 40
 }
 
 variable "disk_type" {
   type        = string
-  default     = "gp2"
   description = "Type of the EBS volume (e.g. standard, gp2, io1)"
+  default     = "gp2"
 }
 
 variable "disk_iops" {
-  type        = string
-  default     = "0"
+  type        = number
   description = "IOPS of the EBS volume (e.g. 100)"
+  default     = 0
 }
 
 variable "worker_price" {
-  type        = string
-  default     = ""
-  description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
+  type        = number
+  description = "Spot price in USD for worker instances or 0 to use on-demand instances"
+  default     = 0
 }
 
 variable "worker_target_groups" {
@@ -97,61 +97,59 @@ variable "ssh_authorized_key" {
 }
 
 variable "asset_dir" {
-  description = "Path to a directory where generated assets should be placed (contains secrets)"
   type        = string
+  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
 }
 
 variable "networking" {
-  description = "Choice of networking provider (calico or flannel)"
   type        = string
+  description = "Choice of networking provider (calico or flannel)"
   default     = "calico"
 }
 
 variable "network_mtu" {
+  type        = number
   description = "CNI interface MTU (applies to calico only). Use 8981 if using instances types with Jumbo frames."
-  type        = string
-  default     = "1480"
+  default     = 1480
 }
 
 variable "host_cidr" {
-  description = "CIDR IPv4 range to assign to EC2 nodes"
   type        = string
+  description = "CIDR IPv4 range to assign to EC2 nodes"
   default     = "10.0.0.0/16"
 }
 
 variable "pod_cidr" {
-  description = "CIDR IPv4 range to assign Kubernetes pods"
   type        = string
+  description = "CIDR IPv4 range to assign Kubernetes pods"
   default     = "10.2.0.0/16"
 }
 
 variable "service_cidr" {
+  type = string
   description = <<EOD
 CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
-
-
-  type = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
-  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   type = string
+  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   default = "cluster.local"
 }
 
 variable "enable_reporting" {
-  type = string
+  type = bool
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default = "false"
+  default = false
 }
 
 variable "enable_aggregation" {
+  type = bool
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type = string
-  default = "false"
+  default = false
 }
 
 variable "worker_node_labels" {
@@ -159,3 +157,12 @@ variable "worker_node_labels" {
   description = "List of initial worker node labels"
   default = []
 }
+
+# unofficial, undocumented, unsupported
+
+variable "cluster_domain_suffix" {
+  type = string
+  description = "Queries for domains with the suffix will be answered by CoreDNS. Default is cluster.local (e.g. foo.default.svc.cluster.local)"
+  default = "cluster.local"
+}
+

--- a/aws/fedora-coreos/kubernetes/workers/variables.tf
+++ b/aws/fedora-coreos/kubernetes/workers/variables.tf
@@ -23,45 +23,45 @@ variable "security_groups" {
 # instances
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
   description = "Number of instances"
+  default     = 1
 }
 
 variable "instance_type" {
   type        = string
-  default     = "t3.small"
   description = "EC2 instance type"
+  default     = "t3.small"
 }
 
 variable "os_image" {
   type        = string
-  default     = "coreos-stable"
   description = "AMI channel for Fedora CoreOS (not yet used)"
+  default     = "coreos-stable"
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
   description = "Size of the EBS volume in GB"
+  default     = 40
 }
 
 variable "disk_type" {
   type        = string
-  default     = "gp2"
   description = "Type of the EBS volume (e.g. standard, gp2, io1)"
+  default     = "gp2"
 }
 
 variable "disk_iops" {
-  type        = string
-  default     = "0"
+  type        = number
   description = "IOPS of the EBS volume (required for io1)"
+  default     = 0
 }
 
 variable "spot_price" {
-  type        = string
-  default     = ""
-  description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
+  type        = number
+  description = "Spot price in USD for worker instances or 0 to use on-demand instances"
+  default     = 0
 }
 
 variable "target_groups" {
@@ -89,19 +89,17 @@ variable "ssh_authorized_key" {
 }
 
 variable "service_cidr" {
+  type = string
   description = <<EOD
 CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
-
-
-  type = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
-  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   type = string
+  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   default = "cluster.local"
 }
 

--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -46,7 +46,7 @@ resource "aws_autoscaling_group" "workers" {
 resource "aws_launch_configuration" "worker" {
   image_id          = data.aws_ami.fedora-coreos.image_id
   instance_type     = var.instance_type
-  spot_price        = var.spot_price
+  spot_price        = var.spot_price > 0 ? var.spot_price : null
   enable_monitoring = false
 
   user_data = data.ct_config.worker-ignition.rendered

--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -63,8 +63,10 @@ The AWS internal `workers` module supports a number of [variables](https://githu
 | worker_count | Number of instances | 1 | 3 |
 | instance_type | EC2 instance type | "t3.small" | "t3.medium" |
 | os_image | AMI channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha |
-| disk_size | Size of the disk in GB | 40 | 100 |
-| spot_price | Spot price in USD for workers. Leave as default empty string for regular on-demand instances | "" | "0.10" |
+| disk_size | Size of the EBS volume in GB | 40 | 100 |
+| disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
+| disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |
+| spot_price | Spot price in USD for worker instances or 0 to use on-demand instances | 0 | 0.10 |
 | clc_snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | service_cidr | Must match `service_cidr` of cluster | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | Must match `cluster_domain_suffix` of cluster | "cluster.local" | "k8s.example.com" |

--- a/docs/cl/aws.md
+++ b/docs/cl/aws.md
@@ -177,7 +177,7 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/aws/con
 | dns_zone | AWS Route53 DNS zone | "aws.example.com" |
 | dns_zone_id | AWS Route53 DNS zone id | "Z3PAABBCFAKEC0" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3NZ..." |
-| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/tempest" |
+| asset_dir | Absolute path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/tempest" |
 
 #### DNS Zone
 
@@ -191,7 +191,7 @@ resource "aws_route53_zone" "zone-for-clusters" {
 }
 ```
 
-Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`.
+Reference the DNS zone id with `aws_route53_zone.zone-for-clusters.zone_id`.
 
 !!! tip ""
     If you have an existing domain name with a zone file elsewhere, just delegate a subdomain that can be managed on Route53 (e.g. aws.mydomain.com) and [update nameservers](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html).
@@ -205,12 +205,11 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | controller_type | EC2 instance type for controllers | "t3.small" | See below |
 | worker_type | EC2 instance type for workers | "t3.small" | See below |
 | os_image | AMI channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge |
-| disk_size | Size of the EBS volume in GB | "40" | "100" |
+| disk_size | Size of the EBS volume in GB | 40 | 100 |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
-| disk_iops | IOPS of the EBS volume | "0" (i.e. auto) | "400" |
-| worker_target_groups | Target group ARNs to which worker instances should be added | [] | ["${aws_lb_target_group.app.id}"] |
-| worker_node_labels | List of initial worker node labels | [] | ["worker-pool=default"] |
-| worker_price | Spot price in USD for workers. Leave as default empty string for regular on-demand instances | "" | "0.10" |
+| disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |
+| worker_target_groups | Target group ARNs to which worker instances should be added | [] | [aws_lb_target_group.app.id] |
+| worker_price | Spot price in USD for worker instances or 0 to use on-demand instances | 0/null | 0.10 |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
@@ -218,7 +217,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | host_cidr | CIDR IPv4 range to assign to EC2 instances | "10.0.0.0/16" | "10.1.0.0/16" |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
-| cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
+| worker_node_labels | List of initial worker node labels | [] | ["worker-pool=default"] |
 
 Check the list of valid [instance types](https://aws.amazon.com/ec2/instance-types/).
 

--- a/docs/fedora-coreos/aws.md
+++ b/docs/fedora-coreos/aws.md
@@ -191,7 +191,7 @@ resource "aws_route53_zone" "zone-for-clusters" {
 }
 ```
 
-Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`.
+Reference the DNS zone id with `aws_route53_zone.zone-for-clusters.zone_id`.
 
 !!! tip ""
     If you have an existing domain name with a zone file elsewhere, just delegate a subdomain that can be managed on Route53 (e.g. aws.mydomain.com) and [update nameservers](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html).
@@ -205,12 +205,11 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | controller_type | EC2 instance type for controllers | "t3.small" | See below |
 | worker_type | EC2 instance type for workers | "t3.small" | See below |
 | os_image | AMI channel for Fedora CoreOS | not yet used | ? |
-| disk_size | Size of the EBS volume in GB | "40" | "100" |
+| disk_size | Size of the EBS volume in GB | 40 | 100 |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
-| disk_iops | IOPS of the EBS volume | "0" (i.e. auto) | "400" |
-| worker_target_groups | Target group ARNs to which worker instances should be added | [] | ["${aws_lb_target_group.app.id}"] |
-| worker_node_labels | List of initial worker node labels | [] | ["worker-pool=default"] |
-| worker_price | Spot price in USD for workers. Leave as default empty string for regular on-demand instances | "" | "0.10" |
+| disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |
+| worker_target_groups | Target group ARNs to which worker instances should be added | [] | [aws_lb_target_group.app.id] |
+| worker_price | Spot price in USD for worker instances or 0 to use on-demand instances | 0 | 0.10 |
 | controller_snippets | Controller Fedora CoreOS Config snippets | [] | UNSUPPORTED |
 | worker_clc_snippets | Worker Fedora CoreOS Config snippets | [] | UNSUPPORTED |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
@@ -218,7 +217,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | host_cidr | CIDR IPv4 range to assign to EC2 instances | "10.0.0.0/16" | "10.1.0.0/16" |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
-| cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
+| worker_node_labels | List of initial worker node labels | [] | ["worker-pool=default"] |
 
 Check the list of valid [instance types](https://aws.amazon.com/ec2/instance-types/).
 


### PR DESCRIPTION
* Review variables available in AWS kubernetes and workers modules and documentation
* Switching between spot and on-demand has worked since Terraform v0.12
* Generally, there are too many knobs. Less useful ones should be de-emphasized or removed
* Remove `cluster_domain_suffix` documentation