### PR TITLE
Add Kubelet kubeconfig output for DigitalOcean

### DIFF
--- a/digital-ocean/container-linux/kubernetes/outputs.tf
+++ b/digital-ocean/container-linux/kubernetes/outputs.tf
@@ -27,6 +27,12 @@ output "workers_ipv6" {
   value = digitalocean_droplet.workers.*.ipv6_address
 }
 
+# Outputs for worker pools
+
+output "kubeconfig" {
+  value = module.bootstrap.kubeconfig-kubelet
+}
+
 # Outputs for custom firewalls
 
 output "controller_tag" {


### PR DESCRIPTION
* Allow the raw kubelet kubeconfig to be consumed via Terraform output