### PR TITLE
Fix Fedora CoreOS docs for selecting a stream

### DIFF
--- a/docs/fedora-coreos/aws.md
+++ b/docs/fedora-coreos/aws.md
@@ -208,7 +208,7 @@ Reference the DNS zone id with `aws_route53_zone.zone-for-clusters.zone_id`.
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | EC2 instance type for controllers | "t3.small" | See below |
 | worker_type | EC2 instance type for workers | "t3.small" | See below |
-| os_image | AMI channel for Fedora CoreOS | not yet used | ? |
+| os_stream | Fedora CoreOS stream for compute instances | "stable" | "testing", "next" |
 | disk_size | Size of the EBS volume in GB | 40 | 100 |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |


### PR DESCRIPTION
* Fedora CoreOS image `os_stream` stable, testing, and next have been configurable since v1.18.3
* Remove mention of outdated `os_image` variable

Related: https://communityblog.fedoraproject.org/contribute-at-the-fedora-coreos-test-day/