### PR TITLE
Use new Azure subnet to set address_prefixes list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,12 @@ Notable changes between versions.
 * Fix Terraform plan error when `controller_count` exceeds AWS zones (e.g. 5 controllers) ([#714](https://github.com/poseidon/typhoon/pull/714))
   * Regressed in v1.17.1 ([#605](https://github.com/poseidon/typhoon/pull/605))
 
+### Azure
+
+* Update Azure subnets to set `address_prefixes` list ([#730](https://github.com/poseidon/typhoon/pull/730))
+  * Fix warning that `address_prefix` is deprecated
+  * Require `terraform-provider-azurerm` v2.8.0+ (action required)
+
 ### Fedora CoreOS
 
 * Fix Calico `install-cni` crashloop on Pod restarts ([#724](https://github.com/poseidon/typhoon/pull/724))

--- a/azure/container-linux/kubernetes/controllers.tf
+++ b/azure/container-linux/kubernetes/controllers.tf
@@ -66,9 +66,9 @@ resource "azurerm_linux_virtual_machine" "controllers" {
     for_each = local.flavor == "flatcar" ? [1] : []
 
     content {
-      name = local.channel
+      name      = local.channel
       publisher = "kinvolk"
-      product = "flatcar-container-linux-free"
+      product   = "flatcar-container-linux-free"
     }
   }
 

--- a/azure/container-linux/kubernetes/network.tf
+++ b/azure/container-linux/kubernetes/network.tf
@@ -21,7 +21,7 @@ resource "azurerm_subnet" "controller" {
 
   name                 = "controller"
   virtual_network_name = azurerm_virtual_network.network.name
-  address_prefix       = cidrsubnet(var.host_cidr, 1, 0)
+  address_prefixes     = [cidrsubnet(var.host_cidr, 1, 0)]
 }
 
 resource "azurerm_subnet_network_security_group_association" "controller" {
@@ -34,7 +34,7 @@ resource "azurerm_subnet" "worker" {
 
   name                 = "worker"
   virtual_network_name = azurerm_virtual_network.network.name
-  address_prefix       = cidrsubnet(var.host_cidr, 1, 1)
+  address_prefixes     = [cidrsubnet(var.host_cidr, 1, 1)]
 }
 
 resource "azurerm_subnet_network_security_group_association" "worker" {

--- a/azure/container-linux/kubernetes/versions.tf
+++ b/azure/container-linux/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    azurerm  = "~> 2.0"
+    azurerm  = "~> 2.8"
     ct       = "~> 0.3"
     template = "~> 2.1"
     null     = "~> 2.1"

--- a/azure/container-linux/kubernetes/workers/workers.tf
+++ b/azure/container-linux/kubernetes/workers/workers.tf
@@ -37,9 +37,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
     for_each = local.flavor == "flatcar" ? [1] : []
 
     content {
-      name = local.channel
+      name      = local.channel
       publisher = "kinvolk"
-      product = "flatcar-container-linux-free"
+      product   = "flatcar-container-linux-free"
     }
   }
 

--- a/azure/fedora-coreos/kubernetes/network.tf
+++ b/azure/fedora-coreos/kubernetes/network.tf
@@ -21,7 +21,7 @@ resource "azurerm_subnet" "controller" {
 
   name                 = "controller"
   virtual_network_name = azurerm_virtual_network.network.name
-  address_prefix       = cidrsubnet(var.host_cidr, 1, 0)
+  address_prefixes     = [cidrsubnet(var.host_cidr, 1, 0)]
 }
 
 resource "azurerm_subnet_network_security_group_association" "controller" {
@@ -34,7 +34,7 @@ resource "azurerm_subnet" "worker" {
 
   name                 = "worker"
   virtual_network_name = azurerm_virtual_network.network.name
-  address_prefix       = cidrsubnet(var.host_cidr, 1, 1)
+  address_prefixes     = [cidrsubnet(var.host_cidr, 1, 1)]
 }
 
 resource "azurerm_subnet_network_security_group_association" "worker" {

--- a/azure/fedora-coreos/kubernetes/versions.tf
+++ b/azure/fedora-coreos/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    azurerm  = "~> 2.0"
+    azurerm  = "~> 2.8"
     ct       = "~> 0.3"
     template = "~> 2.1"
     null     = "~> 2.1"


### PR DESCRIPTION
* Update Azure subnet `address_prefix` to `azure_prefixes` list
* Fix warning that `address_prefix` is deprecated
* Require `terraform-provider-azurerm` v2.8.0+ (action required)

Rel: https://github.com/terraform-providers/terraform-provider-azurerm/pull/6493