### PR TITLE
Isolate each DigitalOcean cluster in its own VPC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,13 @@ Notable changes between versions.
   * Set `networking` to "cilium" to enable
 * Update Calico from v3.14.1 to [v3.15.0](https://docs.projectcalico.org/v3.15/release-notes/)
 
+#### DigitalOcean
+
+* Isolate each cluster in an independent DigitalOcean VPC ([#776](https://github.com/poseidon/typhoon/pull/776))
+  * Create droplets in a VPC per cluster (matches Typhoon AWS, Azure, and GCP)
+  * Require `terraform-provider-digitalocean` v1.16.0+ (action required)
+  * Output `vpc_id` for use with an attached DigitalOcean [loadbalancer](https://github.com/poseidon/typhoon/blob/v1.18.5/docs/architecture/digitalocean.md#custom-load-balancer)
+
 #### Addons
 
 * Update Prometheus from v2.19.0 to [v2.19.1](https://github.com/prometheus/prometheus/releases/tag/v2.19.1)

--- a/digital-ocean/container-linux/kubernetes/controllers.tf
+++ b/digital-ocean/container-linux/kubernetes/controllers.tf
@@ -46,9 +46,10 @@ resource "digitalocean_droplet" "controllers" {
   size  = var.controller_type
 
   # network
-  # only official DigitalOcean images support IPv6
-  ipv6               = local.is_official_image
   private_networking = true
+  vpc_uuid           = digitalocean_vpc.network.id
+  # TODO: Only official DigitalOcean images support IPv6
+  ipv6 = false
 
   user_data = data.ct_config.controller-ignitions.*.rendered[count.index]
   ssh_keys  = var.ssh_fingerprints

--- a/digital-ocean/container-linux/kubernetes/network.tf
+++ b/digital-ocean/container-linux/kubernetes/network.tf
@@ -1,3 +1,10 @@
+# Network VPC
+resource "digitalocean_vpc" "network" {
+  name        = var.cluster_name
+  region      = var.region
+  description = "Network for ${var.cluster_name} cluster"
+}
+
 resource "digitalocean_firewall" "rules" {
   name = var.cluster_name
 

--- a/digital-ocean/container-linux/kubernetes/outputs.tf
+++ b/digital-ocean/container-linux/kubernetes/outputs.tf
@@ -2,6 +2,8 @@ output "kubeconfig-admin" {
   value = module.bootstrap.kubeconfig-admin
 }
 
+# Outputs for Kubernetes Ingress
+
 output "controllers_dns" {
   value = digitalocean_record.controllers[0].fqdn
 }
@@ -43,5 +45,12 @@ output "controller_tag" {
 output "worker_tag" {
   description = "Tag applied to worker droplets"
   value       = digitalocean_tag.workers.name
+}
+
+# Outputs for custom load balancing
+
+output "vpc_id" {
+  description = "ID of the cluster VPC"
+  value       = digitalocean_vpc.network.id
 }
 

--- a/digital-ocean/container-linux/kubernetes/versions.tf
+++ b/digital-ocean/container-linux/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    digitalocean = "~> 1.3"
+    digitalocean = "~> 1.16"
     ct           = "~> 0.4"
     template     = "~> 2.1"
     null         = "~> 2.1"

--- a/digital-ocean/container-linux/kubernetes/workers.tf
+++ b/digital-ocean/container-linux/kubernetes/workers.tf
@@ -35,9 +35,10 @@ resource "digitalocean_droplet" "workers" {
   size  = var.worker_type
 
   # network
-  # only official DigitalOcean images support IPv6
-  ipv6               = local.is_official_image
   private_networking = true
+  vpc_uuid           = digitalocean_vpc.network.id
+  # only official DigitalOcean images support IPv6
+  ipv6 = local.is_official_image
 
   user_data = data.ct_config.worker-ignition.rendered
   ssh_keys  = var.ssh_fingerprints

--- a/digital-ocean/fedora-coreos/kubernetes/controllers.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/controllers.tf
@@ -41,9 +41,10 @@ resource "digitalocean_droplet" "controllers" {
   size  = var.controller_type
 
   # network
-  # TODO: Only official DigitalOcean images support IPv6
-  ipv6               = false
   private_networking = true
+  vpc_uuid           = digitalocean_vpc.network.id
+  # TODO: Only official DigitalOcean images support IPv6
+  ipv6 = false
 
   user_data = data.ct_config.controller-ignitions.*.rendered[count.index]
   ssh_keys  = var.ssh_fingerprints

--- a/digital-ocean/fedora-coreos/kubernetes/network.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/network.tf
@@ -1,3 +1,10 @@
+# Network VPC
+resource "digitalocean_vpc" "network" {
+  name        = var.cluster_name
+  region      = var.region
+  description = "Network for ${var.cluster_name} cluster"
+}
+
 resource "digitalocean_firewall" "rules" {
   name = var.cluster_name
 

--- a/digital-ocean/fedora-coreos/kubernetes/outputs.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/outputs.tf
@@ -2,6 +2,8 @@ output "kubeconfig-admin" {
   value = module.bootstrap.kubeconfig-admin
 }
 
+# Outputs for Kubernetes Ingress
+
 output "controllers_dns" {
   value = digitalocean_record.controllers[0].fqdn
 }
@@ -45,3 +47,9 @@ output "worker_tag" {
   value       = digitalocean_tag.workers.name
 }
 
+# Outputs for custom load balancing
+
+output "vpc_id" {
+  description = "ID of the cluster VPC"
+  value       = digitalocean_vpc.network.id
+}

--- a/digital-ocean/fedora-coreos/kubernetes/versions.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    digitalocean = "~> 1.3"
+    digitalocean = "~> 1.16"
     ct           = "~> 0.4"
     template     = "~> 2.1"
     null         = "~> 2.1"

--- a/digital-ocean/fedora-coreos/kubernetes/workers.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/workers.tf
@@ -37,9 +37,10 @@ resource "digitalocean_droplet" "workers" {
   size  = var.worker_type
 
   # network
-  # TODO: Only official DigitalOcean images support IPv6
-  ipv6               = false
   private_networking = true
+  vpc_uuid           = digitalocean_vpc.network.id
+  # TODO: Only official DigitalOcean images support IPv6
+  ipv6 = false
 
   user_data = data.ct_config.worker-ignition.rendered
   ssh_keys  = var.ssh_fingerprints

--- a/docs/architecture/digitalocean.md
+++ b/docs/architecture/digitalocean.md
@@ -30,6 +30,7 @@ Add a DigitalOcean load balancer to distribute IPv4 TCP traffic (HTTP/HTTPS Ingr
 resource "digitalocean_loadbalancer" "ingress" {
   name        = "ingress"
   region      = "fra1"
+  vpc_uuid    = module.nemo.vpc_id
   droplet_tag = module.nemo.worker_tag
 
   healthcheck {


### PR DESCRIPTION
* DigitalOcean introduced Virtual Private Cloud (VPC) support to match other clouds and enhance the prior "private networking"
feature. Before, droplet's belonging to different clusters (but residing in the same region) could reach one another (although
Typhoon firewall rules prohibit this). Now, droplets in a VPC reside in their own network
* https://www.digitalocean.com/docs/networking/vpc/
* Create droplet instances in a VPC per cluster. This matches the design of Typhoon AWS, Azure, and GCP
* Require `terraform-provider-digitalocean` v1.16.0+ (action required)
* Output `vpc_id` for use with an attached DigitalOcean loadbalancer