### PR TITLE
Update Prometheus from v2.13.1 to v2.14.0-rc.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Notable changes between versions.
 
 #### Addons
 
+* Update Prometheus from v2.13.1 to [v2.14.0-rc.0](https://github.com/prometheus/prometheus/releases/tag/v2.14.0-rc.0)
 * Update Prometheus from v2.13.0 to v2.13.1
   * Refresh rules, alerts, and dashboards from upstreams
 * Remove addon-resizer from kube-state-metrics ([#575](https://github.com/poseidon/typhoon/pull/575))

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: quay.io/prometheus/prometheus:v2.13.1
+          image: quay.io/prometheus/prometheus:v2.14.0-rc.0
           args:
             - --web.listen-address=0.0.0.0:9090
             - --config.file=/etc/prometheus/prometheus.yaml


### PR DESCRIPTION
* Happy PromCon 2019!
* https://github.com/prometheus/prometheus/releases/tag/v2.14.0-rc.0
