### PR TITLE
Add automatic worker deletion on Fedora CoreOS clouds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,12 +9,14 @@ Notable changes between versions.
 
 #### AWS
 
-* Fix `worker_node_labels` for setting initial worker node labels on Fedora CoreOS ([#651](https://github.com/poseidon/typhoon/pull/651))
 * Allow VPC route table extension via reference ([#654](https://github.com/poseidon/typhoon/pull/654))
+* Fix `worker_node_labels` on Fedora CoreOS ([#651](https://github.com/poseidon/typhoon/pull/651))
+* Fix automatic worker node delete on shutdown on Fedora CoreOS ([#657](https://github.com/poseidon/typhoon/pull/657))
 
 #### Google Cloud
 
-* Fix `worker_node_labels` for setting initial worker node labels on Fedora CoreOS ([#651](https://github.com/poseidon/typhoon/pull/651))
+* Fix `worker_node_labels` on Fedora CoreOS ([#651](https://github.com/poseidon/typhoon/pull/651))
+* Fix automatic worker node delete on shutdown on Fedora CoreOS ([#657](https://github.com/poseidon/typhoon/pull/657))
 
 #### DigitalOcean
 

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -78,6 +78,18 @@ systemd:
         RestartSec=10
         [Install]
         WantedBy=multi-user.target
+    - name: delete-node.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Delete Kubernetes node on shutdown
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/bin/true
+        ExecStop=/bin/bash -c '/usr/bin/podman run --volume /etc/kubernetes:/etc/kubernetes:ro,z k8s.gcr.io/hyperkube:v1.17.3 kubectl --kubeconfig=/etc/kubernetes/kubeconfig delete node $HOSTNAME'
+        [Install]
+        WantedBy=multi-user.target
 storage:
   directories:
     - path: /etc/kubernetes

--- a/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -78,6 +78,18 @@ systemd:
         RestartSec=10
         [Install]
         WantedBy=multi-user.target
+    - name: delete-node.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Delete Kubernetes node on shutdown
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/bin/true
+        ExecStop=/bin/bash -c '/usr/bin/podman run --volume /etc/kubernetes:/etc/kubernetes:ro,z k8s.gcr.io/hyperkube:v1.17.3 kubectl --kubeconfig=/etc/kubernetes/kubeconfig delete node $HOSTNAME'
+        [Install]
+        WantedBy=multi-user.target
 storage:
   directories:
     - path: /etc/kubernetes


### PR DESCRIPTION
* On clouds where workers can scale down or be preempted (AWS, GCP, Azure), shutdown runs delete-node.service to remove a node a prevent NotReady nodes from lingering
* Add the delete-node.service that wasn't carried over from Container Linux and port it to use podman