### PR TITLE
DigitalOcean: Fix outputs

### DIFF
--- a/digital-ocean/container-linux/kubernetes/outputs.tf
+++ b/digital-ocean/container-linux/kubernetes/outputs.tf
@@ -12,19 +12,19 @@ output "workers_dns" {
 }
 
 output "controllers_ipv4" {
-  value = [digitalocean_droplet.controllers.*.ipv4_address]
+  value = digitalocean_droplet.controllers.*.ipv4_address
 }
 
 output "controllers_ipv6" {
-  value = [digitalocean_droplet.controllers.*.ipv6_address]
+  value = digitalocean_droplet.controllers.*.ipv6_address
 }
 
 output "workers_ipv4" {
-  value = [digitalocean_droplet.workers.*.ipv4_address]
+  value = digitalocean_droplet.workers.*.ipv4_address
 }
 
 output "workers_ipv6" {
-  value = [digitalocean_droplet.workers.*.ipv6_address]
+  value = digitalocean_droplet.workers.*.ipv6_address
 }
 
 # Outputs for custom firewalls


### PR DESCRIPTION
* Fix list output variables for DigitalOcean

## Testing
I've tested by creating a cluster with Terraform 0.12.16. Referencing variables such as `workers_ipv4` would fail since it was a 1-element tuple containing a list. After my fix it works AFAICT, at least it parses without problems.