### PR TITLE
Update node-exporter from v1.0.0 to v1.0.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@ Notable changes between versions.
 ### Addons
 
 * Update Prometheus from v2.18.1 to [v2.19.0](https://github.com/prometheus/prometheus/releases/tag/v2.19.0)
-* Update node-exporter from v1.0.0-rc.1 to [v1.0.0](https://github.com/prometheus/node_exporter/releases/tag/v1.0.0)
+* Update node-exporter from v1.0.0-rc.1 to [v1.0.1](https://github.com/prometheus/node_exporter/releases/tag/v1.0.1)
 * Update kube-state-metrics from v1.9.6 to v1.9.7
 * Update Grafana from v7.0.0 to v7.0.3
 

--- a/addons/prometheus/exporters/node-exporter/daemonset.yaml
+++ b/addons/prometheus/exporters/node-exporter/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       hostPID: true
       containers:
       - name: node-exporter
-        image: quay.io/prometheus/node-exporter:v1.0.0
+        image: quay.io/prometheus/node-exporter:v1.0.1
         args:
           - --path.procfs=/host/proc
           - --path.sysfs=/host/sys


### PR DESCRIPTION
* https://github.com/prometheus/node_exporter/releases/tag/v1.0.1