### PR TITLE
Use Fedora CoreOS image streams on Google Cloud

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,12 @@ Notable changes between versions.
 * Fix Terraform plan error when `controller_count` exceeds AWS zones (e.g. 5 controllers) ([#714](https://github.com/poseidon/typhoon/pull/714))
   * Regressed in v1.17.1 ([#605](https://github.com/poseidon/typhoon/pull/605))
 
+#### Google
+
+* Use new Fedora CoreOS official [image streams](https://docs.fedoraproject.org/en-US/fedora-coreos/update-streams/) ([#723](https://github.com/poseidon/typhoon/pull/722))
+  * Add `os_stream` variable to set the stream to `stable` (default), `testing`, or `next`
+  * Deprecate `os_image` variable. Manual image uploads are no longer needed
+
 #### Addons
 
 * Update nginx-ingress from v0.30.0 to [v0.32.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.32.0)

--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -210,6 +210,7 @@ Check the list of regions [docs](https://cloud.google.com/compute/docs/regions-z
 |:-----|:------------|:--------|:--------|
 | worker_count | Number of instances | 1 | 3 |
 | machine_type | Compute instance machine type | "n1-standard-1" | See below |
+| os_stream | Fedora CoreOS stream for compute instances | "stable" | "testing", "next" |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | preemptible | If true, Compute Engine will terminate instances randomly within 24 hours | false | true |
 | snippets | Container Linux Config snippets | [] | [examples](/advanced/customization/) |

--- a/docs/fedora-coreos/google-cloud.md
+++ b/docs/fedora-coreos/google-cloud.md
@@ -65,25 +65,6 @@ Additional configuration options are described in the `google` provider [docs](h
 !!! tip
     Regions are listed in [docs](https://cloud.google.com/compute/docs/regions-zones/regions-zones) or with `gcloud compute regions list`. A project may contain multiple clusters across different regions.
 
-## Fedora CoreOS Images
-
-Fedora CoreOS publishes images for Google Cloud, but does not yet upload them. Google Cloud allows [custom boot images](https://cloud.google.com/compute/docs/images/import-existing-image) to be uploaded to a bucket and imported into your project.
-
-[Download](https://getfedora.org/coreos/download/) a Fedora CoreOS GCP gzipped tarball and upload it to a Google Cloud storage bucket.
-
-```
-gsutil list
-gsutil cp fedora-coreos-31.20200323.3.2-gcp.x86_64.tar.gz gs://BUCKET
-```
-
-Create a Compute Engine image from the file.
-
-```
-gcloud compute images create fedora-coreos-31-20200323-3-2 --source-uri gs://BUCKET/fedora-coreos-31.20200323.3.2-gcp.x86_64.tar.gz
-```
-
-Set the [os_image](#variables) in the next step.
-
 ## Cluster
 
 Define a Kubernetes cluster using the module `google-cloud/fedora-coreos/kubernetes`.
@@ -99,7 +80,6 @@ module "yavin" {
   dns_zone_name = "example-zone"
 
   # configuration
-  os_image           = "fedora-coreos-31-20200323-3-2"
   ssh_authorized_key = "ssh-rsa AAAAB3Nz..."
 
   # optional
@@ -204,7 +184,6 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/google-
 | region | Google Cloud region | "us-central1" |
 | dns_zone | Google Cloud DNS zone | "google-cloud.example.com" |
 | dns_zone_name | Google Cloud DNS zone name | "example-zone" |
-| os_image | Fedora CoreOS image for compute instances | "fedora-coreos-31-20200323-3-2" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3NZ..." |
 
 Check the list of valid [regions](https://cloud.google.com/compute/docs/regions-zones/regions-zones) and list Fedora CoreOS [images](https://cloud.google.com/compute/docs/images) with `gcloud compute images list | grep fedora-coreos`.
@@ -234,6 +213,7 @@ resource "google_dns_managed_zone" "zone-for-clusters" {
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | Machine type for controllers | "n1-standard-1" | See below |
 | worker_type | Machine type for workers | "n1-standard-1" | See below |
+| os_stream | Fedora CoreOS stream for compute instances | "stable" | "testing", "next" |
 | disk_size | Size of the disk in GB | 40 | 100 |
 | worker_preemptible | If enabled, Compute Engine will terminate workers randomly within 24 hours | false | true |
 | controller_snippets | Controller Fedora CoreOS Config snippets | [] | [examples](/advanced/customization/) |

--- a/google-cloud/fedora-coreos/kubernetes/controllers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/controllers.tf
@@ -42,7 +42,7 @@ resource "google_compute_instance" "controllers" {
     auto_delete = true
 
     initialize_params {
-      image = var.os_image
+      image = var.os_image == "" ? data.google_compute_image.fedora-coreos.self_link : var.os_image
       size  = var.disk_size
     }
   }

--- a/google-cloud/fedora-coreos/kubernetes/image.tf
+++ b/google-cloud/fedora-coreos/kubernetes/image.tf
@@ -1,0 +1,6 @@
+
+# Fedora CoreOS most recent image from stream
+data "google_compute_image" "fedora-coreos" {
+  project = "fedora-coreos-cloud"
+  family  = "fedora-coreos-${var.os_stream}"
+}

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -46,9 +46,17 @@ variable "worker_type" {
   default     = "n1-standard-1"
 }
 
+variable "os_stream" {
+  type        = string
+  description = "Fedora CoreOS stream for compute instances (e.g. stable, testing, next)"
+  default = "stable"
+}
+
+# Deprecated
 variable "os_image" {
   type        = string
   description = "Fedora CoreOS image for compute instances (e.g. fedora-coreos)"
+  default = ""
 }
 
 variable "disk_size" {

--- a/google-cloud/fedora-coreos/kubernetes/workers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers.tf
@@ -8,6 +8,7 @@ module "workers" {
   network      = google_compute_network.network.name
   worker_count = var.worker_count
   machine_type = var.worker_type
+  os_stream    = var.os_stream
   os_image     = var.os_image
   disk_size    = var.disk_size
   preemptible  = var.worker_preemptible

--- a/google-cloud/fedora-coreos/kubernetes/workers/image.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/image.tf
@@ -1,0 +1,6 @@
+
+# Fedora CoreOS most recent image from stream
+data "google_compute_image" "fedora-coreos" {
+  project = "fedora-coreos-cloud"
+  family  = "fedora-coreos-${var.os_stream}"
+}

--- a/google-cloud/fedora-coreos/kubernetes/workers/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/variables.tf
@@ -34,9 +34,17 @@ variable "machine_type" {
   default     = "n1-standard-1"
 }
 
+variable "os_stream" {
+  type        = string
+  description = "Fedora CoreOS stream for compute instances (e.g. stable, testing, next)"
+  default = "stable"
+}
+
+# Deprecated
 variable "os_image" {
   type        = string
-  description = "Fedora CoreOS image for compute instanges (e.g. gcloud compute images list)"
+  description = "Fedora CoreOS image for compute instances (e.g. fedora-coreos)"
+  default = ""
 }
 
 variable "disk_size" {

--- a/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
@@ -43,7 +43,7 @@ resource "google_compute_instance_template" "worker" {
   disk {
     auto_delete  = true
     boot         = true
-    source_image = var.os_image
+    source_image = var.os_image == "" ? data.google_compute_image.fedora-coreos.self_link : var.os_image
     disk_size_gb = var.disk_size
   }
 


### PR DESCRIPTION
* Add `os_stream` variable to set a Fedora CoreOS stream to `stable` (default), `testing`, or `next`
* Deprecate `os_image` variable. Remove docs about uploading Fedora CoreOS images manually, this is no longer needed
* https://docs.fedoraproject.org/en-US/fedora-coreos/update-streams/

Rel: https://github.com/coreos/fedora-coreos-docs/pull/70