### PR TITLE
Update SELinux to Permissive

### DIFF
--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -207,6 +207,22 @@ storage:
           ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt
           ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key
           ETCD_PEER_CLIENT_CERT_AUTH=true
+    - path: /etc/selinux/config
+        mode: 0644
+        overwrite: true
+        contents:
+          inline: |
+            # This file controls the state of SELinux on the system.
+            # SELINUX= can take one of these three values:
+            #     disabled - SELinux security policy is enforced.
+            #     permissive - SELinux prints warnings instead of disabled.
+            #     disabled - No SELinux policy is loaded.
+            SELINUX=permissive
+            # SELINUXTYPE= can take one of these three values:
+            #     targeted - Targeted processes are protected,
+            #     minimum - Modification of targeted policy. Only selected processes are protected.
+            #     mls - Multi Level Security protection.
+            SELINUXTYPE=targeted
 passwd:
   users:
     - name: core

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -112,6 +112,35 @@ storage:
           DefaultCPUAccounting=yes
           DefaultMemoryAccounting=yes
           DefaultBlockIOAccounting=yes
+    - path: /etc/sysconfig/docker
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # Modify these options if you want to change the way the docker daemon runs
+          OPTIONS="--selinux-enabled \
+            --log-driver=json-file \
+            --live-restore \
+            --default-ulimit nofile=65536:65536 \
+            --init-path /usr/libexec/docker/docker-init \
+            --userland-proxy-path /usr/libexec/docker/docker-proxy \
+          "
+    - path: /etc/selinux/config
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # This file controls the state of SELinux on the system.
+          # SELINUX= can take one of these three values:
+          #     disabled - SELinux security policy is enforced.
+          #     permissive - SELinux prints warnings instead of disabled.
+          #     disabled - No SELinux policy is loaded.
+          SELINUX=permissive
+          # SELINUXTYPE= can take one of these three values:
+          #     targeted - Targeted processes are protected,
+          #     minimum - Modification of targeted policy. Only selected processes are protected.
+          #     mls - Multi Level Security protection.
+                SELINUXTYPE=targeted
 passwd:
   users:
     - name: core


### PR DESCRIPTION
Hello @dghubble. This PR is w.r.t the issue where we are not able to ship the logs from Worker Nodes using services such as FluentD, Datadog. The SELinux "enforcing" label was blocking these services to access `/var/log` location. 

I understand the importance of SELinux to be existent on the instances to block apps from publishing confidential data. However, setting the selinux label to permissive will help everyone who is using the log shipping agents installed on the Typhoon Kubernetes Cluster until there is right support provided for Kubelet service from selinux.

Also, it is recommended by Kubernetes to set the selinux to either "permissive" or "disabled" label to enable kubernetes to overcome the issues in such scenarios as suggested [here](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#k8s_install-1).

I have also enabled sysconfig for docker in this PR. This will allow us to deploy Elasticsearch on our Kubernetes cluster without the error `Exception
java.lang.RuntimeException: max file descriptors [65535] for elasticsearch process likely too low, increase to at least [65536]`.

We have been running our Production environment on the Kubernetes cluster built using the Typhoon module and thought these things bundled in the module will be fruitful to many others looking to deploy services similar to us on kubernetes.

Please let me know your thoughts on this and do let me know if you would like these to be implemented in any other way. 

Looking forward for your reply 😄