### PR TITLE
Default to Calico as the CNI provider on Azure/DigitalOcean

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,14 @@ Notable changes between versions.
 
 ## Latest
 
-
 * Kubernetes [v1.16.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#v1162)
 * Update etcd from v3.4.1 to v3.4.2 ([#570](https://github.com/poseidon/typhoon/pull/570))
 * Update Calico from v3.9.1 to [v3.9.2](https://docs.projectcalico.org/v3.9/release-notes/)
+  * Default to using Calico and supporting NetworkPolicy on all platforms
+
+#### Azure
+
+* Change default networking provider from "flannel" to "calico" ([#573](https://github.com/poseidon/typhoon/pull/573))
 
 #### Bare-Metal
 
@@ -20,10 +24,13 @@ Notable changes between versions.
   * Remove `worker_macs` list variable
   * Remove `worker_domains` list variable
 
+#### DigitalOcean
+
+* Change default networking provider from "flannel" to "calico" ([#573](https://github.com/poseidon/typhoon/pull/573))
+
 #### Addons
 
 * Update Grafana from v6.4.1 to [v6.4.2](https://github.com/grafana/grafana/releases/tag/v6.4.2)
-
 
 ## v1.16.1
 

--- a/azure/container-linux/kubernetes/variables.tf
+++ b/azure/container-linux/kubernetes/variables.tf
@@ -91,7 +91,7 @@ variable "asset_dir" {
 variable "networking" {
   type        = string
   description = "Choice of networking provider (flannel or calico)"
-  default     = "flannel"
+  default     = "calico"
 }
 
 variable "host_cidr" {

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -74,7 +74,7 @@ variable "asset_dir" {
 variable "networking" {
   type        = string
   description = "Choice of networking provider (flannel or calico)"
-  default     = "flannel"
+  default     = "calico"
 }
 
 variable "pod_cidr" {

--- a/docs/cl/azure.md
+++ b/docs/cl/azure.md
@@ -144,9 +144,9 @@ $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                        READY  STATUS    RESTARTS  AGE
 kube-system   coredns-7c6fbb4f4b-b6qzx                    1/1    Running   0         26m
 kube-system   coredns-7c6fbb4f4b-j2k3d                    1/1    Running   0         26m
-kube-system   flannel-bwf24                               2/2    Running   0         26m
-kube-system   flannel-ks5qb                               2/2    Running   0         26m
-kube-system   flannel-tq2wg                               2/2    Running   0         26m
+kube-system   calico-node-1m5bf                           2/2    Running   0         26m              
+kube-system   calico-node-7jmr1                           2/2    Running   0         26m              
+kube-system   calico-node-bknc8                           2/2    Running   0         26m              
 kube-system   kube-apiserver-ramius-controller-0          1/1    Running   0         26m
 kube-system   kube-controller-manager-ramius-controller-0 1/1    Running   0         26m
 kube-system   kube-proxy-j4vpq                            1/1    Running   0         26m
@@ -220,7 +220,7 @@ Reference the DNS zone with `azurerm_dns_zone.clusters.name` and its resource gr
 | worker_priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | Regular | Low |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
-| networking | Choice of networking provider | "flannel" | "flannel" or "calico" |
+| networking | Choice of networking provider | "calico" | "flannel" or "calico" |
 | host_cidr | CIDR IPv4 range to assign to instances | "10.0.0.0/16" | "10.0.0.0/20" |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |

--- a/docs/cl/digital-ocean.md
+++ b/docs/cl/digital-ocean.md
@@ -141,9 +141,9 @@ List the pods.
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE
 kube-system   coredns-1187388186-ld1j7                   1/1       Running   0          11m
 kube-system   coredns-1187388186-rdhf7                   1/1       Running   0          11m
-kube-system   flannel-1cq1v                              2/2       Running   0          11m
-kube-system   flannel-hq9t0                              2/2       Running   0          11m
-kube-system   flannel-v0g9w                              2/2       Running   0          11m
+kube-system   calico-node-1m5bf                          2/2       Running   0          11m              
+kube-system   calico-node-7jmr1                          2/2       Running   0          11m              
+kube-system   calico-node-bknc8                          2/2       Running   0          11m              
 kube-system   kube-apiserver-ip-10.132.115.81            1/1       Running   0          11m
 kube-system   kube-controller-manager-ip-10.132.115.81   1/1       Running   0          11m
 kube-system   kube-proxy-6kxjf                           1/1       Running   0          11m
@@ -219,7 +219,7 @@ Digital Ocean requires the SSH public key be uploaded to your account, so you ma
 | image | Container Linux image for instances | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
-| networking | Choice of networking provider | "flannel" | "flannel" or "calico" |
+| networking | Choice of networking provider | "calico" | "flannel" or "calico" |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 

--- a/docs/topics/security.md
+++ b/docs/topics/security.md
@@ -12,7 +12,7 @@ Typhoon aims to be minimal and secure. We're running it ourselves after all.
 * Workloads run on worker nodes only, unless they tolerate the master taint
 * Kubernetes [Network Policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) and Calico [NetworkPolicy](https://docs.projectcalico.org/latest/reference/calicoctl/resources/networkpolicy) support [^1]
 
-[^1]: Requires `networking = "calico"`. Calico is the default on AWS, bare-metal, and Google Cloud. Azure and Digital Ocean are limited to `networking = "flannel"`.
+[^1]: Requires `networking = "calico"`. Calico is the default on all platforms (AWS, Azure, bare-metal, DigitalOcean, and Google Cloud).
 
 **Hosts**
 


### PR DESCRIPTION
* Change `networking` default from flannel to calico on Azure and DigitalOcean
* AWS, bare-metal, and Google Cloud continue to default to Calico (as they have since v1.7.5)
* Typhoon now defaults to using Calico and supporting NetworkPolicy on all platforms