### PR TITLE
Update Prometheus from v2.18.0-rc.1 to v2.18.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Notable changes between versions.
 
 * Update nginx-ingress from v0.30.0 to [v0.32.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.32.0)
   * Add support for [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)
-* Update Prometheus from v2.17.1 to v2.18.0-rc.1
+* Update Prometheus from v2.17.1 to v2.18.0
 * Update Grafana from v6.7.2 to v7.0.0-beta1
 
 ## v1.18.2

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: quay.io/prometheus/prometheus:v2.18.0-rc.1
+          image: quay.io/prometheus/prometheus:v2.18.0
           args:
             - --web.listen-address=0.0.0.0:9090
             - --config.file=/etc/prometheus/prometheus.yaml


### PR DESCRIPTION
* https://github.com/prometheus/prometheus/releases/tag/v2.18.0
