### PR TITLE
aws: use element() to look up controller subnet_id with wrap around

### DIFF
--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -36,7 +36,7 @@ resource "aws_instance" "controllers" {
 
   # network
   associate_public_ip_address = true
-  subnet_id                   = aws_subnet.public.*.id[count.index]
+  subnet_id                   = element(aws_subnet.public.*.id, count.index)
   vpc_security_group_ids      = [aws_security_group.controller.id]
 
   lifecycle {

--- a/aws/fedora-coreos/kubernetes/controllers.tf
+++ b/aws/fedora-coreos/kubernetes/controllers.tf
@@ -36,7 +36,7 @@ resource "aws_instance" "controllers" {
 
   # network
   associate_public_ip_address = true
-  subnet_id                   = aws_subnet.public.*.id[count.index]
+  subnet_id                   = element(aws_subnet.public.*.id, count.index)
   vpc_security_group_ids      = [aws_security_group.controller.id]
 
   lifecycle {


### PR DESCRIPTION
This PR re-introduces `element` in the AWS modules to look up subnet IDs for controllers. In these situations, `element`'s wrap around behavior is required. Otherwise, if `length(var.controller_count) > length(aws_subnet.public.*.id)`, Terraform fails.

With `controller_count = 5` in `us-west-2`, for example:

```
Error: Invalid index

  on .terraform/modules/green.typhoon/aws/container-linux/kubernetes/controllers.tf line 52, in resource "aws_instance" "controllers":
  52:   subnet_id = aws_subnet.public.*.id[count.index]
    |----------------
    | aws_subnet.public is tuple with 4 elements
    | count.index is 4

The given key does not identify an element in this collection value.
```

## Testing

I merged this change into our fork and can successfully plan. 

## Related

This regression was introduced in https://github.com/poseidon/typhoon/pull/605. I reviewed that and verified that the other cases use the same value for `count` in both resources and should raise index errors if the lists are not equal in length.