### PR TITLE
expose resource group id in Azure

### DIFF
--- a/azure/container-linux/kubernetes/outputs.tf
+++ b/azure/container-linux/kubernetes/outputs.tf
@@ -19,6 +19,10 @@ output "resource_group_name" {
   value = azurerm_resource_group.cluster.name
 }
 
+output "resource_group_id" {
+  value = azurerm_resource_group.cluster.id
+}
+
 output "subnet_id" {
   value = azurerm_subnet.worker.id
 }
@@ -53,4 +57,3 @@ output "backend_address_pool_id" {
   description = "ID of the worker backend address pool"
   value       = azurerm_lb_backend_address_pool.worker.id
 }
-


### PR DESCRIPTION
Add an output variable to the azure module named `resource_group_id`.
## Testing

Actively using this patch with a pre-production cluster that uses
azure-csi-driver configured with a service principal and role assignment e.g.:

    resource "azurerm_role_assignment" "some_role" {
      name                 = "some-name"
      scope                = "${module.typhoon_cluster.resource_group_id}"
      role_definition_name = "Contributor"
      principal_id         = "${azuread_service_principal.some_sp.object_id}"
    }