### PR TITLE
Add stricter types to Azure modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ Notable changes between versions.
 
 #### Azure
 
+* Add Terraform v0.12 variables types ([#557](https://github.com/poseidon/typhoon/pull/557))
+* Change `workers` module default `vm_type` to `Standard_DS1_v2` (followup to [#539](https://github.com/poseidon/typhoon/pull/539))
 * Add `node_labels` variable to internal `workers` module ([#550](https://github.com/poseidon/typhoon/pull/550))
 
 #### Bare-Metal
@@ -31,7 +33,7 @@ Notable changes between versions.
 
 #### Addons
 
-* Update nginx-ingress from v0.25.1 to [v0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0) ([#555](https://github.com/poseidon/typhoon/pull/555))
+* Update nginx-ingress from v0.25.1 to [v0.26.1](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.1) ([#555](https://github.com/poseidon/typhoon/pull/555))
   * Add lifecycle hook to allow draining for up to 5 minutes
 * Update Grafana from v6.3.5 to [v6.3.6](https://github.com/grafana/grafana/releases/tag/v6.3.6)
 

--- a/azure/container-linux/kubernetes/variables.tf
+++ b/azure/container-linux/kubernetes/variables.tf
@@ -23,27 +23,27 @@ variable "dns_zone_group" {
 # instances
 
 variable "controller_count" {
-  type        = string
-  default     = "1"
+  type        = number
   description = "Number of controllers (i.e. masters)"
+  default     = 1
 }
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
   description = "Number of workers"
+  default     = 1
 }
 
 variable "controller_type" {
   type        = string
-  default     = "Standard_B2s"
   description = "Machine type for controllers (see `az vm list-skus --location centralus`)"
+  default     = "Standard_B2s"
 }
 
 variable "worker_type" {
   type        = string
-  default     = "Standard_DS1_v2"
   description = "Machine type for workers (see `az vm list-skus --location centralus`)"
+  default     = "Standard_DS1_v2"
 }
 
 variable "os_image" {
@@ -53,15 +53,15 @@ variable "os_image" {
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
   description = "Size of the disk in GB"
+  default     = 40
 }
 
 variable "worker_priority" {
   type        = string
-  default     = "Regular"
   description = "Set worker priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time."
+  default     = "Regular"
 }
 
 variable "controller_clc_snippets" {
@@ -84,60 +84,60 @@ variable "ssh_authorized_key" {
 }
 
 variable "asset_dir" {
-  description = "Path to a directory where generated assets should be placed (contains secrets)"
   type        = string
+  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
 }
 
 variable "networking" {
-  description = "Choice of networking provider (flannel or calico)"
   type        = string
+  description = "Choice of networking provider (flannel or calico)"
   default     = "flannel"
 }
 
 variable "host_cidr" {
-  description = "CIDR IPv4 range to assign to instances"
   type        = string
+  description = "CIDR IPv4 range to assign to instances"
   default     = "10.0.0.0/16"
 }
 
 variable "pod_cidr" {
-  description = "CIDR IPv4 range to assign Kubernetes pods"
   type        = string
+  description = "CIDR IPv4 range to assign Kubernetes pods"
   default     = "10.2.0.0/16"
 }
 
 variable "service_cidr" {
+  type = string
   description = <<EOD
 CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
-
-
-  type = string
   default = "10.3.0.0/16"
 }
 
-variable "cluster_domain_suffix" {
-  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type = string
-  default = "cluster.local"
-}
-
 variable "enable_reporting" {
-  type = string
+  type = bool
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default = "false"
+  default = false
 }
 
 variable "enable_aggregation" {
+  type = bool
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type = string
-  default = "false"
+  default = false
 }
 
 variable "worker_node_labels" {
   type = list(string)
   description = "List of initial worker node labels"
   default = []
+}
+
+# unofficial, undocumented, unsupported
+
+variable "cluster_domain_suffix" {
+  type = string
+  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
+  default = "cluster.local"
 }
 

--- a/azure/container-linux/kubernetes/workers/variables.tf
+++ b/azure/container-linux/kubernetes/workers/variables.tf
@@ -33,27 +33,27 @@ variable "backend_address_pool_id" {
 # instances
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
   description = "Number of instances"
+  default     = 1
 }
 
 variable "vm_type" {
   type        = string
-  default     = "Standard_F1"
   description = "Machine type for instances (see `az vm list-skus --location centralus`)"
+  default     = "Standard_DS1_v2"
 }
 
 variable "os_image" {
   type        = string
-  default     = "coreos-stable"
   description = "Channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha)"
+  default     = "coreos-stable"
 }
 
 variable "priority" {
   type        = string
-  default     = "Regular"
   description = "Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be evicted at any time."
+  default     = "Regular"
 }
 
 variable "clc_snippets" {
@@ -75,20 +75,12 @@ variable "ssh_authorized_key" {
 }
 
 variable "service_cidr" {
+  type = string
   description = <<EOD
 CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
-
-
-  type = string
   default = "10.3.0.0/16"
-}
-
-variable "cluster_domain_suffix" {
-  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type = string
-  default = "cluster.local"
 }
 
 variable "node_labels" {
@@ -96,3 +88,12 @@ variable "node_labels" {
   description = "List of initial node labels"
   default = []
 }
+
+# unofficial, undocumented, unsupported
+
+variable "cluster_domain_suffix" {
+  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
+  type = string
+  default = "cluster.local"
+}
+

--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -62,7 +62,7 @@ The AWS internal `workers` module supports a number of [variables](https://githu
 |:-----|:------------|:--------|:--------|
 | worker_count | Number of instances | 1 | 3 |
 | instance_type | EC2 instance type | "t3.small" | "t3.medium" |
-| os_image | AMI channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha |
+| os_image | AMI channel for a Container Linux derivative | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha |
 | disk_size | Size of the EBS volume in GB | 40 | 100 |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |
@@ -130,9 +130,9 @@ The Azure internal `workers` module supports a number of [variables](https://git
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
 | worker_count | Number of instances | 1 | 3 |
-| vm_type | Machine type for instances | "Standard_F1" | See below |
-| os_image | Channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha |
-| priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | Regular | Low |
+| vm_type | Machine type for instances | "Standard_DS1_v2" | See below |
+| os_image | Channel for a Container Linux derivative | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha |
+| priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | "Regular" | "Low" |
 | clc_snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | node_labels | List of initial node labels | [] | ["worker-pool=foo"] |

--- a/docs/cl/azure.md
+++ b/docs/cl/azure.md
@@ -175,7 +175,7 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/azure/c
 | dns_zone | Azure DNS zone | "azure.example.com" |
 | dns_zone_group | Resource group where the Azure DNS zone resides | "global" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3NZ..." |
-| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/ramius" |
+| asset_dir | Absolute path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/ramius" |
 
 !!! tip
     Regions are shown in [docs](https://azure.microsoft.com/en-us/global-infrastructure/regions/) or with `az account list-locations --output table`.
@@ -195,14 +195,14 @@ resource "azurerm_resource_group" "global" {
 
 # DNS zone for clusters
 resource "azurerm_dns_zone" "clusters" {
-  resource_group_name = "${azurerm_resource_group.global.name}"
+  resource_group_name = azurerm_resource_group.global.name
 
   name      = "azure.example.com"
   zone_type = "Public"
 }
 ```
 
-Reference the DNS zone with `"${azurerm_dns_zone.clusters.name}"` and its resource group with `"${azurerm_resource_group.global.name}"`.
+Reference the DNS zone with `azurerm_dns_zone.clusters.name` and its resource group with `"azurerm_resource_group.global.name`.
 
 !!! tip ""
     If you have an existing domain name with a zone file elsewhere, just delegate a subdomain that can be managed on Azure DNS (e.g. azure.mydomain.com) and [update nameservers](https://docs.microsoft.com/en-us/azure/dns/dns-delegate-domain-azure-dns).
@@ -213,10 +213,10 @@ Reference the DNS zone with `"${azurerm_dns_zone.clusters.name}"` and its resour
 |:-----|:------------|:--------|:--------|
 | controller_count | Number of controllers (i.e. masters) | 1 | 1 |
 | worker_count | Number of workers | 1 | 3 |
-| controller_type | Machine type for controllers | "Standard_DS1_v2" | See below |
-| worker_type | Machine type for workers | "Standard_F1" | See below |
-| os_image | Channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha |
-| disk_size | Size of the disk in GB | "40" | "100" |
+| controller_type | Machine type for controllers | "Standard_B2s" | See below |
+| worker_type | Machine type for workers | "Standard_DS1_v2" | See below |
+| os_image | Channel for a Container Linux derivative | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha |
+| disk_size | Size of the disk in GB | 40 | 100 |
 | worker_node_labels | List of initial worker node labels | [] | ["worker-pool=default"] |
 | worker_priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | Regular | Low |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |


### PR DESCRIPTION
* Review variables available in Azure kubernetes and workers
modules and sync with documentation
* Fix internal `workers` module default type to `Standard_DS1_v2`