### PR TITLE
Update Grafana from v7.0.0-beta1 to v7.0.0-beta2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Notable changes between versions.
 * Update nginx-ingress from v0.30.0 to [v0.32.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.32.0)
   * Add support for [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)
 * Update Prometheus from v2.17.1 to v2.18.1
-* Update Grafana from v6.7.2 to v7.0.0-beta1
+* Update Grafana from v6.7.2 to v7.0.0-beta2
 
 ## v1.18.2
 

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: docker.io/grafana/grafana:7.0.0-beta1
+          image: docker.io/grafana/grafana:7.0.0-beta2
           env:
             - name: GF_PATHS_CONFIG
               value: "/etc/grafana/custom.ini"


### PR DESCRIPTION
* https://github.com/grafana/grafana/releases/tag/v7.0.0-beta2
