### PR TITLE
Fix Fedora CoreOS AMI to filter for stable images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,11 @@ Notable changes between versions.
 * Deprecate `asset_dir` variable and remove docs ([#678](https://github.com/poseidon/typhoon/pull/678))
 * Deprecate support for [gitRepo](https://kubernetes.io/docs/concepts/storage/volumes/#gitrepo) volumes. A future release will drop support.
 
+#### AWS
+
+* Fix Fedora CoreOS AMI to filter for stable images ([#685](https://github.com/poseidon/typhoon/pull/685))
+  * Latest Fedora CoreOS `testing` or `bodhi-update` images could be chosen depending on the region
+
 #### DigitalOcean
 
 * Rename `image` variable to `os_image` for consistency ([#677](https://github.com/poseidon/typhoon/pull/677)) (action required)

--- a/aws/fedora-coreos/kubernetes/ami.tf
+++ b/aws/fedora-coreos/kubernetes/ami.tf
@@ -18,6 +18,11 @@ data "aws_ami" "fedora-coreos" {
     values = ["fedora-coreos-31.*.*.*-hvm"]
   }
 
+  filter {
+    name   = "description"
+    values = ["Fedora CoreOS stable*"]
+  }
+
   # try to filter out dev images (AWS filters can't)
   name_regex = "^fedora-coreos-31.[0-9]*.[0-9]*.[0-9]*-hvm*"
 }

--- a/aws/fedora-coreos/kubernetes/workers/ami.tf
+++ b/aws/fedora-coreos/kubernetes/workers/ami.tf
@@ -18,6 +18,11 @@ data "aws_ami" "fedora-coreos" {
     values = ["fedora-coreos-31.*.*.*-hvm"]
   }
 
+  filter {
+    name   = "description"
+    values = ["Fedora CoreOS stable*"]
+  }
+
   # try to filter out dev images (AWS filters can't)
   name_regex = "^fedora-coreos-31.[0-9]*.[0-9]*.[0-9]*-hvm*"
 }


### PR DESCRIPTION
* Fix issue observed in us-east-1 where AMI filters chose the latest testing channel release, rather than the stable chanel
* Fedora CoreOS AMI filter selects the latest image with a matching name, x86_64, and hvm, excluding dev images. Add a filter for "Fedora CoreOS stable", which seems to be the only
distinguishing metadata indicating the channel