### PR TITLE
Use GCP region_instance_group_manager version block format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@ Notable changes between versions.
 * Replace usage of `template_dir` with `templatefile` function ([#587](https://github.com/poseidon/typhoon/pull/587))
   * Require Terraform version v0.12.6+ (action required)
 
+#### Google
+
+* Use new `google_compute_region_instance_group_manager` version block format
+  * Fixes warning that `instance_template` is deprecated
+  * Require `terraform-provider-google` v2.19.0+ (action required)
+
 ## v1.16.3
 
 * Kubernetes [v1.16.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#v1163)

--- a/google-cloud/container-linux/kubernetes/versions.tf
+++ b/google-cloud/container-linux/kubernetes/versions.tf
@@ -3,9 +3,9 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google       = "~> 2.5"
-    ct           = "~> 0.3"
-    template     = "~> 2.1"
-    null         = "~> 2.1"
+    google   = "~> 2.19"
+    ct       = "~> 0.3"
+    template = "~> 2.1"
+    null     = "~> 2.1"
   }
 }

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -5,8 +5,11 @@ resource "google_compute_region_instance_group_manager" "workers" {
 
   # instance name prefix for instances in the group
   base_instance_name = "${var.name}-worker"
-  instance_template  = google_compute_instance_template.worker.self_link
   region             = var.region
+  version {
+    name = "default"
+    instance_template  = google_compute_instance_template.worker.self_link
+  }
 
   target_size  = var.worker_count
   target_pools = [google_compute_target_pool.workers.self_link]


### PR DESCRIPTION
* terraform-provider-google v2.19.0 deprecates `instance_template` within `google_compute_region_instance_group_manager` in order to support a scheme with multiple version blocks. Adapt our single version to the new format to resolve deprecation warnings.
* Fixes: Warning: "instance_template": [DEPRECATED] This field will be replaced by `version.instance_template` in 3.0.0
* Require terraform-provider-google v2.19.0+ (action required)