### PR TITLE
Set docker log driver to json-file on Fedora CoreOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Notable changes between versions.
 
 * Kubernetes [v1.17.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md#v1173)
 * Update Calico from v3.11.2 to v3.12.0
+* Allow Fedora CoreOS clusters to pass CNCF conformance suite
+  * Set Docker log driver to `json-file` as a workaround
 
 #### Bare-Metal
 
@@ -13,8 +15,8 @@ Notable changes between versions.
 
 #### Google Cloud
 
-* Add Terraform module for Fedora CoreOS ([#632](https://github.com/poseidon/typhoon/pull/632))
-* Add support for Flatcar Container Linux ([#639](https://github.com/poseidon/typhoon/pull/639))
+* Add initial Terraform module for Fedora CoreOS ([#632](https://github.com/poseidon/typhoon/pull/632))
+* Add initial support for Flatcar Container Linux ([#639](https://github.com/poseidon/typhoon/pull/639))
 
 #### Addons
 

--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -182,6 +182,19 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
+    - path: /etc/sysconfig/docker
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # Modify these options if you want to change the way the docker daemon runs
+          OPTIONS="--selinux-enabled \
+            --log-driver=json-file \
+            --live-restore \
+            --default-ulimit nofile=1024:1024 \
+            --init-path /usr/libexec/docker/docker-init \
+            --userland-proxy-path /usr/libexec/docker/docker-proxy \
+          "
     - path: /etc/etcd/etcd.env
       mode: 0644
       contents:

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -98,6 +98,19 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
+    - path: /etc/sysconfig/docker
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # Modify these options if you want to change the way the docker daemon runs
+          OPTIONS="--selinux-enabled \
+            --log-driver=json-file \
+            --live-restore \
+            --default-ulimit nofile=1024:1024 \
+            --init-path /usr/libexec/docker/docker-init \
+            --userland-proxy-path /usr/libexec/docker/docker-proxy \
+          "
 passwd:
   users:
     - name: core

--- a/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -193,6 +193,19 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
+    - path: /etc/sysconfig/docker
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # Modify these options if you want to change the way the docker daemon runs
+          OPTIONS="--selinux-enabled \
+            --log-driver=json-file \
+            --live-restore \
+            --default-ulimit nofile=1024:1024 \
+            --init-path /usr/libexec/docker/docker-init \
+            --userland-proxy-path /usr/libexec/docker/docker-proxy \
+          "
     - path: /etc/etcd/etcd.env
       mode: 0644
       contents:

--- a/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
@@ -106,6 +106,19 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
+    - path: /etc/sysconfig/docker
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # Modify these options if you want to change the way the docker daemon runs
+          OPTIONS="--selinux-enabled \
+            --log-driver=json-file \
+            --live-restore \
+            --default-ulimit nofile=1024:1024 \
+            --init-path /usr/libexec/docker/docker-init \
+            --userland-proxy-path /usr/libexec/docker/docker-proxy \
+          "
 passwd:
   users:
     - name: core

--- a/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -182,6 +182,19 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
+    - path: /etc/sysconfig/docker
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # Modify these options if you want to change the way the docker daemon runs
+          OPTIONS="--selinux-enabled \
+            --log-driver=json-file \
+            --live-restore \
+            --default-ulimit nofile=1024:1024 \
+            --init-path /usr/libexec/docker/docker-init \
+            --userland-proxy-path /usr/libexec/docker/docker-proxy \
+          "
     - path: /etc/etcd/etcd.env
       mode: 0644
       contents:

--- a/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -98,6 +98,19 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
+    - path: /etc/sysconfig/docker
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # Modify these options if you want to change the way the docker daemon runs
+          OPTIONS="--selinux-enabled \
+            --log-driver=json-file \
+            --live-restore \
+            --default-ulimit nofile=1024:1024 \
+            --init-path /usr/libexec/docker/docker-init \
+            --userland-proxy-path /usr/libexec/docker/docker-proxy \
+          "
 passwd:
   users:
     - name: core


### PR DESCRIPTION
* Fix the last minor issue for Fedora CoreOS clusters to pass CNCF's Kubernetes conformance tests
* Kubelet supports a seldom used feature `kubectl logs --limit-bytes=N` to trim a log stream to a desired length. Kubelet handles this in the CRI driver. The Kubelet docker shim only supports the limit bytes feature when Docker is configured with the default `json-file` logging driver
* CNCF conformance tests started requiring limit-bytes be supported, indirectly forcing the log driver choice until either the Kubelet or the conformance tests are fixed
* Fedora CoreOS defaults Docker to use `journald` (desired). For now, as a workaround to offer conformant clusters, the log driver can be set back to `json-file`. RHEL CoreOS likely won't have noticed the non-conformance since its using crio runtime
* https://github.com/kubernetes/kubernetes/issues/86367

```
{"msg":"Test Suite completed","total":278,"completed":278,"skipped":4565,"failed":0}

Ran 278 of 4843 Specs in 4217.818 seconds
SUCCESS! -- 278 Passed | 0 Failed | 0 Pending | 4565 Skipped
PASS

Ginkgo ran 1 suite in 1h10m19.544918084s
Test Suite Passed
```