### PR TITLE
Allow terraform-provider-google v3.x plugin versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@ Notable changes between versions.
 * Enable kube-proxy metrics and allow Prometheus scrapes
   * Allow TCP/10249 traffic with worker node sources
 
+#### Google
+
+* Allow `terraform-provider-google` v3.0+ ([#617](https://github.com/poseidon/typhoon/pull/617))
+  * Only enforce `v2.19+` to ease migration, as no v3.x features are used
+
 #### Addons
 
 * Update Prometheus from v2.14.0 to [v2.15.2](https://github.com/prometheus/prometheus/releases/tag/v2.15.2)

--- a/docs/cl/google-cloud.md
+++ b/docs/cl/google-cloud.md
@@ -49,7 +49,7 @@ Configure the Google Cloud provider to use your service account key, project-id,
 
 ```tf
 provider "google" {
-  version     = "2.20.0"
+  version     = "3.4.0"
   project     = "project-id"
   region      = "us-central1"
   credentials = file("~/.config/google-cloud/terraform.json")

--- a/google-cloud/container-linux/kubernetes/versions.tf
+++ b/google-cloud/container-linux/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google   = "~> 2.19"
+    google   = ">= 2.19, < 4.0"
     ct       = "~> 0.3"
     template = "~> 2.1"
     null     = "~> 2.1"


### PR DESCRIPTION
* Typhoon Google Cloud is compatible with `terraform-provider-google` v3.x releases
* No v3.x specific features are used, so v2.19+ versions are still allowed
