### PR TITLE
Use a route table with separate (rather than inline) routes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Notable changes between versions.
 #### AWS
 
 * Fix `worker_node_labels` for setting initial worker node labels on Fedora CoreOS ([#651](https://github.com/poseidon/typhoon/pull/651))
+* Allow VPC route table extension via reference ([#654](https://github.com/poseidon/typhoon/pull/654))
 
 #### Google Cloud
 

--- a/aws/container-linux/kubernetes/network.tf
+++ b/aws/container-linux/kubernetes/network.tf
@@ -25,19 +25,21 @@ resource "aws_internet_gateway" "gateway" {
 resource "aws_route_table" "default" {
   vpc_id = aws_vpc.network.id
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.gateway.id
-  }
-
-  route {
-    ipv6_cidr_block = "::/0"
-    gateway_id      = aws_internet_gateway.gateway.id
-  }
-
   tags = {
     "Name" = var.cluster_name
   }
+}
+
+resource "aws_route" "egress-ipv4" {
+  route_table_id = aws_route_table.default.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id = aws_internet_gateway.gateway.id
+}
+
+resource "aws_route" "egress-ipv6" {
+  route_table_id = aws_route_table.default.id
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id = aws_internet_gateway.gateway.id
 }
 
 # Subnets (one per availability zone)

--- a/aws/fedora-coreos/kubernetes/network.tf
+++ b/aws/fedora-coreos/kubernetes/network.tf
@@ -25,19 +25,21 @@ resource "aws_internet_gateway" "gateway" {
 resource "aws_route_table" "default" {
   vpc_id = aws_vpc.network.id
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.gateway.id
-  }
-
-  route {
-    ipv6_cidr_block = "::/0"
-    gateway_id      = aws_internet_gateway.gateway.id
-  }
-
   tags = {
     "Name" = var.cluster_name
   }
+}
+
+resource "aws_route" "egress-ipv4" {
+  route_table_id = aws_route_table.default.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id = aws_internet_gateway.gateway.id
+}
+
+resource "aws_route" "egress-ipv6" {
+  route_table_id = aws_route_table.default.id
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id = aws_internet_gateway.gateway.id
 }
 
 # Subnets (one per availability zone)

--- a/docs/architecture/aws.md
+++ b/docs/architecture/aws.md
@@ -79,6 +79,23 @@ resource "aws_security_group_rule" "some-app" {
 }
 ```
 
+## Routes
+
+Add a custom [route](https://www.terraform.io/docs/providers/aws/r/route.html) to the VPC route table.
+
+```tf
+data "aws_route_table" "default" {
+  vpc_id = module.temptest.vpc_id
+  subnet_id = module.tempest.subnet_ids[0]
+}
+
+resource "aws_route" "peering" {
+  route_table_id = data.aws_route_table.default.id
+  destination_cidr_block = "192.168.4.0/24"
+  ...
+}
+```
+
 ## IPv6
 
 AWS Network Load Balancers do not support `dualstack`.


### PR DESCRIPTION
* Allow users to extend the route table using a data reference and adding route resources (e.g. unusual peering setups)
* Note: Internally connecting AWS clusters can reduce cross-cloud flexibility and inhibits blue-green cluster patterns. It is not recommended