### PR TITLE
Update Grafana from v6.6.2 to v6.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Notable changes between versions.
 #### Addons
 
 * Update Prometheus from v2.16.0 to [v2.17.0-rc.3](https://github.com/prometheus/prometheus/releases/tag/v2.17.0-rc.3)
+* Update Grafana from v6.6.2 to [v6.7.1](https://github.com/grafana/grafana/releases/tag/v6.7.1)
 
 ## v1.17.4
 

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: docker.io/grafana/grafana:6.6.2
+          image: docker.io/grafana/grafana:6.7.1
           env:
             - name: GF_PATHS_CONFIG
               value: "/etc/grafana/custom.ini"


### PR DESCRIPTION
* https://github.com/grafana/grafana/releases/tag/v6.7.0