### PR TITLE
Update kube-state-metrics from v1.9.0 to v1.9.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ Notable changes between versions.
 
 * Update Prometheus from v2.14.0 to [v2.15.2](https://github.com/prometheus/prometheus/releases/tag/v2.15.2)
   * Add discovery for kube-proxy service endpoints
-* Update kube-state-metrics from v1.8.0 to v1.9.0
+* Update kube-state-metrics from v1.8.0 to v1.9.1
 * Reduce node-exporter DaemonSet tolerations ([#614](https://github.com/poseidon/typhoon/pull/614))
 * Update Grafana from v6.5.1 to v6.5.2
 

--- a/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.9.0
+        image: quay.io/coreos/kube-state-metrics:v1.9.1
         ports:
           - name: metrics
             containerPort: 8080


### PR DESCRIPTION
* https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.1