### PR TITLE
Update Calico from v3.12.0 to v3.13.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Notable changes between versions.
 * Update etcd from v3.4.3 to [v3.4.4](https://github.com/etcd-io/etcd/releases/tag/v3.4.4)
   * On Container Linux, fetch using the docker transport format ([#659](https://github.com/poseidon/typhoon/pull/659))
 * Update CoreDNS from v1.6.6 to v1.6.7 ([#648](https://github.com/poseidon/typhoon/pull/648))
+* Update Calico from v3.12.0 to [v3.13.1](https://docs.projectcalico.org/v3.13/release-notes/)
 
 #### AWS
 

--- a/aws/container-linux/kubernetes/bootstrap.tf
+++ b/aws/container-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d1831e626a06d1aa63a75ca90a670ca594657fbf"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=804029edd5a6a5cf02e0db4919e7f2bb601d0089"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d1831e626a06d1aa63a75ca90a670ca594657fbf"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=804029edd5a6a5cf02e0db4919e7f2bb601d0089"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/container-linux/kubernetes/bootstrap.tf
+++ b/azure/container-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d1831e626a06d1aa63a75ca90a670ca594657fbf"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=804029edd5a6a5cf02e0db4919e7f2bb601d0089"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/bare-metal/container-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/container-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d1831e626a06d1aa63a75ca90a670ca594657fbf"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=804029edd5a6a5cf02e0db4919e7f2bb601d0089"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d1831e626a06d1aa63a75ca90a670ca594657fbf"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=804029edd5a6a5cf02e0db4919e7f2bb601d0089"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/digital-ocean/container-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/container-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d1831e626a06d1aa63a75ca90a670ca594657fbf"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=804029edd5a6a5cf02e0db4919e7f2bb601d0089"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/container-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/container-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d1831e626a06d1aa63a75ca90a670ca594657fbf"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=804029edd5a6a5cf02e0db4919e7f2bb601d0089"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d1831e626a06d1aa63a75ca90a670ca594657fbf"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=804029edd5a6a5cf02e0db4919e7f2bb601d0089"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]


### PR DESCRIPTION
* https://docs.projectcalico.org/v3.13/release-notes/
