### PR TITLE
Update nginx-ingress from v0.25.1 to v0.26.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@ Notable changes between versions.
 
 #### Addons
 
+* Update nginx-ingress from v0.25.1 to [v0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0) ([#555](https://github.com/poseidon/typhoon/pull/555))
+  * Add lifecycle hook to allow draining for up to 5 minutes
 * Update Grafana from v6.3.5 to [v6.3.6](https://github.com/grafana/grafana/releases/tag/v6.3.6)
 
 ## v1.16.0

--- a/addons/nginx-ingress/aws/deployment.yaml
+++ b/addons/nginx-ingress/aws/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1
           args:
             - /nginx-ingress-controller
             - --ingress-class=public
@@ -65,6 +65,11 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown
           securityContext:
             capabilities:
               add:
@@ -73,4 +78,4 @@ spec:
               - ALL
             runAsUser: 33 # www-data
       restartPolicy: Always
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300

--- a/addons/nginx-ingress/azure/deployment.yaml
+++ b/addons/nginx-ingress/azure/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1
           args:
             - /nginx-ingress-controller
             - --ingress-class=public
@@ -65,6 +65,11 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown
           securityContext:
             capabilities:
               add:
@@ -73,4 +78,4 @@ spec:
               - ALL
             runAsUser: 33 # www-data
       restartPolicy: Always
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300

--- a/addons/nginx-ingress/bare-metal/deployment.yaml
+++ b/addons/nginx-ingress/bare-metal/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1
           args:
             - /nginx-ingress-controller
             - --ingress-class=public
@@ -62,6 +62,11 @@ spec:
             successThreshold: 1
             failureThreshold: 3
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown
           securityContext:
             capabilities:
               add:
@@ -70,5 +75,5 @@ spec:
               - ALL
             runAsUser: 33 # www-data
       restartPolicy: Always
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300
 

--- a/addons/nginx-ingress/digital-ocean/daemonset.yaml
+++ b/addons/nginx-ingress/digital-ocean/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1
           args:
             - /nginx-ingress-controller
             - --ingress-class=public
@@ -65,6 +65,11 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown
           securityContext:
             capabilities:
               add:
@@ -73,4 +78,4 @@ spec:
               - ALL
             runAsUser: 33 # www-data
       restartPolicy: Always
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300

--- a/addons/nginx-ingress/google-cloud/deployment.yaml
+++ b/addons/nginx-ingress/google-cloud/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1
           args:
             - /nginx-ingress-controller
             - --ingress-class=public
@@ -65,6 +65,11 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown
           securityContext:
             capabilities:
               add:
@@ -73,4 +78,4 @@ spec:
               - ALL
             runAsUser: 33 # www-data
       restartPolicy: Always
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300


### PR DESCRIPTION
* Add lifecycle hook to allow draining connections for up to 5 minutes
* https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0
* https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.1