### PR TITLE
container linux kubelet: Make calico mount readonly

### DIFF
--- a/aws/container-linux/kubernetes/cl/controller.yaml
+++ b/aws/container-linux/kubernetes/cl/controller.yaml
@@ -79,7 +79,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/aws/container-linux/kubernetes/workers/cl/worker.yaml
+++ b/aws/container-linux/kubernetes/workers/cl/worker.yaml
@@ -54,7 +54,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -73,7 +73,7 @@ systemd:
           --volume /sys/fs/cgroup:/sys/fs/cgroup:ro \
           --volume /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd \
           --volume /etc/pki/tls/certs:/usr/share/ca-certificates:ro \
-          --volume /var/lib/calico:/var/lib/calico \
+          --volume /var/lib/calico:/var/lib/calico:ro \
           --volume /var/lib/docker:/var/lib/docker \
           --volume /var/lib/kubelet:/var/lib/kubelet:rshared,z \
           --volume /var/log:/var/log \

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -43,7 +43,7 @@ systemd:
           --volume /sys/fs/cgroup:/sys/fs/cgroup:ro \
           --volume /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd \
           --volume /etc/pki/tls/certs:/usr/share/ca-certificates:ro \
-          --volume /var/lib/calico:/var/lib/calico \
+          --volume /var/lib/calico:/var/lib/calico:ro \
           --volume /var/lib/docker:/var/lib/docker \
           --volume /var/lib/kubelet:/var/lib/kubelet:rshared,z \
           --volume /var/log:/var/log \

--- a/azure/container-linux/kubernetes/cl/controller.yaml
+++ b/azure/container-linux/kubernetes/cl/controller.yaml
@@ -78,7 +78,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/azure/container-linux/kubernetes/workers/cl/worker.yaml
+++ b/azure/container-linux/kubernetes/workers/cl/worker.yaml
@@ -53,7 +53,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/bare-metal/container-linux/kubernetes/cl/controller.yaml
+++ b/bare-metal/container-linux/kubernetes/cl/controller.yaml
@@ -87,7 +87,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/bare-metal/container-linux/kubernetes/cl/worker.yaml
+++ b/bare-metal/container-linux/kubernetes/cl/worker.yaml
@@ -62,7 +62,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -72,7 +72,7 @@ systemd:
           --volume /sys/fs/cgroup:/sys/fs/cgroup:ro \
           --volume /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd \
           --volume /etc/pki/tls/certs:/usr/share/ca-certificates:ro \
-          --volume /var/lib/calico:/var/lib/calico \
+          --volume /var/lib/calico:/var/lib/calico:ro \
           --volume /var/lib/docker:/var/lib/docker \
           --volume /var/lib/kubelet:/var/lib/kubelet:rshared,z \
           --volume /var/log:/var/log \

--- a/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
@@ -42,7 +42,7 @@ systemd:
           --volume /sys/fs/cgroup:/sys/fs/cgroup:ro \
           --volume /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd \
           --volume /etc/pki/tls/certs:/usr/share/ca-certificates:ro \
-          --volume /var/lib/calico:/var/lib/calico \
+          --volume /var/lib/calico:/var/lib/calico:ro \
           --volume /var/lib/docker:/var/lib/docker \
           --volume /var/lib/kubelet:/var/lib/kubelet:rshared,z \
           --volume /var/log:/var/log \

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml
@@ -89,7 +89,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml
@@ -64,7 +64,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/google-cloud/container-linux/kubernetes/cl/controller.yaml
+++ b/google-cloud/container-linux/kubernetes/cl/controller.yaml
@@ -78,7 +78,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/google-cloud/container-linux/kubernetes/workers/cl/worker.yaml
+++ b/google-cloud/container-linux/kubernetes/workers/cl/worker.yaml
@@ -53,7 +53,7 @@ systemd:
           --mount volume=run,target=/run \
           --volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
           --mount volume=usr-share-certs,target=/usr/share/ca-certificates \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico,readOnly=true \
           --mount volume=var-lib-calico,target=/var/lib/calico \
           --volume var-lib-docker,kind=host,source=/var/lib/docker \
           --mount volume=var-lib-docker,target=/var/lib/docker \

--- a/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -73,7 +73,7 @@ systemd:
           --volume /sys/fs/cgroup:/sys/fs/cgroup:ro \
           --volume /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd \
           --volume /etc/pki/tls/certs:/usr/share/ca-certificates:ro \
-          --volume /var/lib/calico:/var/lib/calico \
+          --volume /var/lib/calico:/var/lib/calico:ro \
           --volume /var/lib/docker:/var/lib/docker \
           --volume /var/lib/kubelet:/var/lib/kubelet:rshared,z \
           --volume /var/log:/var/log \

--- a/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -43,7 +43,7 @@ systemd:
           --volume /sys/fs/cgroup:/sys/fs/cgroup:ro \
           --volume /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd \
           --volume /etc/pki/tls/certs:/usr/share/ca-certificates:ro \
-          --volume /var/lib/calico:/var/lib/calico \
+          --volume /var/lib/calico:/var/lib/calico:ro \
           --volume /var/lib/docker:/var/lib/docker \
           --volume /var/lib/kubelet:/var/lib/kubelet:rshared,z \
           --volume /var/log:/var/log \


### PR DESCRIPTION
In container linux change the kubelet's `/var/lib/calico` mount to
`readOnly`. Kubelet only needs to read this and not make any amendments
to the file.

