### PR TITLE
Fix worker_node_labels for initial Fedora CoreOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Notable changes between versions.
 
 * Update CoreDNS from v1.6.6 to v1.6.7 ([#648](https://github.com/poseidon/typhoon/pull/648))
 
+#### AWS
+
+* Fix `worker_node_labels` for setting initial worker node labels on Fedora CoreOS ([#651](https://github.com/poseidon/typhoon/pull/651))
+
+#### Google Cloud
+
+* Fix `worker_node_labels` for setting initial worker node labels on Fedora CoreOS ([#651](https://github.com/poseidon/typhoon/pull/651))
+
 #### DigitalOcean
 
 * Add support for Flatcar Container Linux ([#644](https://github.com/poseidon/typhoon/pull/644))

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -66,9 +66,9 @@ systemd:
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
           --node-labels=node.kubernetes.io/node \
-          %{ for label in split(",", node_labels) }
+          %{~ for label in split(",", node_labels) ~}
           --node-labels=${label} \
-          %{ endfor ~}
+          %{~ endfor ~}
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -66,9 +66,9 @@ systemd:
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
           --node-labels=node.kubernetes.io/node \
-          %{ for label in split(",", node_labels) }
+          %{~ for label in split(",", node_labels) ~}
           --node-labels=${label} \
-          %{ endfor ~}
+          %{~ endfor ~}
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins


### PR DESCRIPTION
* Add Terraform strip markers to consume beginning and trailing whitespace in templated Kubelet arguments for podman (Fedora CoreOS only)
* Fix initial `worker_node_labels` being quietly ignored on Fedora CoreOS cloud platforms that offer the feature
* Close https://github.com/poseidon/typhoon/issues/650
