### PR TITLE
Ensure /etc/kubernetes exists following Kubelet inlining

### DIFF
--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml
@@ -155,6 +155,9 @@ systemd:
         [Install]
         WantedBy=multi-user.target
 storage:
+  directories:
+    - path: /etc/kubernetes
+      filesystem: root
   files:
     - path: /etc/hostname
       filesystem: root

--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml
@@ -103,6 +103,9 @@ systemd:
         WantedBy=multi-user.target
 
 storage:
+  directories:
+    - path: /etc/kubernetes
+      filesystem: root
   files:
     - path: /etc/hostname
       filesystem: root

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml
@@ -152,6 +152,9 @@ systemd:
         [Install]
         WantedBy=multi-user.target
 storage:
+  directories:
+    - path: /etc/kubernetes
+      filesystem: root
   files:
     - path: /opt/bootstrap/layout
       filesystem: root

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml
@@ -111,6 +111,9 @@ systemd:
         [Install]
         WantedBy=multi-user.target
 storage:
+  directories:
+    - path: /etc/kubernetes
+      filesystem: root
   files:
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root


### PR DESCRIPTION
* [Inlining the Kubelet service](https://github.com/poseidon/typhoon/pull/606) removed the need for the `kubelet.env` file declared in Ignition. However, on some platforms, this removed the guarantee that `/etc/kubernetes` exists at boot. Bare-Metal and DigitalOcean distribute the Kubelet kubeconfig through Terraform file provisioner (scp) and place it in (now missing) `/etc/kubernetes` (failing)
* Fix bare-metal and DigitalOcean Ignition to ensure the `/etc/kubernetes` directory exists following first boot from disk
* Cloud platforms with worker pools distribute the kubeconfig through Ignition user data (no impact or need)

Closes #612 