### PR TITLE
Support worker managed identity in Azure

### DIFF
--- a/azure/container-linux/kubernetes/outputs.tf
+++ b/azure/container-linux/kubernetes/outputs.tf
@@ -19,6 +19,10 @@ output "resource_group_name" {
   value = azurerm_resource_group.cluster.name
 }
 
+output "resource_group_id" {
+  value = azurerm_resource_group.cluster.id
+}
+
 output "subnet_id" {
   value = azurerm_subnet.worker.id
 }
@@ -29,6 +33,11 @@ output "security_group_id" {
 
 output "kubeconfig" {
   value = module.bootstrap.kubeconfig-kubelet
+}
+
+output "worker_principal_id" {
+  description = "The identity principal for the worker pool VMs"
+  value       = module.workers.principal_id
 }
 
 # Outputs for custom firewalling

--- a/azure/container-linux/kubernetes/variables.tf
+++ b/azure/container-linux/kubernetes/variables.tf
@@ -46,6 +46,12 @@ variable "worker_type" {
   default     = "Standard_DS1_v2"
 }
 
+variable "worker_identity" {
+  description = "The type of Identity management to specify for the worker VMs. Options are None (default) or SystemAssigned"
+  type = string
+  default = "None"
+}
+
 variable "os_image" {
   type        = string
   default     = "coreos-stable"

--- a/azure/container-linux/kubernetes/workers.tf
+++ b/azure/container-linux/kubernetes/workers.tf
@@ -21,5 +21,6 @@ module "workers" {
   cluster_domain_suffix = var.cluster_domain_suffix
   clc_snippets          = var.worker_clc_snippets
   node_labels           = var.worker_node_labels
+  identity              = var.worker_identity
 }
 

--- a/azure/container-linux/kubernetes/workers/outputs.tf
+++ b/azure/container-linux/kubernetes/workers/outputs.tf
@@ -1,0 +1,3 @@
+output "principal_id" {
+  value = azurerm_virtual_machine_scale_set.workers.identity[0].principal_id
+}

--- a/azure/container-linux/kubernetes/workers/variables.tf
+++ b/azure/container-linux/kubernetes/workers/variables.tf
@@ -97,3 +97,8 @@ variable "cluster_domain_suffix" {
   default = "cluster.local"
 }
 
+variable "identity" {
+  description = "The type of Identity management to specify for the worker VMs. Options are None (default) or SystemAssigned"
+  type = string
+  default = "None"
+}

--- a/azure/container-linux/kubernetes/workers/workers.tf
+++ b/azure/container-linux/kubernetes/workers/workers.tf
@@ -18,6 +18,10 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
     capacity = var.worker_count
   }
 
+  identity {
+    type = var.identity
+  }
+
   # boot
   storage_profile_image_reference {
     publisher = "CoreOS"


### PR DESCRIPTION
Add a variable `worker_identity` to optionally configure system managed
identity for the worker vms in Azure.

## Testing

Using this in production like this:

    resource "azurerm_role_assignment" "cluster-role" {
      name                 = "${random_uuid.cluster-role-name.result}"
      scope                = "${module.typhoon_cluster.resource_group_id}"
      role_definition_name = "Contributor"
      principal_id         = "${module.typhoon_cluster.worker_principal_id}"
    }

See also: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview