### PR TITLE
Update Fedora CoreOS kernel arguments to align with upstream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Notable changes between versions.
 
 * Update Calico from v3.11.2 to v3.12.0
 
+#### Bare-Metal
+
+* Add Fedora CoreOS kernel arguments initrd and console ([#640](https://github.com/poseidon/typhoon/pull/640))
+
 #### Google Cloud
 
 * Add Terraform module for Fedora CoreOS ([#632](https://github.com/poseidon/typhoon/pull/632))

--- a/bare-metal/fedora-coreos/kubernetes/profiles.tf
+++ b/bare-metal/fedora-coreos/kubernetes/profiles.tf
@@ -4,10 +4,12 @@ locals {
   remote_args = [
     "ip=dhcp",
     "rd.neednet=1",
-    "coreos.inst=yes",
+    "initrd=fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
     "coreos.inst.image_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-metal.x86_64.raw.xz",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
-    "coreos.inst.install_dev=${var.install_disk}"
+    "coreos.inst.install_dev=${var.install_disk}",
+    "console=tty0",
+    "console=ttyS0",
   ]
 
   cached_kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel-x86_64"
@@ -15,10 +17,12 @@ locals {
   cached_args = [
     "ip=dhcp",
     "rd.neednet=1",
-    "coreos.inst=yes",
+    "initrd=fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
     "coreos.inst.image_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-metal.x86_64.raw.xz",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
-    "coreos.inst.install_dev=${var.install_disk}"
+    "coreos.inst.install_dev=${var.install_disk}",
+    "console=tty0",
+    "console=ttyS0",
   ]
 
   kernel = var.cached_install ? local.cached_kernel : local.remote_kernel


### PR DESCRIPTION
* Align bare-metal kernel arguments with upstream docs
    * Add missing initrd argument which can cause issues if not present. Fix #638
    * Add tty0 and ttyS0 consoles (matches Container Linux)
    * Remove unused coreos.inst=yes