### PR TITLE
Expose azure information for load balancing and DNS

### DIFF
--- a/azure/container-linux/kubernetes/outputs.tf
+++ b/azure/container-linux/kubernetes/outputs.tf
@@ -9,6 +9,13 @@ output "ingress_static_ipv4" {
   description = "IPv4 address of the load balancer for distributing traffic to Ingress controllers"
 }
 
+# Outputs for controllers
+
+output "controller_public_ips" {
+  description = "IPv4 addresses of the controller VMs (e.g. for SSH)"
+  value       = azurerm_public_ip.controllers.*.ip_address
+}
+
 # Outputs for worker pools
 
 output "region" {
@@ -54,3 +61,7 @@ output "backend_address_pool_id" {
   value       = azurerm_lb_backend_address_pool.worker.id
 }
 
+output "backend_probe_id" {
+  description = "ID of the worker backend health probe"
+  value       = azurerm_lb_probe.ingress.id
+}


### PR DESCRIPTION
Add two extra output variables for azure

* the ingress http probe id is usefull for custom load balancing rules
* the controller public IPs are usefull to create DNS entries

## Testing

Use these in a production cluster like this:

    resource "azurerm_lb_rule" "ingress-extra" {
      count               = length(var.extra_ingress_ports)
      resource_group_name = module.typhoon_cluster.resource_group_name

      name                           = "ingress-extra-${element(var.extra_ingress_ports, count.index)}"
      loadbalancer_id                = module.typhoon_cluster.loadbalancer_id
      frontend_ip_configuration_name = "ingress"

      protocol                = "Tcp"
      frontend_port           = element(var.extra_ingress_ports, count.index)
      backend_port            = element(var.extra_ingress_ports, count.index)
      backend_address_pool_id = module.typhoon_cluster.backend_address_pool_id
      probe_id                = module.typhoon_cluster.backend_probe_id
    }