### PR TITLE
Reduce Calcio MTU on Fedora CoreOS Azure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Notable changes between versions.
 #### Azure
 
 * Use `strict` Fedora CoreOS Config (FCC) snippet parsing ([#755](https://github.com/poseidon/typhoon/pull/755))
+* Reduce Calico vxlan interface MTU to maintain performance ([#767](https://github.com/poseidon/typhoon/pull/766))
 
 #### AWS
 

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -10,8 +10,9 @@ module "bootstrap" {
   networking = var.networking
 
   # only effective with Calico networking
+  # we should be able to use 1450 MTU, but in practice, 1410 was needed
   network_encapsulation = "vxlan"
-  network_mtu           = "1450"
+  network_mtu           = "1410"
 
   pod_cidr              = var.pod_cidr
   service_cidr          = var.service_cidr


### PR DESCRIPTION
* Change the Calico VXLAN interface for MTU from 1450 to 1410
* VXLAN on Azure should support MTU 1450. However, there is history where performance measures have shown that 1410 is needed to have expected performance. Flatcar Linux has the same MTU 1410 override and note
* FCOS 31.20200323.3.2 was known to perform fine with 1450, but now in 31.20200517.3.0 the right value seems to be 1410