### PR TITLE
Set docker log driver to journald on Fedora CoreOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Notable changes between versions.
 
 ## Latest
 
+## v1.18.0
+
 * Kubernetes [v1.18.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#v1180)
 * Update etcd from v3.4.4 to [v3.4.5](https://github.com/etcd-io/etcd/releases/tag/v3.4.5)
 * Switch from upstream hyperkube image to individual images ([#669](https://github.com/poseidon/typhoon/pull/669))
@@ -15,6 +17,7 @@ Notable changes between versions.
   * Update Typhoon container image security policy to list `quay.io/poseidon/kubelet`as an official distributed artifact
   * Background: Kubernetes will [stop releasing](https://github.com/kubernetes/kubernetes/pull/88676) the hyperkube container
   image and provide the Kubelet as a binary for distros to package
+* Set Fedora CoreOS log driver back to the default `journald` ([#681](https://github.com/poseidon/typhoon/pull/681))
 * Deprecate `asset_dir` variable and remove docs ([#678](https://github.com/poseidon/typhoon/pull/678))
 
 #### DigitalOcean

--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -187,19 +187,6 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
-    - path: /etc/sysconfig/docker
-      mode: 0644
-      overwrite: true
-      contents:
-        inline: |
-          # Modify these options if you want to change the way the docker daemon runs
-          OPTIONS="--selinux-enabled \
-            --log-driver=json-file \
-            --live-restore \
-            --default-ulimit nofile=1024:1024 \
-            --init-path /usr/libexec/docker/docker-init \
-            --userland-proxy-path /usr/libexec/docker/docker-proxy \
-          "
     - path: /etc/etcd/etcd.env
       mode: 0644
       contents:

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -110,19 +110,6 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
-    - path: /etc/sysconfig/docker
-      mode: 0644
-      overwrite: true
-      contents:
-        inline: |
-          # Modify these options if you want to change the way the docker daemon runs
-          OPTIONS="--selinux-enabled \
-            --log-driver=json-file \
-            --live-restore \
-            --default-ulimit nofile=1024:1024 \
-            --init-path /usr/libexec/docker/docker-init \
-            --userland-proxy-path /usr/libexec/docker/docker-proxy \
-          "
 passwd:
   users:
     - name: core

--- a/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -198,19 +198,6 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
-    - path: /etc/sysconfig/docker
-      mode: 0644
-      overwrite: true
-      contents:
-        inline: |
-          # Modify these options if you want to change the way the docker daemon runs
-          OPTIONS="--selinux-enabled \
-            --log-driver=json-file \
-            --live-restore \
-            --default-ulimit nofile=1024:1024 \
-            --init-path /usr/libexec/docker/docker-init \
-            --userland-proxy-path /usr/libexec/docker/docker-proxy \
-          "
     - path: /etc/etcd/etcd.env
       mode: 0644
       contents:

--- a/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
@@ -112,19 +112,6 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
-    - path: /etc/sysconfig/docker
-      mode: 0644
-      overwrite: true
-      contents:
-        inline: |
-          # Modify these options if you want to change the way the docker daemon runs
-          OPTIONS="--selinux-enabled \
-            --log-driver=json-file \
-            --live-restore \
-            --default-ulimit nofile=1024:1024 \
-            --init-path /usr/libexec/docker/docker-init \
-            --userland-proxy-path /usr/libexec/docker/docker-proxy \
-          "
 passwd:
   users:
     - name: core

--- a/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -187,19 +187,6 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
-    - path: /etc/sysconfig/docker
-      mode: 0644
-      overwrite: true
-      contents:
-        inline: |
-          # Modify these options if you want to change the way the docker daemon runs
-          OPTIONS="--selinux-enabled \
-            --log-driver=json-file \
-            --live-restore \
-            --default-ulimit nofile=1024:1024 \
-            --init-path /usr/libexec/docker/docker-init \
-            --userland-proxy-path /usr/libexec/docker/docker-proxy \
-          "
     - path: /etc/etcd/etcd.env
       mode: 0644
       contents:

--- a/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -110,19 +110,6 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
-    - path: /etc/sysconfig/docker
-      mode: 0644
-      overwrite: true
-      contents:
-        inline: |
-          # Modify these options if you want to change the way the docker daemon runs
-          OPTIONS="--selinux-enabled \
-            --log-driver=json-file \
-            --live-restore \
-            --default-ulimit nofile=1024:1024 \
-            --init-path /usr/libexec/docker/docker-init \
-            --userland-proxy-path /usr/libexec/docker/docker-proxy \
-          "
 passwd:
   users:
     - name: core


### PR DESCRIPTION
* Before Kubernetes v1.18.0, Kubelet only supported kubectl `--limit-bytes` with the Docker `json-file` log driver so the Fedora CoreOS default was overridden for conformance. See https://github.com/poseidon/typhoon/pull/642
* Kubelet v1.18+ implemented support for other docker log drivers, so the Fedora CoreOS default `journald` can be used again

Rel: https://github.com/kubernetes/kubernetes/issues/86367