### PR TITLE
Introduce controllers and workers list of detail objects for bare-metal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,19 @@
 
 Notable changes between versions.
 
+## Latest
+
+#### Bare-Metal
+
+* Add `controllers` and `workers` as typed lists of machine detail objects ([#566](https://github.com/poseidon/typhoon/pull/566))
+  * Define clusters' machines cleanly and with Terraform v0.12 type constraints (**action required**, see PR example)
+  * Remove `controller_names` list variable
+  * Remove `controller_macs` list variable
+  * Remove `controller_domains` list variable
+  * Remove `worker_names` list variable
+  * Remove `worker_macs` list variable
+  * Remove `worker_domains` list variable
+
 ## v1.16.1
 
 * Kubernetes [v1.16.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#v1161)

--- a/bare-metal/container-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/container-linux/kubernetes/bootstrap.tf
@@ -4,7 +4,7 @@ module "bootstrap" {
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]
-  etcd_servers                    = var.controller_domains
+  etcd_servers                    = var.controllers.*.domain
   asset_dir                       = var.asset_dir
   networking                      = var.networking
   network_mtu                     = var.network_mtu

--- a/bare-metal/container-linux/kubernetes/groups.tf
+++ b/bare-metal/container-linux/kubernetes/groups.tf
@@ -1,34 +1,34 @@
 resource "matchbox_group" "install" {
-  count = length(var.controller_names) + length(var.worker_names)
+  count = length(var.controllers) + length(var.workers)
 
-  name = format("install-%s", element(concat(var.controller_names, var.worker_names), count.index))
+  name = format("install-%s", concat(var.controllers.*.name, var.workers.*.name)[count.index])
 
   # pick one of 4 Matchbox profiles (Container Linux or Flatcar, cached or non-cached)
-  profile = local.flavor == "flatcar" ? var.cached_install ? element(matchbox_profile.cached-flatcar-linux-install.*.name, count.index) : element(matchbox_profile.flatcar-install.*.name, count.index) : var.cached_install ? element(matchbox_profile.cached-container-linux-install.*.name, count.index) : element(matchbox_profile.container-linux-install.*.name, count.index)
+  profile = local.flavor == "flatcar" ? var.cached_install ? matchbox_profile.cached-flatcar-linux-install.*.name[count.index] : matchbox_profile.flatcar-install.*.name[count.index] : var.cached_install ? matchbox_profile.cached-container-linux-install.*.name[count.index] : matchbox_profile.container-linux-install.*.name[count.index]
 
   selector = {
-    mac = element(concat(var.controller_macs, var.worker_macs), count.index)
+    mac = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
   }
 }
 
 resource "matchbox_group" "controller" {
-  count   = length(var.controller_names)
-  name    = format("%s-%s", var.cluster_name, element(var.controller_names, count.index))
-  profile = element(matchbox_profile.controllers.*.name, count.index)
+  count   = length(var.controllers)
+  name    = format("%s-%s", var.cluster_name, var.controllers[count.index].name)
+  profile = matchbox_profile.controllers.*.name[count.index]
 
   selector = {
-    mac = element(var.controller_macs, count.index)
+    mac = var.controllers[count.index].mac
     os  = "installed"
   }
 }
 
 resource "matchbox_group" "worker" {
-  count   = length(var.worker_names)
-  name    = format("%s-%s", var.cluster_name, element(var.worker_names, count.index))
-  profile = element(matchbox_profile.workers.*.name, count.index)
+  count   = length(var.workers)
+  name    = format("%s-%s", var.cluster_name, var.workers[count.index].name)
+  profile = matchbox_profile.workers.*.name[count.index]
 
   selector = {
-    mac = element(var.worker_macs, count.index)
+    mac = var.workers[count.index].mac
     os  = "installed"
   }
 }

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -1,15 +1,14 @@
 locals {
   # coreos-stable -> coreos flavor, stable channel
   # flatcar-stable -> flatcar flavor, stable channel
-  flavor = element(split("-", var.os_channel), 0)
-
-  channel = element(split("-", var.os_channel), 1)
+  flavor = split("-", var.os_channel)[0]
+  channel = split("-", var.os_channel)[1]
 }
 
 // Container Linux Install profile (from release.core-os.net)
 resource "matchbox_profile" "container-linux-install" {
-  count = length(var.controller_names) + length(var.worker_names)
-  name  = format("%s-container-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))
+  count = length(var.controllers) + length(var.workers)
+  name  = format("%s-container-linux-install-%s", var.cluster_name, concat(var.controllers.*.name, var.workers.*.name)[count.index])
 
   kernel = "${var.download_protocol}://${local.channel}.release.core-os.net/amd64-usr/${var.os_version}/coreos_production_pxe.vmlinuz"
 
@@ -26,11 +25,11 @@ resource "matchbox_profile" "container-linux-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = element(data.template_file.container-linux-install-configs.*.rendered, count.index)
+  container_linux_config = data.template_file.container-linux-install-configs.*.rendered[count.index]
 }
 
 data "template_file" "container-linux-install-configs" {
-  count = length(var.controller_names) + length(var.worker_names)
+  count = length(var.controllers) + length(var.workers)
 
   template = file("${path.module}/cl/install.yaml.tmpl")
 
@@ -49,8 +48,8 @@ data "template_file" "container-linux-install-configs" {
 // Container Linux Install profile (from matchbox /assets cache)
 // Note: Admin must have downloaded os_version into matchbox assets/coreos.
 resource "matchbox_profile" "cached-container-linux-install" {
-  count = length(var.controller_names) + length(var.worker_names)
-  name  = format("%s-cached-container-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))
+  count = length(var.controllers) + length(var.workers)
+  name  = format("%s-cached-container-linux-install-%s", var.cluster_name, concat(var.controllers.*.name, var.workers.*.name)[count.index])
 
   kernel = "/assets/coreos/${var.os_version}/coreos_production_pxe.vmlinuz"
 
@@ -67,11 +66,11 @@ resource "matchbox_profile" "cached-container-linux-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = element(data.template_file.cached-container-linux-install-configs.*.rendered, count.index)
+  container_linux_config = data.template_file.cached-container-linux-install-configs.*.rendered[count.index]
 }
 
 data "template_file" "cached-container-linux-install-configs" {
-  count = length(var.controller_names) + length(var.worker_names)
+  count = length(var.controllers) + length(var.workers)
 
   template = file("${path.module}/cl/install.yaml.tmpl")
 
@@ -89,8 +88,8 @@ data "template_file" "cached-container-linux-install-configs" {
 
 // Flatcar Linux install profile (from release.flatcar-linux.net)
 resource "matchbox_profile" "flatcar-install" {
-  count = length(var.controller_names) + length(var.worker_names)
-  name  = format("%s-flatcar-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))
+  count = length(var.controllers) + length(var.workers)
+  name  = format("%s-flatcar-install-%s", var.cluster_name, concat(var.controllers.*.name, var.workers.*.name)[count.index])
 
   kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
 
@@ -107,14 +106,14 @@ resource "matchbox_profile" "flatcar-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = element(data.template_file.container-linux-install-configs.*.rendered, count.index)
+  container_linux_config = data.template_file.container-linux-install-configs.*.rendered[count.index]
 }
 
 // Flatcar Linux Install profile (from matchbox /assets cache)
 // Note: Admin must have downloaded os_version into matchbox assets/flatcar.
 resource "matchbox_profile" "cached-flatcar-linux-install" {
-  count = length(var.controller_names) + length(var.worker_names)
-  name  = format("%s-cached-flatcar-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))
+  count = length(var.controllers) + length(var.workers)
+  name  = format("%s-cached-flatcar-linux-install-%s", var.cluster_name, concat(var.controllers.*.name, var.workers.*.name)[count.index])
 
   kernel = "/assets/flatcar/${var.os_version}/flatcar_production_pxe.vmlinuz"
 
@@ -131,32 +130,32 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = element(data.template_file.cached-container-linux-install-configs.*.rendered, count.index)
+  container_linux_config = data.template_file.cached-container-linux-install-configs.*.rendered[count.index]
 }
 
 // Kubernetes Controller profiles
 resource "matchbox_profile" "controllers" {
-  count        = length(var.controller_names)
-  name         = format("%s-controller-%s", var.cluster_name, element(var.controller_names, count.index))
-  raw_ignition = element(data.ct_config.controller-ignitions.*.rendered, count.index)
+  count        = length(var.controllers)
+  name         = format("%s-controller-%s", var.cluster_name, var.controllers.*.name[count.index])
+  raw_ignition = data.ct_config.controller-ignitions.*.rendered[count.index]
 }
 
 data "ct_config" "controller-ignitions" {
-  count        = length(var.controller_names)
-  content      = element(data.template_file.controller-configs.*.rendered, count.index)
+  count        = length(var.controllers)
+  content      = data.template_file.controller-configs.*.rendered[count.index]
   pretty_print = false
-  snippets     = local.clc_map[element(var.controller_names, count.index)]
+  snippets     = local.clc_map[var.controllers.*.name[count.index]]
 }
 
 data "template_file" "controller-configs" {
-  count = length(var.controller_names)
+  count = length(var.controllers)
 
   template = file("${path.module}/cl/controller.yaml.tmpl")
 
   vars = {
-    domain_name            = element(var.controller_domains, count.index)
-    etcd_name              = element(var.controller_names, count.index)
-    etcd_initial_cluster   = join(",", formatlist("%s=https://%s:2380", var.controller_names, var.controller_domains))
+    domain_name            = var.controllers.*.domain[count.index]
+    etcd_name              = var.controllers.*.name[count.index]
+    etcd_initial_cluster   = join(",", formatlist("%s=https://%s:2380", var.controllers.*.name, var.controllers.*.domain))
     cgroup_driver = var.os_channel == "flatcar-edge" ? "systemd" : "cgroupfs"
     cluster_dns_service_ip = module.bootstrap.cluster_dns_service_ip
     cluster_domain_suffix  = var.cluster_domain_suffix
@@ -166,25 +165,25 @@ data "template_file" "controller-configs" {
 
 // Kubernetes Worker profiles
 resource "matchbox_profile" "workers" {
-  count        = length(var.worker_names)
-  name         = format("%s-worker-%s", var.cluster_name, element(var.worker_names, count.index))
-  raw_ignition = element(data.ct_config.worker-ignitions.*.rendered, count.index)
+  count        = length(var.workers)
+  name         = format("%s-worker-%s", var.cluster_name, var.workers.*.name[count.index])
+  raw_ignition = data.ct_config.worker-ignitions.*.rendered[count.index]
 }
 
 data "ct_config" "worker-ignitions" {
-  count        = length(var.worker_names)
-  content      = element(data.template_file.worker-configs.*.rendered, count.index)
+  count        = length(var.workers)
+  content      = data.template_file.worker-configs.*.rendered[count.index]
   pretty_print = false
-  snippets     = local.clc_map[element(var.worker_names, count.index)]
+  snippets     = local.clc_map[var.workers.*.name[count.index]]
 }
 
 data "template_file" "worker-configs" {
-  count = length(var.worker_names)
+  count = length(var.workers)
 
   template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
-    domain_name            = element(var.worker_domains, count.index)
+    domain_name            = var.workers.*.domain[count.index]
     cgroup_driver = var.os_channel == "flatcar-edge" ? "systemd" : "cgroupfs"
     cluster_dns_service_ip = module.bootstrap.cluster_dns_service_ip
     cluster_domain_suffix  = var.cluster_domain_suffix
@@ -198,7 +197,7 @@ locals {
   # Default Container Linux config snippets map every node names to list("\n") so
   # all lookups succeed
   clc_defaults = zipmap(
-    concat(var.controller_names, var.worker_names),
+    concat(var.controllers.*.name, var.workers.*.name),
     chunklist(data.template_file.clc-default-snippets.*.rendered, 1),
   )
 
@@ -208,7 +207,7 @@ locals {
 
 // Horrible hack to generate a Terraform list of node count length
 data "template_file" "clc-default-snippets" {
-  count    = length(var.controller_names) + length(var.worker_names)
+  count    = length(var.controllers) + length(var.workers)
   template = "\n"
 }
 

--- a/bare-metal/container-linux/kubernetes/ssh.tf
+++ b/bare-metal/container-linux/kubernetes/ssh.tf
@@ -1,6 +1,6 @@
 # Secure copy assets to controllers. Activates kubelet.service
 resource "null_resource" "copy-controller-secrets" {
-  count = length(var.controller_names)
+  count = length(var.controllers)
 
   # Without depends_on, remote-exec could start and wait for machines before
   # matchbox groups are written, causing a deadlock.
@@ -13,7 +13,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = var.controller_domains[count.index]
+    host    = var.controllers.*.domain[count.index]
     user    = "core"
     timeout = "60m"
   }
@@ -88,7 +88,7 @@ resource "null_resource" "copy-controller-secrets" {
 
 # Secure copy kubeconfig to all workers. Activates kubelet.service
 resource "null_resource" "copy-worker-secrets" {
-  count = length(var.worker_names)
+  count = length(var.workers)
 
   # Without depends_on, remote-exec could start and wait for machines before
   # matchbox groups are written, causing a deadlock.
@@ -100,7 +100,7 @@ resource "null_resource" "copy-worker-secrets" {
 
   connection {
     type    = "ssh"
-    host    = var.worker_domains[count.index]
+    host    = var.workers.*.domain[count.index]
     user    = "core"
     timeout = "60m"
   }
@@ -129,7 +129,7 @@ resource "null_resource" "bootstrap" {
 
   connection {
     type    = "ssh"
-    host    = var.controller_domains[0]
+    host    = var.controllers[0].domain
     user    = "core"
     timeout = "15m"
   }

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -21,36 +21,32 @@ variable "os_version" {
 }
 
 # machines
-# Terraform's crude "type system" does not properly support lists of maps so we do this.
 
-variable "controller_names" {
-  type        = list(string)
-  description = "Ordered list of controller names (e.g. [node1])"
+variable "controllers" {
+  type = list(object({
+    name = string
+    mac = string
+    domain = string
+  }))
+  description = <<EOD
+List of controller machine details (unique name, identifying MAC address, FQDN)
+[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
+EOD
 }
 
-variable "controller_macs" {
-  type        = list(string)
-  description = "Ordered list of controller identifying MAC addresses (e.g. [52:54:00:a1:9c:ae])"
-}
-
-variable "controller_domains" {
-  type        = list(string)
-  description = "Ordered list of controller FQDNs (e.g. [node1.example.com])"
-}
-
-variable "worker_names" {
-  type        = list(string)
-  description = "Ordered list of worker names (e.g. [node2, node3])"
-}
-
-variable "worker_macs" {
-  type        = list(string)
-  description = "Ordered list of worker identifying MAC addresses (e.g. [52:54:00:b2:2f:86, 52:54:00:c3:61:77])"
-}
-
-variable "worker_domains" {
-  type        = list(string)
-  description = "Ordered list of worker FQDNs (e.g. [node2.example.com, node3.example.com])"
+variable "workers" {
+  type = list(object({
+    name = string
+    mac = string
+    domain = string
+  }))
+  description = <<EOD
+List of worker machine details (unique name, identifying MAC address, FQDN)
+[
+  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
+  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
+]
+EOD
 }
 
 variable "clc_snippets" {

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -4,7 +4,7 @@ module "bootstrap" {
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]
-  etcd_servers                    = var.controller_domains
+  etcd_servers                    = var.controllers.*.domain
   asset_dir                       = var.asset_dir
   networking                      = var.networking
   network_mtu                     = var.network_mtu

--- a/bare-metal/fedora-coreos/kubernetes/groups.tf
+++ b/bare-metal/fedora-coreos/kubernetes/groups.tf
@@ -1,22 +1,22 @@
 # Match each controller or worker to a profile
 
 resource "matchbox_group" "controller" {
-  count   = length(var.controller_names)
-  name    = format("%s-%s", var.cluster_name, var.controller_names[count.index])
+  count   = length(var.controllers)
+  name    = format("%s-%s", var.cluster_name, var.controllers.*.name[count.index])
   profile = matchbox_profile.controllers.*.name[count.index]
 
   selector = {
-    mac = var.controller_macs[count.index]
+    mac = var.controllers.*.mac[count.index]
   }
 }
 
 resource "matchbox_group" "worker" {
-  count   = length(var.worker_names)
-  name    = format("%s-%s", var.cluster_name, var.worker_names[count.index])
+  count   = length(var.workers)
+  name    = format("%s-%s", var.cluster_name, var.workers.*.name[count.index])
   profile = matchbox_profile.workers.*.name[count.index]
 
   selector = {
-    mac = var.worker_macs[count.index]
+    mac = var.workers.*.mac[count.index]
   }
 }
 

--- a/bare-metal/fedora-coreos/kubernetes/ssh.tf
+++ b/bare-metal/fedora-coreos/kubernetes/ssh.tf
@@ -1,6 +1,6 @@
 # Secure copy assets to controllers. Activates kubelet.service
 resource "null_resource" "copy-controller-secrets" {
-  count = length(var.controller_names)
+  count = length(var.controllers)
 
   # Without depends_on, remote-exec could start and wait for machines before
   # matchbox groups are written, causing a deadlock.
@@ -12,7 +12,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = var.controller_domains[count.index]
+    host    = var.controllers.*.domain[count.index]
     user    = "core"
     timeout = "60m"
   }
@@ -85,7 +85,7 @@ resource "null_resource" "copy-controller-secrets" {
 
 # Secure copy kubeconfig to all workers. Activates kubelet.service
 resource "null_resource" "copy-worker-secrets" {
-  count = length(var.worker_names)
+  count = length(var.workers)
 
   # Without depends_on, remote-exec could start and wait for machines before
   # matchbox groups are written, causing a deadlock.
@@ -96,7 +96,7 @@ resource "null_resource" "copy-worker-secrets" {
 
   connection {
     type    = "ssh"
-    host    = var.worker_domains[count.index]
+    host    = var.workers.*.domain[count.index]
     user    = "core"
     timeout = "60m"
   }
@@ -125,7 +125,7 @@ resource "null_resource" "bootstrap" {
 
   connection {
     type    = "ssh"
-    host    = var.controller_domains[0]
+    host    = var.controllers[0].domain
     user    = "core"
     timeout = "15m"
   }

--- a/bare-metal/fedora-coreos/kubernetes/variables.tf
+++ b/bare-metal/fedora-coreos/kubernetes/variables.tf
@@ -22,36 +22,32 @@ variable "os_version" {
 }
 
 # machines
-# Terraform's crude "type system" does not properly support lists of maps so we do this.
 
-variable "controller_names" {
-  type        = list(string)
-  description = "Ordered list of controller names (e.g. [node1])"
+variable "controllers" {
+  type = list(object({
+    name = string
+    mac = string
+    domain = string
+  }))
+  description = <<EOD
+List of controller machine details (unique name, identifying MAC address, FQDN)
+[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
+EOD
 }
 
-variable "controller_macs" {
-  type        = list(string)
-  description = "Ordered list of controller identifying MAC addresses (e.g. [52:54:00:a1:9c:ae])"
-}
-
-variable "controller_domains" {
-  type        = list(string)
-  description = "Ordered list of controller FQDNs (e.g. [node1.example.com])"
-}
-
-variable "worker_names" {
-  type        = list(string)
-  description = "Ordered list of worker names (e.g. [node2, node3])"
-}
-
-variable "worker_macs" {
-  type        = list(string)
-  description = "Ordered list of worker identifying MAC addresses (e.g. [52:54:00:b2:2f:86, 52:54:00:c3:61:77])"
-}
-
-variable "worker_domains" {
-  type        = list(string)
-  description = "Ordered list of worker FQDNs (e.g. [node2.example.com, node3.example.com])"
+variable "workers" {
+  type = list(object({
+    name = string
+    mac = string
+    domain = string
+  }))
+  description = <<EOD
+List of worker machine details (unique name, identifying MAC address, FQDN)
+[
+  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
+  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
+]
+EOD
 }
 
 variable "snippets" {

--- a/docs/cl/bare-metal.md
+++ b/docs/cl/bare-metal.md
@@ -174,20 +174,22 @@ module "bare-metal-mercury" {
   asset_dir          = "/home/user/.secrets/clusters/mercury"
 
   # machines
-  controller_names   = ["node1"]
-  controller_macs    = ["52:54:00:a1:9c:ae"]
-  controller_domains = ["node1.example.com"]
-  worker_names = [
-    "node2",
-    "node3",
-  ]
-  worker_macs = [
-    "52:54:00:b2:2f:86",
-    "52:54:00:c3:61:77",
-  ]
-  worker_domains = [
-    "node2.example.com",
-    "node3.example.com",
+  controllers = [{
+    name   = "node1"
+    mac    = "52:54:00:a1:9c:ae"
+    domain = "node1.example.com"
+  }]
+  workers = [
+    {
+      name   = "node2",
+      mac    = "52:54:00:b2:2f:86"
+      domain = "node2.example.com"
+    },
+    {
+      name   = "node3",
+      mac    = "52:54:00:c3:61:77"
+      domain = "node3.example.com"
+    }
   ]
 
   # set to http only if you cannot chainload to iPXE firmware with https support
@@ -334,12 +336,8 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/bare-me
 | k8s_domain_name | FQDN resolving to the controller(s) nodes. Workers and kubectl will communicate with this endpoint | "myk8s.example.com" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3Nz..." |
 | asset_dir | Absolute path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/mercury" |
-| controller_names | Ordered list of controller short names | ["node1"] |
-| controller_macs | Ordered list of controller identifying MAC addresses | ["52:54:00:a1:9c:ae"] |
-| controller_domains | Ordered list of controller FQDNs | ["node1.example.com"] |
-| worker_names | Ordered list of worker short names | ["node2", "node3"] |
-| worker_macs | Ordered list of worker identifying MAC addresses | ["52:54:00:b2:2f:86", "52:54:00:c3:61:77"] |
-| worker_domains | Ordered list of worker FQDNs | ["node2.example.com", "node3.example.com"] |
+| controllers | List of controller machine detail objects (unique name, identifying MAC address, FQDN) | `[{name="node1", mac="52:54:00:a1:9c:ae", domain="node1.example.com"}]` |
+| workers | List of worker machine detail objects (unique name, identifying MAC address, FQDN) | `[{name="node2", mac="52:54:00:b2:2f:86", domain="node2.example.com"}, {name="node3", mac="52:54:00:c3:61:77", domain="node3.example.com"}]` |
 
 ### Optional
 

--- a/docs/fedora-coreos/bare-metal.md
+++ b/docs/fedora-coreos/bare-metal.md
@@ -178,20 +178,22 @@ module "bare-metal-mercury" {
   asset_dir          = "/home/user/.secrets/clusters/mercury"
 
   # machines
-  controller_names   = ["node1"]
-  controller_macs    = ["52:54:00:a1:9c:ae"]
-  controller_domains = ["node1.example.com"]
-  worker_names = [
-    "node2",
-    "node3",
-  ]
-  worker_macs = [
-    "52:54:00:b2:2f:86",
-    "52:54:00:c3:61:77",
-  ]
-  worker_domains = [
-    "node2.example.com",
-    "node3.example.com",
+  controllers = [{
+    name   = "node1"
+    mac    = "52:54:00:a1:9c:ae"
+    domain = "node1.example.com"
+  }]
+  workers = [
+    {
+      name   = "node2",
+      mac    = "52:54:00:b2:2f:86"
+      domain = "node2.example.com"
+    },
+    {
+      name   = "node3",
+      mac    = "52:54:00:c3:61:77"
+      domain = "node3.example.com"
+    }
   ]
 }
 ```
@@ -325,12 +327,8 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/bare-me
 | k8s_domain_name | FQDN resolving to the controller(s) nodes. Workers and kubectl will communicate with this endpoint | "myk8s.example.com" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3Nz..." |
 | asset_dir | Absolute path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/mercury" |
-| controller_names | Ordered list of controller short names | ["node1"] |
-| controller_macs | Ordered list of controller identifying MAC addresses | ["52:54:00:a1:9c:ae"] |
-| controller_domains | Ordered list of controller FQDNs | ["node1.example.com"] |
-| worker_names | Ordered list of worker short names | ["node2", "node3"] |
-| worker_macs | Ordered list of worker identifying MAC addresses | ["52:54:00:b2:2f:86", "52:54:00:c3:61:77"] |
-| worker_domains | Ordered list of worker FQDNs | ["node2.example.com", "node3.example.com"] |
+| controllers | List of controller machine detail objects (unique name, identifying MAC address, FQDN) | `[{name="node1", mac="52:54:00:a1:9c:ae", domain="node1.example.com"}]` |
+| workers | List of worker machine detail objects (unique name, identifying MAC address, FQDN) | `[{name="node2", mac="52:54:00:b2:2f:86", domain="node2.example.com"}, {name="node3", mac="52:54:00:c3:61:77", domain="node3.example.com"}]` |
 
 ### Optional
 


### PR DESCRIPTION
* Define bare-metal `controllers` and `workers` as a complex type `list(object{name=string, mac=string, domain=string})` to allow clusters with many machines to be defined more cleanly
  * Remove `controller_names` list variable
  * Remove `controller_macs` list variable
  * Remove `controller_domains` list variable
  * Remove `worker_names` list variable
  * Remove `worker_macs` list variable
  * Remove `worker_domains` list variable

Using the tutorial docs example, a cluster previously defined as:

```
module "bare-metal-mercury" {
  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=v1.16.1"
  ...

  # machines
  controller_names   = ["node1"]
  controller_macs    = ["52:54:00:a1:9c:ae"]
  controller_domains = ["node1.example.com"]
  worker_names = [
    "node2",
    "node3",
  ]
  worker_macs = [
    "52:54:00:b2:2f:86",
    "52:54:00:c3:61:77",
  ]
  worker_domains = [
    "node2.example.com",
    "node3.example.com",
  ]
}
```

should now be defined:

```
module "bare-metal-mercury" {
  source = "git::https://github.com/poseidon/typhoon//bare-metal/fedora-coreos/kubernetes?ref=v1.16.2"

  # machines
  controllers = [{
    name   = "node1"
    mac    = "52:54:00:a1:9c:ae"
    domain = "node1.example.com"
  }]
  workers = [
    {
      name   = "node2",
      mac    = "52:54:00:b2:2f:86"
      domain = "node2.example.com"
    },
    {
      name   = "node3",
      mac    = "52:54:00:c3:61:77"
      domain = "node3.example.com"
    }
  ]
}
```

As before, all machine names must be unique. Optional features like `clc_snippets` may map from a machine name to a value (e.g. list of snippets contents in this case). 