### PR TITLE
Update Prometheus from v2.18.1 to v2.19.0-rc.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Notable changes between versions.
 
 ### Addons
 
+* Update Prometheus from v2.18.1 to [v2.19.0-rc.0](https://github.com/prometheus/prometheus/releases/tag/v2.19.0-rc.0)
 * Update node-exporter from v1.0.0-rc.1 to [v1.0.0](https://github.com/prometheus/node_exporter/releases/tag/v1.0.0)
 * Update kube-state-metrics from v1.9.6 to v1.9.7
 * Update Grafana from v7.0.0 to v7.0.3

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: quay.io/prometheus/prometheus:v2.18.1
+          image: quay.io/prometheus/prometheus:v2.19.0-rc.0
           args:
             - --web.listen-address=0.0.0.0:9090
             - --config.file=/etc/prometheus/prometheus.yaml


### PR DESCRIPTION
* https://github.com/prometheus/prometheus/releases/tag/v2.19.0-rc.0