### PR TITLE
Detect most recent Fedora CoreOS AMI in region

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Notable changes between versions.
 #### AWS
 
 * Add `node_labels` variable to internal `workers` module ([#550](https://github.com/poseidon/typhoon/pull/550))
+* For Fedora CoreOS, detect most recent AMI in the region
 
 #### Azure
 
@@ -24,7 +25,7 @@ Notable changes between versions.
 
 * Fix Terraform missing comma error ([#549](https://github.com/poseidon/typhoon/pull/549))
 * Remove deprecated `container_linux_oem` variable ([#562](https://github.com/poseidon/typhoon/pull/562))
-* Use new kernel, initrd, and raw paths for Fedora CoreOS ([#563](https://github.com/poseidon/typhoon/pull/563))
+* For Fedora CoreOS, use new kernel, initrd, and raw paths ([#563](https://github.com/poseidon/typhoon/pull/563))
 
 #### DigitalOcean
 

--- a/aws/fedora-coreos/kubernetes/ami.tf
+++ b/aws/fedora-coreos/kubernetes/ami.tf
@@ -13,9 +13,11 @@ data "aws_ami" "fedora-coreos" {
     values = ["hvm"]
   }
 
-  // pin on known ok versions as preview matures
   filter {
     name   = "name"
-    values = ["fedora-coreos-30.20190905.0-hvm"]
+    values = ["fedora-coreos-30.*.*-hvm"]
   }
+
+  # try to filter out dev images (AWS filters can't)
+  name_regex = "^fedora-coreos-30.[0-9]*.[0-9]*-hvm*"
 }

--- a/aws/fedora-coreos/kubernetes/workers/ami.tf
+++ b/aws/fedora-coreos/kubernetes/workers/ami.tf
@@ -13,9 +13,11 @@ data "aws_ami" "fedora-coreos" {
     values = ["hvm"]
   }
 
-  // pin on known ok versions as preview matures
   filter {
     name   = "name"
-    values = ["fedora-coreos-30.20190905.0-hvm"]
+    values = ["fedora-coreos-30.*.*-hvm"]
   }
+ 
+  # try to filter out dev images (AWS filters can't)
+  name_regex = "^fedora-coreos-30.[0-9]*.[0-9]*-hvm*"
 }

--- a/docs/fedora-coreos/aws.md
+++ b/docs/fedora-coreos/aws.md
@@ -53,7 +53,7 @@ Configure the AWS provider to use your access key credentials in a `providers.tf
 ```tf
 provider "aws" {
   version                 = "2.29.0"
-  region                  = "us-east-1"   # MUST be us-east-1 right now!
+  region                  = "eu-central-1"
   shared_credentials_file = "/home/user/.config/aws/credentials"
 }
 


### PR DESCRIPTION
* Detect the most recent Fedora CoreOS AMI to allow usage
of Fedora CoreOS in supported regions (previously just
us-east-1)
* Unpin the Fedora CoreOS AMI image which was pinned to
images that had been checked. This does mean if Fedora
publishes a broken image, it will be selected
* Filter out "dev" images which have similar naming
