### PR TITLE
Fix race condition creating DigitalOcean firewall rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Notable changes between versions.
 
 ## Latest
 
+## v1.18.2
+
 * Kubernetes [v1.18.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#v1182)
 * Choose Fedora CoreOS or Flatcar Linux (**action required**)
   * Use a `fedora-coreos` module for Fedora CoreOS
@@ -13,13 +15,17 @@ Notable changes between versions.
 
 ### Fedora CoreOS
 
-* Fix race condition during bootstrap related to SELinux shared content label ([#708](https://github.com/poseidon/typhoon/pull/708))
+* Fix bootstrap race condition from SELinux unshared content label ([#708](https://github.com/poseidon/typhoon/pull/708))
 
 #### Azure
 
 * Add support for Fedora CoreOS ([#704](https://github.com/poseidon/typhoon/pull/704))
 
-### Container Linux
+#### DigitalOcean
+
+* Fix race condition creating firewall allow rules ([#709](https://github.com/poseidon/typhoon/pull/709))
+
+### Flatcar Linux
 
 #### AWS
 
@@ -42,6 +48,7 @@ Notable changes between versions.
 #### DigitalOcean
 
 * Change `os_image` to be required. Recommend uploading a Flatcar Linux image (**action required**) ([#702](https://github.com/poseidon/typhoon/pull/702))
+* Fix race condition creating firewall allow rules ([#709](https://github.com/poseidon/typhoon/pull/709))
 
 ## v1.18.1
 

--- a/digital-ocean/container-linux/kubernetes/network.tf
+++ b/digital-ocean/container-linux/kubernetes/network.tf
@@ -1,7 +1,10 @@
 resource "digitalocean_firewall" "rules" {
   name = var.cluster_name
 
-  tags = ["${var.cluster_name}-controller", "${var.cluster_name}-worker"]
+  tags = [
+    digitalocean_tag.controllers.name,
+    digitalocean_tag.workers.name
+  ]
 
   # allow ssh, internal flannel, internal node-exporter, internal kubelet
   inbound_rule {
@@ -59,7 +62,7 @@ resource "digitalocean_firewall" "rules" {
 resource "digitalocean_firewall" "controllers" {
   name = "${var.cluster_name}-controllers"
 
-  tags = ["${var.cluster_name}-controller"]
+  tags = [digitalocean_tag.controllers.name]
 
   # etcd
   inbound_rule {
@@ -93,7 +96,7 @@ resource "digitalocean_firewall" "controllers" {
 resource "digitalocean_firewall" "workers" {
   name = "${var.cluster_name}-workers"
 
-  tags = ["${var.cluster_name}-worker"]
+  tags = [digitalocean_tag.workers.name]
 
   # allow HTTP/HTTPS ingress
   inbound_rule {

--- a/digital-ocean/fedora-coreos/kubernetes/network.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/network.tf
@@ -1,7 +1,10 @@
 resource "digitalocean_firewall" "rules" {
   name = var.cluster_name
 
-  tags = ["${var.cluster_name}-controller", "${var.cluster_name}-worker"]
+  tags = [
+    digitalocean_tag.controllers.name,
+    digitalocean_tag.workers.name
+  ]
 
   # allow ssh, internal flannel, internal node-exporter, internal kubelet
   inbound_rule {
@@ -59,7 +62,7 @@ resource "digitalocean_firewall" "rules" {
 resource "digitalocean_firewall" "controllers" {
   name = "${var.cluster_name}-controllers"
 
-  tags = ["${var.cluster_name}-controller"]
+  tags = [digitalocean_tag.controllers.name]
 
   # etcd
   inbound_rule {
@@ -93,7 +96,7 @@ resource "digitalocean_firewall" "controllers" {
 resource "digitalocean_firewall" "workers" {
   name = "${var.cluster_name}-workers"
 
-  tags = ["${var.cluster_name}-worker"]
+  tags = [digitalocean_tag.workers.name]
 
   # allow HTTP/HTTPS ingress
   inbound_rule {


### PR DESCRIPTION
* DigitalOcean firewall rules should reference Terraform tag resources rather than using tag strings. Otherwise, terraform apply can fail (neeeds rerun) if a tag has not yet been created