### PR TITLE
Update Grafana from v7.0.0-beta2 to v7.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,7 +53,7 @@ Notable changes between versions.
 * Update Prometheus from v2.17.1 to v2.18.1
   * Update kube-state-metrics from v1.9.5 to [v1.9.6](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.6)
   * Update node-exporter from v1.0.0-rc.0 to [v1.0.0-rc.1](https://github.com/prometheus/node_exporter/releases/tag/v1.0.0-rc.1)
-* Update Grafana from v6.7.2 to v7.0.0
+* Update Grafana from v6.7.2 to [v7.0.0](https://grafana.com/docs/grafana/latest/guides/whats-new-in-v7-0/)
 
 ## v1.18.2
 

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: docker.io/grafana/grafana:7.0.0-beta3
+          image: docker.io/grafana/grafana:7.0.0
           env:
             - name: GF_PATHS_CONFIG
               value: "/etc/grafana/custom.ini"


### PR DESCRIPTION
* https://grafana.com/docs/grafana/latest/guides/whats-new-in-v7-0/

Note: We found v7.0.0-beta3 to be broken, v7.0.0-beta2 was what was actually used in our environment.