### PR TITLE
Reduce Prometheus addon's node-exporter tolerations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Notable changes between versions.
 * Update Prometheus from v2.14.0 to [v2.15.1](https://github.com/prometheus/prometheus/releases/tag/v2.15.1)
   * Add discovery for kube-proxy service endpoints
 * Update kube-state-metrics from v1.8.0 to v1.9.0
+* Reduce node-exporter DaemonSet tolerations ([#614](https://github.com/poseidon/typhoon/pull/614))
 * Update Grafana from v6.5.1 to v6.5.2
 
 ## v1.17.0

--- a/addons/prometheus/exporters/node-exporter/daemonset.yaml
+++ b/addons/prometheus/exporters/node-exporter/daemonset.yaml
@@ -57,7 +57,9 @@ spec:
             mountPath: /host/root
             readOnly: true
       tolerations:
-        - effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+        - key: node.kubernetes.io/not-ready
           operator: Exists
       volumes:
         - name: proc


### PR DESCRIPTION
* Change `node-exporter` DaemonSet tolerations from tolerating all possible NoSchedule taints to tolerating the master taint and the not-ready taint
* Users who add custom node taints must add their custom taints to the addon node-exporter DaemonSet. As an addon, its expected users copy and manipulate manifests out-of-band in their own systems
