### PR TITLE
Rename Container Linux snippets variable for consistency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Notable changes between versions.
 
 * Change `kube-proxy` and `calico` or `flannel` to tolerate specific taints ([#682](https://github.com/poseidon/typhoon/pull/682))
   * Tolerate master and not-ready taints, rather than tolerating all taints
+* Rename Container Linux `controller_clc_snippets` to `controller_snippets` for consistency
+* Rename Container Linux `worker_clc_snippets` to `worker_snippets` for consistency
+* Rename Container Linux `clc_snippets` (bare-metal) to `snippets` for consistency
 * Fix bootstrap when `networking` mode `flannel` (non-default) is chosen
   * Regressed in v1.18.0 changes for Calico ([#675](https://github.com/poseidon/typhoon/pull/675))
 
@@ -36,7 +39,7 @@ Notable changes between versions.
 
 #### Bare-Metal
 
-* Update default `os_stream` from testing to stable
+* Update Fedora CoreOS default `os_stream` from testing to stable
 
 #### Google Cloud
 

--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -52,7 +52,7 @@ data "ct_config" "controller-ignitions" {
   count        = var.controller_count
   content      = data.template_file.controller-configs.*.rendered[count.index]
   pretty_print = false
-  snippets     = var.controller_clc_snippets
+  snippets     = var.controller_snippets
 }
 
 # Controller Container Linux configs

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -77,13 +77,13 @@ variable "worker_target_groups" {
   default     = []
 }
 
-variable "controller_clc_snippets" {
+variable "controller_snippets" {
   type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
 
-variable "worker_clc_snippets" {
+variable "worker_snippets" {
   type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -18,7 +18,7 @@ module "workers" {
   ssh_authorized_key    = var.ssh_authorized_key
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
-  clc_snippets          = var.worker_clc_snippets
+  snippets          = var.worker_snippets
   node_labels           = var.worker_node_labels
 }
 

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -70,7 +70,7 @@ variable "target_groups" {
   default     = []
 }
 
-variable "clc_snippets" {
+variable "snippets" {
   type        = list(string)
   description = "Container Linux Config snippets"
   default     = []

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -73,7 +73,7 @@ resource "aws_launch_configuration" "worker" {
 data "ct_config" "worker-ignition" {
   content      = data.template_file.worker-config.rendered
   pretty_print = false
-  snippets     = var.clc_snippets
+  snippets     = var.snippets
 }
 
 # Worker Container Linux config

--- a/azure/container-linux/kubernetes/controllers.tf
+++ b/azure/container-linux/kubernetes/controllers.tf
@@ -141,7 +141,7 @@ data "ct_config" "controller-ignitions" {
   count        = var.controller_count
   content      = data.template_file.controller-configs.*.rendered[count.index]
   pretty_print = false
-  snippets     = var.controller_clc_snippets
+  snippets     = var.controller_snippets
 }
 
 # Controller Container Linux configs

--- a/azure/container-linux/kubernetes/variables.tf
+++ b/azure/container-linux/kubernetes/variables.tf
@@ -64,13 +64,13 @@ variable "worker_priority" {
   default     = "Regular"
 }
 
-variable "controller_clc_snippets" {
+variable "controller_snippets" {
   type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
 
-variable "worker_clc_snippets" {
+variable "worker_snippets" {
   type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []

--- a/azure/container-linux/kubernetes/workers.tf
+++ b/azure/container-linux/kubernetes/workers.tf
@@ -19,6 +19,6 @@ module "workers" {
   ssh_authorized_key    = var.ssh_authorized_key
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
-  clc_snippets          = var.worker_clc_snippets
+  snippets          = var.worker_snippets
   node_labels           = var.worker_node_labels
 }

--- a/azure/container-linux/kubernetes/workers/variables.tf
+++ b/azure/container-linux/kubernetes/workers/variables.tf
@@ -56,7 +56,7 @@ variable "priority" {
   default     = "Regular"
 }
 
-variable "clc_snippets" {
+variable "snippets" {
   type        = list(string)
   description = "Container Linux Config snippets"
   default     = []

--- a/azure/container-linux/kubernetes/workers/workers.tf
+++ b/azure/container-linux/kubernetes/workers/workers.tf
@@ -98,7 +98,7 @@ resource "azurerm_monitor_autoscale_setting" "workers" {
 data "ct_config" "worker-ignition" {
   content      = data.template_file.worker-config.rendered
   pretty_print = false
-  snippets     = var.clc_snippets
+  snippets     = var.snippets
 }
 
 # Worker Container Linux configs

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -144,7 +144,7 @@ data "ct_config" "controller-ignitions" {
   count        = length(var.controllers)
   content      = data.template_file.controller-configs.*.rendered[count.index]
   pretty_print = false
-  snippets     = local.clc_map[var.controllers.*.name[count.index]]
+  snippets = lookup(var.snippets, var.controllers.*.name[count.index], [])
 }
 
 data "template_file" "controller-configs" {
@@ -174,7 +174,7 @@ data "ct_config" "worker-ignitions" {
   count        = length(var.workers)
   content      = data.template_file.worker-configs.*.rendered[count.index]
   pretty_print = false
-  snippets     = local.clc_map[var.workers.*.name[count.index]]
+  snippets = lookup(var.snippets, var.workers.*.name[count.index], [])
 }
 
 data "template_file" "worker-configs" {
@@ -192,24 +192,3 @@ data "template_file" "worker-configs" {
     node_taints            = join(",", lookup(var.worker_node_taints, var.workers.*.name[count.index], []))
   }
 }
-
-locals {
-  # Hack to workaround https://github.com/hashicorp/terraform/issues/17251
-  # Still an issue in Terraform v0.12 https://github.com/hashicorp/terraform/issues/20572
-  # Default Container Linux config snippets map every node names to list("\n") so
-  # all lookups succeed
-  clc_defaults = zipmap(
-    concat(var.controllers.*.name, var.workers.*.name),
-    chunklist(data.template_file.clc-default-snippets.*.rendered, 1),
-  )
-
-  # Union of the default and user specific snippets, later overrides prior.
-  clc_map = merge(local.clc_defaults, var.clc_snippets)
-}
-
-// Horrible hack to generate a Terraform list of node count length
-data "template_file" "clc-default-snippets" {
-  count    = length(var.controllers) + length(var.workers)
-  template = "\n"
-}
-

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -49,7 +49,7 @@ List of worker machine details (unique name, identifying MAC address, FQDN)
 EOD
 }
 
-variable "clc_snippets" {
+variable "snippets" {
   type        = map(list(string))
   description = "Map from machine names to lists of Container Linux Config snippets"
   default     = {}

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -72,7 +72,7 @@ data "ct_config" "controller-ignitions" {
   count        = var.controller_count
   content      = data.template_file.controller-configs.*.rendered[count.index]
   pretty_print = false
-  snippets     = var.controller_clc_snippets
+  snippets     = var.controller_snippets
 }
 
 # Controller Container Linux configs

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -47,13 +47,13 @@ variable "os_image" {
   default     = "coreos-stable"
 }
 
-variable "controller_clc_snippets" {
+variable "controller_snippets" {
   type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
 
-variable "worker_clc_snippets" {
+variable "worker_snippets" {
   type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []

--- a/digital-ocean/container-linux/kubernetes/workers.tf
+++ b/digital-ocean/container-linux/kubernetes/workers.tf
@@ -60,7 +60,7 @@ resource "digitalocean_tag" "workers" {
 data "ct_config" "worker-ignition" {
   content      = data.template_file.worker-config.rendered
   pretty_print = false
-  snippets     = var.worker_clc_snippets
+  snippets     = var.worker_snippets
 }
 
 # Worker Container Linux config

--- a/docs/advanced/customization.md
+++ b/docs/advanced/customization.md
@@ -125,7 +125,7 @@ systemd:
             Environment="ETCD_LOG_PACKAGE_LEVELS=etcdserver=WARNING,security=DEBUG"
 ```
 
-Reference the CLC contents by location (e.g. `file("./custom-units.yaml")`). On [AWS](/cl/aws/#cluster), [Azure](/cl/azure/#cluster), [DigitalOcean](/cl/digital-ocean/#cluster), or [Google Cloud](/cl/google-cloud/#cluster) extend the `controller_clc_snippets` or `worker_clc_snippets` list variables.
+Reference the CLC contents by location (e.g. `file("./custom-units.yaml")`). On [AWS](/cl/aws/#cluster), [Azure](/cl/azure/#cluster), [DigitalOcean](/cl/digital-ocean/#cluster), or [Google Cloud](/cl/google-cloud/#cluster) extend the `controller_snippets` or `worker_snippets` list variables.
 
 ```tf
 module "nemo" {
@@ -133,11 +133,11 @@ module "nemo" {
 
   controller_count        = 1
   worker_count            = 2
-  controller_clc_snippets = [
+  controller_snippets = [
     file("./custom-files"),
     file("./custom-units"),
   ]
-  worker_clc_snippets = [
+  worker_snippets = [
     file("./custom-files"),
     file("./custom-units")",
   ]
@@ -145,12 +145,12 @@ module "nemo" {
 }
 ```
 
-On [Bare-Metal](/cl/bare-metal/#cluster), different CLCs may be used for each node (since hardware may be heterogeneous). Extend the `clc_snippets` map variable by mapping a controller or worker name key to a list of snippets.
+On [Bare-Metal](/cl/bare-metal/#cluster), different CLCs may be used for each node (since hardware may be heterogeneous). Extend the `snippets` map variable by mapping a controller or worker name key to a list of snippets.
 
 ```tf
 module "mercury" {
   ...
-  clc_snippets = {
+  snippets = {
     "node2" = [file("./units/hello.yaml")]
     "node3" = [
       file("./units/world.yaml"),

--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -67,7 +67,7 @@ The AWS internal `workers` module supports a number of [variables](https://githu
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |
 | spot_price | Spot price in USD for worker instances or 0 to use on-demand instances | 0 | 0.10 |
-| clc_snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
+| snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | service_cidr | Must match `service_cidr` of cluster | "10.3.0.0/16" | "10.3.0.0/24" |
 | node_labels | List of initial node labels | [] | ["worker-pool=foo"] |
 
@@ -133,7 +133,7 @@ The Azure internal `workers` module supports a number of [variables](https://git
 | vm_type | Machine type for instances | "Standard_DS1_v2" | See below |
 | os_image | Channel for a Container Linux derivative | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha |
 | priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | "Regular" | "Low" |
-| clc_snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
+| snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | node_labels | List of initial node labels | [] | ["worker-pool=foo"] |
 
@@ -209,7 +209,7 @@ Check the list of regions [docs](https://cloud.google.com/compute/docs/regions-z
 | os_image | Container Linux image for compute instances | "coreos-stable" | "coreos-alpha", "coreos-beta" |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | preemptible | If true, Compute Engine will terminate instances randomly within 24 hours | false | true |
-| clc_snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
+| snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | service_cidr | Must match `service_cidr` of cluster | "10.3.0.0/16" | "10.3.0.0/24" |
 | node_labels | List of initial node labels | [] | ["worker-pool=foo"] |
 

--- a/docs/cl/aws.md
+++ b/docs/cl/aws.md
@@ -214,8 +214,8 @@ Reference the DNS zone id with `aws_route53_zone.zone-for-clusters.zone_id`.
 | disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |
 | worker_target_groups | Target group ARNs to which worker instances should be added | [] | [aws_lb_target_group.app.id] |
 | worker_price | Spot price in USD for worker instances or 0 to use on-demand instances | 0/null | 0.10 |
-| controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
-| worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
+| controller_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
+| worker_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | network_mtu | CNI interface MTU (calico only) | 1480 | 8981 |
 | host_cidr | CIDR IPv4 range to assign to EC2 instances | "10.0.0.0/16" | "10.1.0.0/16" |

--- a/docs/cl/azure.md
+++ b/docs/cl/azure.md
@@ -231,8 +231,8 @@ Reference the DNS zone with `azurerm_dns_zone.clusters.name` and its resource gr
 | os_image | Channel for a Container Linux derivative | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | worker_priority | Set priority to Spot to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | Regular | Spot |
-| controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
-| worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
+| controller_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
+| worker_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
 | networking | Choice of networking provider | "calico" | "flannel" or "calico" |
 | host_cidr | CIDR IPv4 range to assign to instances | "10.0.0.0/16" | "10.0.0.0/20" |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |

--- a/docs/cl/bare-metal.md
+++ b/docs/cl/bare-metal.md
@@ -352,7 +352,7 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/bare-me
 | install_disk | Disk device where Container Linux should be installed | "/dev/sda" | "/dev/sdb" |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | network_mtu | CNI interface MTU (calico-only) | 1480 | - |
-| clc_snippets | Map from machine names to lists of Container Linux Config snippets | {} | [example](/advanced/customization/#usage) |
+| snippets | Map from machine names to lists of Container Linux Config snippets | {} | [examples](/advanced/customization/) |
 | network_ip_autodetection_method | Method to detect host IPv4 address (calico-only) | "first-found" | "can-reach=10.0.0.1" |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |

--- a/docs/cl/digital-ocean.md
+++ b/docs/cl/digital-ocean.md
@@ -244,8 +244,8 @@ Digital Ocean requires the SSH public key be uploaded to your account, so you ma
 | controller_type | Droplet type for controllers | "s-2vcpu-2gb" | s-2vcpu-2gb, s-2vcpu-4gb, s-4vcpu-8gb, ... |
 | worker_type | Droplet type for workers | "s-1vcpu-2gb" | s-1vcpu-2gb, s-2vcpu-2gb, ... |
 | os_image | Container Linux image for instances | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha, "custom-image-id" |
-| controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
-| worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
+| controller_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
+| worker_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | networking | Choice of networking provider | "calico" | "flannel" or "calico" |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |

--- a/docs/cl/google-cloud.md
+++ b/docs/cl/google-cloud.md
@@ -238,8 +238,8 @@ resource "google_dns_managed_zone" "zone-for-clusters" {
 | os_image | Container Linux image for compute instances | "coreos-stable" | "flatcar-linux-2303-4-0" |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | worker_preemptible | If enabled, Compute Engine will terminate workers randomly within 24 hours | false | true |
-| controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
-| worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
+| controller_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
+| worker_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |

--- a/google-cloud/container-linux/kubernetes/controllers.tf
+++ b/google-cloud/container-linux/kubernetes/controllers.tf
@@ -68,7 +68,7 @@ data "ct_config" "controller-ignitions" {
   count        = var.controller_count
   content      = data.template_file.controller-configs.*.rendered[count.index]
   pretty_print = false
-  snippets     = var.controller_clc_snippets
+  snippets     = var.controller_snippets
 }
 
 # Controller Container Linux configs

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -64,13 +64,13 @@ variable "worker_preemptible" {
   default     = false
 }
 
-variable "controller_clc_snippets" {
+variable "controller_snippets" {
   type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
 
-variable "worker_clc_snippets" {
+variable "worker_snippets" {
   type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []

--- a/google-cloud/container-linux/kubernetes/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers.tf
@@ -17,7 +17,7 @@ module "workers" {
   ssh_authorized_key    = var.ssh_authorized_key
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
-  clc_snippets          = var.worker_clc_snippets
+  snippets          = var.worker_snippets
   node_labels           = var.worker_node_labels
 }
 

--- a/google-cloud/container-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/workers/variables.tf
@@ -52,7 +52,7 @@ variable "preemptible" {
   default     = false
 }
 
-variable "clc_snippets" {
+variable "snippets" {
   type        = list(string)
   description = "Container Linux Config snippets"
   default     = []

--- a/google-cloud/container-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/container-linux/kubernetes/workers/workers.tf
@@ -73,7 +73,7 @@ resource "google_compute_instance_template" "worker" {
 data "ct_config" "worker-ignition" {
   content      = data.template_file.worker-config.rendered
   pretty_print = false
-  snippets     = var.clc_snippets
+  snippets     = var.snippets
 }
 
 # Worker Container Linux config


### PR DESCRIPTION
* Rename controller_clc_snippets to controller_snippets (cloud platforms)
* Rename worker_clc_snippets to worker_snippets (cloud platforms)
* Rename clc_snippets to snippets (bare-metal)
