### PR TITLE
Rename DigitalOcean image variable to os_image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@ Notable changes between versions.
   * Background: Kubernetes will [stop releasing](https://github.com/kubernetes/kubernetes/pull/88676) the hyperkube container
   image and provide the Kubelet as a binary for distros to package
 
+#### DigitalOcean
+
+* Rename `image` variable to `os_image` for consistency ([#677](https://github.com/poseidon/typhoon/pull/677)) (action required)
+
 #### Addons
 
 * Update Prometheus from v2.16.0 to [v2.17.0](https://github.com/prometheus/prometheus/releases/tag/v2.17.0)

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -1,6 +1,6 @@
 locals {
   official_images = ["coreos-stable", "coreos-beta", "coreos-alpha"]
-  is_official_image = contains(local.official_images, var.image)
+  is_official_image = contains(local.official_images, var.os_image)
 }
 
 # Controller Instance DNS records
@@ -42,7 +42,7 @@ resource "digitalocean_droplet" "controllers" {
   name   = "${var.cluster_name}-controller-${count.index}"
   region = var.region
 
-  image = var.image
+  image = var.os_image
   size  = var.controller_type
 
   # network

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -41,7 +41,7 @@ variable "worker_type" {
   default     = "s-1vcpu-2gb"
 }
 
-variable "image" {
+variable "os_image" {
   type        = string
   description = "Container Linux image for instances (e.g. coreos-stable)"
   default     = "coreos-stable"

--- a/digital-ocean/container-linux/kubernetes/workers.tf
+++ b/digital-ocean/container-linux/kubernetes/workers.tf
@@ -31,7 +31,7 @@ resource "digitalocean_droplet" "workers" {
   name   = "${var.cluster_name}-worker-${count.index}"
   region = var.region
 
-  image = var.image
+  image = var.os_image
   size  = var.worker_type
 
   # network

--- a/docs/cl/digital-ocean.md
+++ b/docs/cl/digital-ocean.md
@@ -71,7 +71,7 @@ module "nemo" {
   cluster_name = "nemo"
   region       = "nyc3"
   dns_zone     = "digital-ocean.example.com"
-  image        = "coreos-stable"
+  os_image     = "coreos-stable"
 
   # configuration
   ssh_fingerprints = ["d7:9d:79:ae:56:32:73:79:95:88:e3:a2:ab:5d:45:e7"]
@@ -95,7 +95,7 @@ Flatcar Linux publishes DigitalOcean images, but does not upload them. DigitalOc
 ```tf
 module "nemo" {
   ...
-  image = data.digitalocean_image.flatcar-stable.id
+  os_image = data.digitalocean_image.flatcar-stable.id
 }
 
 data "digitalocean_image" "flatcar-stable" {
@@ -103,7 +103,7 @@ data "digitalocean_image" "flatcar-stable" {
 }
 ```
 
-Set the [image](#variables) to the custom image id.
+Set the [os_image](#variables) to the custom image id.
 
 ## ssh-agent
 
@@ -244,7 +244,7 @@ Digital Ocean requires the SSH public key be uploaded to your account, so you ma
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | Droplet type for controllers | "s-2vcpu-2gb" | s-2vcpu-2gb, s-2vcpu-4gb, s-4vcpu-8gb, ... |
 | worker_type | Droplet type for workers | "s-1vcpu-2gb" | s-1vcpu-2gb, s-2vcpu-2gb, ... |
-| image | Container Linux image for instances | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha, "custom-image-id" |
+| os_image | Container Linux image for instances | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha, "custom-image-id" |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | networking | Choice of networking provider | "calico" | "flannel" or "calico" |


### PR DESCRIPTION
* Rename variable `image` to `os_image` to match the naming used for the same purpose on other supported platforms (e.g. AWS, Azure, GCP)