### PR TITLE
Add guide for Typhoon with Flatcar Linux on DigitalOcean

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between versions.
 
 ## Latest
 
+#### DigitalOcean
+
+* Add support for Flatcar Container Linux ([#644](https://github.com/poseidon/typhoon/pull/644))
+
 ## v1.17.3
 
 * Kubernetes [v1.17.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md#v1173)
@@ -23,8 +27,8 @@ Notable changes between versions.
 
 #### Google Cloud
 
-* Add initial Terraform module for Fedora CoreOS ([#632](https://github.com/poseidon/typhoon/pull/632))
-* Add initial support for Flatcar Container Linux ([#639](https://github.com/poseidon/typhoon/pull/639))
+* Add Terraform module for Fedora CoreOS ([#632](https://github.com/poseidon/typhoon/pull/632))
+* Add support for Flatcar Container Linux ([#639](https://github.com/poseidon/typhoon/pull/639))
 
 #### Addons
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Typhoon is available for [Flatcar Container Linux](https://www.flatcar-linux.org
 | AWS           | Flatcar Linux    | [aws/container-linux/kubernetes](aws/container-linux/kubernetes) | stable |
 | Bare-Metal    | Flatcar Linux    | [bare-metal/container-linux/kubernetes](bare-metal/container-linux/kubernetes) | stable |
 | Google Cloud  | Flatcar Linux  | [google-cloud/container-linux/kubernetes](google-cloud/container-linux/kubernetes) | alpha |
+| Digital Ocean | Flatcar Linux  | [digital-ocean/container-linux/kubernetes](digital-ocean/container-linux/kubernetes) | alpha |
 
 ## Documentation
 

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -1,3 +1,8 @@
+locals {
+  official_images = ["coreos-stable", "coreos-beta", "coreos-alpha"]
+  is_official_image = contains(local.official_images, var.image)
+}
+
 # Controller Instance DNS records
 resource "digitalocean_record" "controllers" {
   count = var.controller_count
@@ -41,7 +46,8 @@ resource "digitalocean_droplet" "controllers" {
   size  = var.controller_type
 
   # network
-  ipv6               = true
+  # only official DigitalOcean images support IPv6
+  ipv6               = local.is_official_image
   private_networking = true
 
   user_data = data.ct_config.controller-ignitions.*.rendered[count.index]

--- a/digital-ocean/container-linux/kubernetes/workers.tf
+++ b/digital-ocean/container-linux/kubernetes/workers.tf
@@ -12,7 +12,8 @@ resource "digitalocean_record" "workers-record-a" {
 }
 
 resource "digitalocean_record" "workers-record-aaaa" {
-  count = var.worker_count
+  # only official DigitalOcean images support IPv6
+  count = local.is_official_image ? var.worker_count : 0
 
   # DNS zone where record should be created
   domain = var.dns_zone
@@ -34,7 +35,8 @@ resource "digitalocean_droplet" "workers" {
   size  = var.worker_type
 
   # network
-  ipv6               = true
+  # only official DigitalOcean images support IPv6
+  ipv6               = local.is_official_image
   private_networking = true
 
   user_data = data.ct_config.worker-ignition.rendered

--- a/docs/cl/digital-ocean.md
+++ b/docs/cl/digital-ocean.md
@@ -71,6 +71,7 @@ module "nemo" {
   cluster_name = "nemo"
   region       = "nyc3"
   dns_zone     = "digital-ocean.example.com"
+  image        = "coreos-stable"
 
   # configuration
   ssh_fingerprints = ["d7:9d:79:ae:56:32:73:79:95:88:e3:a2:ab:5d:45:e7"]
@@ -81,6 +82,28 @@ module "nemo" {
 ```
 
 Reference the [variables docs](#variables) or the [variables.tf](https://github.com/poseidon/typhoon/blob/master/digital-ocean/container-linux/kubernetes/variables.tf) source.
+
+### Flatcar Linux Only
+
+!!! warning
+    Typhoon for Flatcar Linux on DigitalOcean is alpha. Also IPv6 is unsupported with DigitalOcean custom images.
+
+Flatcar Linux publishes DigitalOcean images, but does not upload them. DigitalOcean allows [custom boot images](https://blog.digitalocean.com/custom-images/) by file or URL.
+
+[Download](https://www.flatcar-linux.org/releases/) the Flatcar Linux DigitalOcean bin image (or copy the URL) and [upload](https://cloud.digitalocean.com/images/custom_images) it as a custom image. Rename the image with the channel and version to refer to these images over time.
+
+```tf
+module "nemo" {
+  ...
+  image = data.digitalocean_image.flatcar-stable.id
+}
+
+data "digitalocean_image" "flatcar-stable" {
+  name = "flatcar-stable-2303.4.0.bin.bz2"
+}
+```
+
+Set the [image](#variables) to the custom image id.
 
 ## ssh-agent
 
@@ -224,7 +247,7 @@ Digital Ocean requires the SSH public key be uploaded to your account, so you ma
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | Droplet type for controllers | "s-2vcpu-2gb" | s-2vcpu-2gb, s-2vcpu-4gb, s-4vcpu-8gb, ... |
 | worker_type | Droplet type for workers | "s-1vcpu-2gb" | s-1vcpu-2gb, s-2vcpu-2gb, ... |
-| image | Container Linux image for instances | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha |
+| image | Container Linux image for instances | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha, "custom-image-id" |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | networking | Choice of networking provider | "calico" | "flannel" or "calico" |

--- a/docs/cl/google-cloud.md
+++ b/docs/cl/google-cloud.md
@@ -89,15 +89,12 @@ module "yavin" {
 
 Reference the [variables docs](#variables) or the [variables.tf](https://github.com/poseidon/typhoon/blob/master/google-cloud/container-linux/kubernetes/variables.tf) source.
 
-### Flatcar Linux Images
+### Flatcar Linux Only
 
-!!! success
-    Skip this section when using CoreOS Container Linux (default). CoreOS Container Linux publishes official images to Google Cloud.
-
-!!! danger
+!!! warning
     Typhoon for Flatcar Linux on Google Cloud is alpha.
 
-Flatcar Linux publishes images for Google Cloud, but does not yet upload them. Google Cloud allows [custom boot images](https://cloud.google.com/compute/docs/images/import-existing-image) to be uploaded to a bucket and imported into your project.
+Flatcar Linux publishes Google Cloud images, but does not upload them. Google Cloud allows [custom boot images](https://cloud.google.com/compute/docs/images/import-existing-image) to be uploaded to a bucket and imported into a project.
 
 [Download](https://www.flatcar-linux.org/releases/) the Flatcar Linux GCE gzipped tarball and upload it to a Google Cloud storage bucket.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Typhoon is available for [Flatcar Container Linux](https://www.flatcar-linux.org
 | AWS           | Flatcar Linux    | [aws/container-linux/kubernetes](cl/aws.md) | stable |
 | Bare-Metal    | Flatcar Linux    | [bare-metal/container-linux/kubernetes](cl/bare-metal.md) | stable |
 | Google Cloud  | Flatcar Linux  | [google-cloud/container-linux/kubernetes](cl/google-cloud.md) | alpha |
+| Digital Ocean | Flatcar Linux  | [digital-ocean/container-linux/kubernetes](cl/digital-ocean.md) | alpha |
 
 ## Documentation
 


### PR DESCRIPTION
* Add docs on manually uploading a Flatcar Linux DigitalOcean bin image as a custom image and using a data reference
* Set status of Flatcar Linux on DigitalOcean to alpha
* IPv6 is not supported for DigitalOcean custom images