### PR TITLE
Change container-linux module preference to Flatcar Linux

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,31 @@ Notable changes between versions.
 
 ## Latest
 
+* Choose Fedora CoreOS or Flatcar Linux (**action required**)
+  * Use a `fedora-coreos` module for Fedora CoreOS
+  * Use a `container-linux` module for Flatcar Linux
+  * CoreOS Container Linux [won't receive updates](https://coreos.com/os/eol/) after May 2020
+
+#### AWS
+
+* Change Container Linux `os_image` default from `coreos-stable` to `flatcar-stable`
+
+#### Azure
+
+* Change Container Linux `os_image` default from `coreos-stable` to `flatcar-stable`
+
+#### Bare-Metal
+
+* Container Linux users should change [os_channel](https://typhoon.psdn.io/cl/bare-metal/#required) from a CoreOS channel to a Flatcar channel
+
+#### Google
+
+* Change Container Linux `os_image` to be required. Container Linux users should upload a Flatcar Linux image and set it (**action required**)
+
+#### DigitalOcean
+
+* Change Container Linux `os_image` to be required. Container Linux users should upload a Flatcar Linux image and set it (**action required**)
+
 ## v1.18.1
 
 * Kubernetes [v1.18.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#v1181)

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -44,7 +44,7 @@ variable "worker_type" {
 variable "os_image" {
   type        = string
   description = "AMI channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge)"
-  default     = "coreos-stable"
+  default     = "flatcar-stable"
 }
 
 variable "disk_size" {
@@ -94,12 +94,6 @@ variable "worker_snippets" {
 variable "ssh_authorized_key" {
   type        = string
   description = "SSH public key for user 'core'"
-}
-
-variable "asset_dir" {
-  type        = string
-  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
-  default     = ""
 }
 
 variable "networking" {
@@ -154,6 +148,12 @@ variable "worker_node_labels" {
 }
 
 # unofficial, undocumented, unsupported
+
+variable "asset_dir" {
+  type        = string
+  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
+  default     = ""
+}
 
 variable "cluster_domain_suffix" {
   type        = string

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -37,7 +37,7 @@ variable "instance_type" {
 variable "os_image" {
   type        = string
   description = "AMI channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge)"
-  default     = "coreos-stable"
+  default     = "flatcar-stable"
 }
 
 variable "disk_size" {

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -44,7 +44,7 @@ variable "worker_type" {
 variable "os_image" {
   type        = string
   description = "AMI channel for Fedora CoreOS (not yet used)"
-  default     = "coreos-stable"
+  default     = "stable"
 }
 
 variable "disk_size" {

--- a/aws/fedora-coreos/kubernetes/workers/variables.tf
+++ b/aws/fedora-coreos/kubernetes/workers/variables.tf
@@ -37,7 +37,7 @@ variable "instance_type" {
 variable "os_image" {
   type        = string
   description = "AMI channel for Fedora CoreOS (not yet used)"
-  default     = "coreos-stable"
+  default     = "stable"
 }
 
 variable "disk_size" {

--- a/azure/container-linux/kubernetes/variables.tf
+++ b/azure/container-linux/kubernetes/variables.tf
@@ -48,8 +48,8 @@ variable "worker_type" {
 
 variable "os_image" {
   type        = string
-  default     = "coreos-stable"
   description = "Channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta)"
+  default     = "flatcar-stable"
 }
 
 variable "disk_size" {
@@ -81,12 +81,6 @@ variable "worker_snippets" {
 variable "ssh_authorized_key" {
   type        = string
   description = "SSH public key for user 'core'"
-}
-
-variable "asset_dir" {
-  type        = string
-  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
-  default     = ""
 }
 
 variable "networking" {
@@ -135,6 +129,12 @@ variable "worker_node_labels" {
 }
 
 # unofficial, undocumented, unsupported
+
+variable "asset_dir" {
+  type        = string
+  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
+  default     = ""
+}
 
 variable "cluster_domain_suffix" {
   type        = string

--- a/azure/container-linux/kubernetes/workers/variables.tf
+++ b/azure/container-linux/kubernetes/workers/variables.tf
@@ -46,8 +46,8 @@ variable "vm_type" {
 
 variable "os_image" {
   type        = string
-  description = "Channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha)"
-  default     = "coreos-stable"
+  description = "Channel for a Container Linux derivative (flatcar-stable, flatcar-beta, coreos-stable, coreos-beta, coreos-alpha)"
+  default     = "flatcar-stable"
 }
 
 variable "priority" {

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -79,12 +79,6 @@ variable "ssh_authorized_key" {
   description = "SSH public key for user 'core'"
 }
 
-variable "asset_dir" {
-  type        = string
-  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
-  default     = ""
-}
-
 variable "networking" {
   type        = string
   description = "Choice of networking provider (flannel or calico)"
@@ -157,6 +151,12 @@ variable "enable_aggregation" {
 }
 
 # unofficial, undocumented, unsupported
+
+variable "asset_dir" {
+  type        = string
+  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
+  default     = ""
+}
 
 variable "cluster_domain_suffix" {
   type        = string

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -43,8 +43,7 @@ variable "worker_type" {
 
 variable "os_image" {
   type        = string
-  description = "Container Linux image for instances (e.g. coreos-stable)"
-  default     = "coreos-stable"
+  description = "Container Linux image for instances (e.g. coreos-stable, custom-image-id)"
 }
 
 variable "controller_snippets" {
@@ -64,12 +63,6 @@ variable "worker_snippets" {
 variable "ssh_fingerprints" {
   type        = list(string)
   description = "SSH public key fingerprints. (e.g. see `ssh-add -l -E md5`)"
-}
-
-variable "asset_dir" {
-  type        = string
-  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
-  default     = ""
 }
 
 variable "networking" {
@@ -106,6 +99,12 @@ variable "enable_aggregation" {
 }
 
 # unofficial, undocumented, unsupported
+
+variable "asset_dir" {
+  type        = string
+  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
+  default     = ""
+}
 
 variable "cluster_domain_suffix" {
   type        = string

--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -5,8 +5,10 @@ Typhoon AWS, Azure, and Google Cloud allow additional groups of workers to be de
 Internal Terraform Modules:
 
 * `aws/container-linux/kubernetes/workers`
+* `aws/fedora-coreos/kubernetes/workers`
 * `azure/container-linux/kubernetes/workers`
 * `google-cloud/container-linux/kubernetes/workers`
+* `google-cloud/fedora-coreos/kubernetes/workers`
 
 ## AWS
 
@@ -20,7 +22,7 @@ module "tempest-worker-pool" {
   vpc_id          = module.tempest.vpc_id
   subnet_ids      = module.tempest.subnet_ids
   security_groups = module.tempest.worker_security_groups
-  
+
   # configuration
   name               = "tempest-pool"
   kubeconfig         = module.tempest.kubeconfig
@@ -29,7 +31,7 @@ module "tempest-worker-pool" {
   # optional
   worker_count  = 2
   instance_type = "m5.large"
-  os_image      = "coreos-beta"
+  os_image      = "flatcar-beta"
 }
 ```
 
@@ -62,12 +64,12 @@ The AWS internal `workers` module supports a number of [variables](https://githu
 |:-----|:------------|:--------|:--------|
 | worker_count | Number of instances | 1 | 3 |
 | instance_type | EC2 instance type | "t3.small" | "t3.medium" |
-| os_image | AMI channel for a Container Linux derivative | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha |
+| os_image | AMI channel for a Container Linux derivative | "flatcar-stable" | flatcar-stable, flatcar-beta, flatcar-alph, coreos-stable, coreos-beta, coreos-alpha |
 | disk_size | Size of the EBS volume in GB | 40 | 100 |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |
 | spot_price | Spot price in USD for worker instances or 0 to use on-demand instances | 0 | 0.10 |
-| snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
+| snippets | Container Linux Config snippets | [] | [examples](/advanced/customization/) |
 | service_cidr | Must match `service_cidr` of cluster | "10.3.0.0/16" | "10.3.0.0/24" |
 | node_labels | List of initial node labels | [] | ["worker-pool=foo"] |
 
@@ -80,7 +82,7 @@ Create a cluster following the Azure [tutorial](../cl/azure.md#cluster). Define 
 ```tf
 module "ramius-worker-pool" {
   source = "git::https://github.com/poseidon/typhoon//azure/container-linux/kubernetes/workers?ref=v1.18.1"
-  
+
   # Azure
   region                  = module.ramius.region
   resource_group_name     = module.ramius.resource_group_name
@@ -131,9 +133,9 @@ The Azure internal `workers` module supports a number of [variables](https://git
 |:-----|:------------|:--------|:--------|
 | worker_count | Number of instances | 1 | 3 |
 | vm_type | Machine type for instances | "Standard_DS1_v2" | See below |
-| os_image | Channel for a Container Linux derivative | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha |
-| priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | "Regular" | "Low" |
-| snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
+| os_image | Channel for a Container Linux derivative | "flatcar-stable" | flatcar-stable, flatcar-beta, coreos-stable, coreos-beta, coreos-alpha |
+| priority | Set priority to Spot to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | "Regular" | "Spot" |
+| snippets | Container Linux Config snippets | [] | [examples](/advanced/customization/) |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | node_labels | List of initial node labels | [] | ["worker-pool=foo"] |
 
@@ -156,7 +158,7 @@ module "yavin-worker-pool" {
   name               = "yavin-16x"
   kubeconfig         = module.yavin.kubeconfig
   ssh_authorized_key = var.ssh_authorized_key
-  
+
   # optional
   worker_count = 2
   machine_type = "n1-standard-16"
@@ -196,6 +198,7 @@ The Google Cloud internal `workers` module supports a number of [variables](http
 | region | Region for the worker pool instances. May differ from the cluster's region | "europe-west2" |
 | network | Must be set to `network_name` output by cluster | module.cluster.network_name |
 | kubeconfig | Must be set to `kubeconfig` output by cluster | module.cluster.kubeconfig |
+| os_image | Container Linux image for compute instances | "fedora-coreos-or-flatcar-image", coreos-stable, coreos-beta, coreos-alpha |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3NZ..." |
 
 Check the list of regions [docs](https://cloud.google.com/compute/docs/regions-zones/regions-zones) or with `gcloud compute regions list`.
@@ -206,10 +209,9 @@ Check the list of regions [docs](https://cloud.google.com/compute/docs/regions-z
 |:-----|:------------|:--------|:--------|
 | worker_count | Number of instances | 1 | 3 |
 | machine_type | Compute instance machine type | "n1-standard-1" | See below |
-| os_image | Container Linux image for compute instances | "coreos-stable" | "coreos-alpha", "coreos-beta" |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | preemptible | If true, Compute Engine will terminate instances randomly within 24 hours | false | true |
-| snippets | Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |
+| snippets | Container Linux Config snippets | [] | [examples](/advanced/customization/) |
 | service_cidr | Must match `service_cidr` of cluster | "10.3.0.0/16" | "10.3.0.0/24" |
 | node_labels | List of initial node labels | [] | ["worker-pool=foo"] |
 

--- a/docs/cl/aws.md
+++ b/docs/cl/aws.md
@@ -208,7 +208,7 @@ Reference the DNS zone id with `aws_route53_zone.zone-for-clusters.zone_id`.
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | EC2 instance type for controllers | "t3.small" | See below |
 | worker_type | EC2 instance type for workers | "t3.small" | See below |
-| os_image | AMI channel for a Container Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge |
+| os_image | AMI channel for a Container Linux derivative | "flatcar-stable" | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge |
 | disk_size | Size of the EBS volume in GB | 40 | 100 |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |

--- a/docs/cl/azure.md
+++ b/docs/cl/azure.md
@@ -228,7 +228,7 @@ Reference the DNS zone with `azurerm_dns_zone.clusters.name` and its resource gr
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | Machine type for controllers | "Standard_B2s" | See below |
 | worker_type | Machine type for workers | "Standard_DS1_v2" | See below |
-| os_image | Channel for a Container Linux derivative | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta |
+| os_image | Channel for a Container Linux derivative | "flatcar-stable" | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | worker_priority | Set priority to Spot to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | Regular | Spot |
 | controller_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/#usage) |

--- a/docs/cl/bare-metal.md
+++ b/docs/cl/bare-metal.md
@@ -165,8 +165,8 @@ module "mercury" {
   # bare-metal
   cluster_name            = "mercury"
   matchbox_http_endpoint  = "http://matchbox.example.com"
-  os_channel              = "coreos-stable"
-  os_version              = "2191.5.0"
+  os_channel              = "flatcar-stable"
+  os_version              = "2345.3.1"
 
   # configuration
   k8s_domain_name    = "node1.example.com"
@@ -337,7 +337,7 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/bare-me
 | cluster_name | Unique cluster name | "mercury" |
 | matchbox_http_endpoint | Matchbox HTTP read-only endpoint | "http://matchbox.example.com:port" |
 | os_channel | Channel for a Container Linux derivative | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge |
-| os_version | Version for a Container Linux derivative to PXE and install | "1632.3.0" |
+| os_version | Version for a Container Linux derivative to PXE and install | "2345.3.1" |
 | k8s_domain_name | FQDN resolving to the controller(s) nodes. Workers and kubectl will communicate with this endpoint | "myk8s.example.com" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3Nz..." |
 | controllers | List of controller machine detail objects (unique name, identifying MAC address, FQDN) | `[{name="node1", mac="52:54:00:a1:9c:ae", domain="node1.example.com"}]` |

--- a/docs/cl/digital-ocean.md
+++ b/docs/cl/digital-ocean.md
@@ -59,6 +59,20 @@ provider "ct" {
 }
 ```
 
+### Flatcar Linux Images
+
+Flatcar Linux publishes DigitalOcean images, but does not yet upload them. DigitalOcean allows [custom images](https://blog.digitalocean.com/custom-images/) to be uploaded via URLor file.
+
+[Download](https://www.flatcar-linux.org/releases/) the Flatcar Linux DigitalOcean bin image. Rename the image with the channel and version (to refer to these images over time) and [upload](https://cloud.digitalocean.com/images/custom_images) it as a custom image.
+
+```tf
+data "digitalocean_image" "flatcar-stable-2303-4-0" {
+  name = "flatcar-stable-2303.4.0.bin.bz2"
+}
+```
+
+Set the [os_image](#variables) in the next step.
+
 ## Cluster
 
 Define a Kubernetes cluster using the module `digital-ocean/container-linux/kubernetes`.
@@ -71,9 +85,9 @@ module "nemo" {
   cluster_name = "nemo"
   region       = "nyc3"
   dns_zone     = "digital-ocean.example.com"
-  os_image     = "coreos-stable"
 
   # configuration
+  os_image         = data.digitalocean_image.flatcar-stable-2303-4-0.id
   ssh_fingerprints = ["d7:9d:79:ae:56:32:73:79:95:88:e3:a2:ab:5d:45:e7"]
 
   # optional
@@ -82,28 +96,6 @@ module "nemo" {
 ```
 
 Reference the [variables docs](#variables) or the [variables.tf](https://github.com/poseidon/typhoon/blob/master/digital-ocean/container-linux/kubernetes/variables.tf) source.
-
-### Flatcar Linux Only
-
-!!! warning
-    Typhoon for Flatcar Linux on DigitalOcean is alpha. Also IPv6 is unsupported with DigitalOcean custom images.
-
-Flatcar Linux publishes DigitalOcean images, but does not upload them. DigitalOcean allows [custom boot images](https://blog.digitalocean.com/custom-images/) by file or URL.
-
-[Download](https://www.flatcar-linux.org/releases/) the Flatcar Linux DigitalOcean bin image (or copy the URL) and [upload](https://cloud.digitalocean.com/images/custom_images) it as a custom image. Rename the image with the channel and version to refer to these images over time.
-
-```tf
-module "nemo" {
-  ...
-  os_image = data.digitalocean_image.flatcar-stable.id
-}
-
-data "digitalocean_image" "flatcar-stable" {
-  name = "flatcar-stable-2303.4.0.bin.bz2"
-}
-```
-
-Set the [os_image](#variables) to the custom image id.
 
 ## ssh-agent
 
@@ -198,6 +190,7 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/digital
 | cluster_name | Unique cluster name (prepended to dns_zone) | "nemo" |
 | region | Digital Ocean region | "nyc1", "sfo2", "fra1", tor1" |
 | dns_zone | Digital Ocean domain (i.e. DNS zone) | "do.example.com" |
+| os_image | Container Linux image for instances | "custom-image-id", coreos-stable, coreos-beta, coreos-alpha |
 | ssh_fingerprints | SSH public key fingerprints | ["d7:9d..."] |
 
 #### DNS Zone
@@ -243,7 +236,6 @@ Digital Ocean requires the SSH public key be uploaded to your account, so you ma
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | Droplet type for controllers | "s-2vcpu-2gb" | s-2vcpu-2gb, s-2vcpu-4gb, s-4vcpu-8gb, ... |
 | worker_type | Droplet type for workers | "s-1vcpu-2gb" | s-1vcpu-2gb, s-2vcpu-2gb, ... |
-| os_image | Container Linux image for instances | "coreos-stable" | coreos-stable, coreos-beta, coreos-alpha, "custom-image-id" |
 | controller_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | worker_snippets | Worker Container Linux Config snippets | [] | [example](/advanced/customization/) |
 | networking | Choice of networking provider | "calico" | "flannel" or "calico" |

--- a/docs/cl/google-cloud.md
+++ b/docs/cl/google-cloud.md
@@ -65,6 +65,25 @@ Additional configuration options are described in the `google` provider [docs](h
 !!! tip
     Regions are listed in [docs](https://cloud.google.com/compute/docs/regions-zones/regions-zones) or with `gcloud compute regions list`. A project may contain multiple clusters across different regions.
 
+### Flatcar Linux Images
+
+Flatcar Linux publishes Google Cloud images, but does not yet upload them. Google Cloud allows [custom boot images](https://cloud.google.com/compute/docs/images/import-existing-image) to be uploaded to a bucket and imported into your project.
+
+[Download](https://www.flatcar-linux.org/releases/) the Flatcar Linux GCE gzipped tarball and upload it to a Google Cloud storage bucket.
+
+```
+gsutil list
+gsutil cp flatcar_production_gce.tar.gz gs://BUCKET
+```
+
+Create a Compute Engine image from the file.
+
+```
+gcloud compute images create flatcar-linux-2303-4-0 --source-uri gs://BUCKET_NAME/flatcar_production_gce.tar.gz
+```
+
+Set the [os_image](#variables) in the next step.
+
 ## Cluster
 
 Define a Kubernetes cluster using the module `google-cloud/container-linux/kubernetes`.
@@ -80,6 +99,7 @@ module "yavin" {
   dns_zone_name = "example-zone"
 
   # configuration
+  os_image           = "flatcar-linux-2303-4-0"
   ssh_authorized_key = "ssh-rsa AAAAB3Nz..."
 
   # optional
@@ -88,28 +108,6 @@ module "yavin" {
 ```
 
 Reference the [variables docs](#variables) or the [variables.tf](https://github.com/poseidon/typhoon/blob/master/google-cloud/container-linux/kubernetes/variables.tf) source.
-
-### Flatcar Linux Only
-
-!!! warning
-    Typhoon for Flatcar Linux on Google Cloud is alpha.
-
-Flatcar Linux publishes Google Cloud images, but does not upload them. Google Cloud allows [custom boot images](https://cloud.google.com/compute/docs/images/import-existing-image) to be uploaded to a bucket and imported into a project.
-
-[Download](https://www.flatcar-linux.org/releases/) the Flatcar Linux GCE gzipped tarball and upload it to a Google Cloud storage bucket.
-
-```
-gsutil list
-gsutil cp flatcar_production_gce.tar.gz gs://BUCKET
-```
-
-Create a Compute Engine image from the file.
-
-```
-gcloud compute images create flatcar-linux-2303-4-0 --source-uri gs://BUCKET_NAME/flatcar_production_gce.tar.gz
-```
-
-Set the [os_image](#variables) to the image name (e.g. `flatcar-linux-2303-4-0`)
 
 ## ssh-agent
 
@@ -206,6 +204,7 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/google-
 | region | Google Cloud region | "us-central1" |
 | dns_zone | Google Cloud DNS zone | "google-cloud.example.com" |
 | dns_zone_name | Google Cloud DNS zone name | "example-zone" |
+| os_image | Container Linux image for compute instances | "flatcar-linux-2303-4-0", coreos-stable, coreos-beta, coreos-alpha |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3NZ..." |
 
 Check the list of valid [regions](https://cloud.google.com/compute/docs/regions-zones/regions-zones) and list Container Linux [images](https://cloud.google.com/compute/docs/images) with `gcloud compute images list | grep coreos`.
@@ -235,7 +234,6 @@ resource "google_dns_managed_zone" "zone-for-clusters" {
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | Machine type for controllers | "n1-standard-1" | See below |
 | worker_type | Machine type for workers | "n1-standard-1" | See below |
-| os_image | Container Linux image for compute instances | "coreos-stable" | "flatcar-linux-2303-4-0" |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | worker_preemptible | If enabled, Compute Engine will terminate workers randomly within 24 hours | false | true |
 | controller_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |

--- a/google-cloud/container-linux/kubernetes/variables.tf
+++ b/google-cloud/container-linux/kubernetes/variables.tf
@@ -48,8 +48,7 @@ variable "worker_type" {
 
 variable "os_image" {
   type        = string
-  description = "Container Linux image for compute instances (e.g. coreos-stable)"
-  default     = "coreos-stable"
+  description = "Container Linux image for compute instances (e.g. coreos-stable, custom-image)"
 }
 
 variable "disk_size" {
@@ -81,12 +80,6 @@ variable "worker_snippets" {
 variable "ssh_authorized_key" {
   type        = string
   description = "SSH public key for user 'core'"
-}
-
-variable "asset_dir" {
-  type        = string
-  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
-  default     = ""
 }
 
 variable "networking" {
@@ -130,6 +123,12 @@ variable "worker_node_labels" {
 }
 
 # unofficial, undocumented, unsupported
+
+variable "asset_dir" {
+  type        = string
+  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
+  default     = ""
+}
 
 variable "cluster_domain_suffix" {
   type        = string

--- a/google-cloud/container-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/container-linux/kubernetes/workers/variables.tf
@@ -37,7 +37,6 @@ variable "machine_type" {
 variable "os_image" {
   type        = string
   description = "Container Linux image for compute instanges (e.g. gcloud compute images list)"
-  default     = "coreos-stable"
 }
 
 variable "disk_size" {


### PR DESCRIPTION
* No change to Fedora CoreOS modules
* For Container Linx AWS and Azure, change the `os_image` default from coreos-stable to flatcar-stable
* For Container Linux GCP and DigitalOcean, change `os_image` to be required since users should upload a Flatcar Linux image and set the variable
* For Container Linux bare-metal, recommend users change the `os_channel` to Flatcar Linux. No actual module change.
