### PR TITLE
Revert "Update Prometheus from v2.19.1 to v2.19.2"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Notable changes between versions.
 
 #### Addons
 
-* Update Prometheus from v2.19.0 to [v2.19.2](https://github.com/prometheus/prometheus/releases/tag/v2.19.2)
+* Update Prometheus from v2.19.0 to [v2.19.1](https://github.com/prometheus/prometheus/releases/tag/v2.19.1)
 * Update Grafana from v7.0.3 to [v7.0.4](https://github.com/grafana/grafana/releases/tag/v7.0.4)
 
 ## v1.18.4

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: quay.io/prometheus/prometheus:v2.19.2
+          image: quay.io/prometheus/prometheus:v2.19.1
           args:
             - --web.listen-address=0.0.0.0:9090
             - --config.file=/etc/prometheus/prometheus.yaml


### PR DESCRIPTION
* Prometheus has not published the v1.19.2 image
* This reverts commit 81b6f54169119702c3cc6a3ecabca77f8646b444.
