### PR TITLE
Update node-exporter from v0.18.1 to v1.0.0-rc.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Notable changes between versions.
 * Update nginx-ingress from v0.28.0 to [v0.30.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.30.0)
 * Update Prometheus from v2.15.2 to [v2.16.0](https://github.com/prometheus/prometheus/releases/tag/v2.16.0)
   * Update kube-state-metrics from v1.9.4 to v1.9.5
+  * Update node-exporter from v0.18.1 to [v1.0.0-rc.0](https://github.com/prometheus/node_exporter/releases/tag/v1.0.0-rc.0)
 * Update Grafana from v6.6.1 to v6.6.2
 
 ## v1.17.3

--- a/addons/prometheus/exporters/node-exporter/daemonset.yaml
+++ b/addons/prometheus/exporters/node-exporter/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       hostPID: true
       containers:
       - name: node-exporter
-        image: quay.io/prometheus/node-exporter:v0.18.1
+        image: quay.io/prometheus/node-exporter:v1.0.0-rc.0
         args:
           - --path.procfs=/host/proc
           - --path.sysfs=/host/sys

--- a/addons/prometheus/rules.yaml
+++ b/addons/prometheus/rules.yaml
@@ -1212,7 +1212,7 @@ data:
               "annotations": {
                 "message": "{{ $value }} RAID disk(s) on node {{ $labels.instance }} are inactive."
               },
-              "expr": "node_md_disks - node_md_disks_active > 0",
+              "expr": "node_md_disks{state=\"failed\"} > 0",
               "for": "10m",
               "labels": {
                 "severity": "warning"


### PR DESCRIPTION
* Update mdadm alert rule; node-exporter adds `state` label to `node_md_disks` and removes `node_md_disks_active`
* https://github.com/prometheus/node_exporter/releases/tag/v1.0.0-rc.0
