### PR TITLE
Allow target group health check to pass

### DIFF
--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -61,7 +61,8 @@ systemd:
           --cluster_domain=${cluster_domain_suffix} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --exit-on-lock-contention \
-          --healthz-port=0 \
+          --healthz-port=10254 \
+          --healthz-bind-address=0.0.0.0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \


### PR DESCRIPTION
When I created an AWS Fedora CoreOS cluster using Typhoon, the instances in the worker target group did not pass the health checks. On each worker, I manually updated the healthz port and added a bind address, then ran "systemctl daemon-reload" and "systemctl restart kubelet". Within minutes, the health checks were passing and my ingress controller was letting requests pass into services.