### PR TITLE
Remove os_image variable on Google Cloud Fedora CoreOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,13 @@ Notable changes between versions.
   * Require `terraform-provider-digitalocean` v1.16.0+ (action required)
   * Output `vpc_id` for use with an attached DigitalOcean [loadbalancer](https://github.com/poseidon/typhoon/blob/v1.18.5/docs/architecture/digitalocean.md#custom-load-balancer)
 
+### Fedora CoreOS
+
+#### Google
+
+* Remove `os_image` variable (deprecated in v1.18.3)
+  * Use `os_stream` to select a Fedora CoreOS image stream
+
 #### Addons
 
 * Update Prometheus from v2.19.0 to [v2.19.1](https://github.com/prometheus/prometheus/releases/tag/v2.19.1)
@@ -105,7 +112,7 @@ Notable changes between versions.
 
 #### Google
 
-* Support Fedora CoreOS [image streams](https://docs.fedoraproject.org/en-US/fedora-coreos/update-streams/) ([#723](https://github.com/poseidon/typhoon/pull/722))
+* Support Fedora CoreOS [image streams](https://docs.fedoraproject.org/en-US/fedora-coreos/update-streams/) ([#723](https://github.com/poseidon/typhoon/pull/723))
   * Add `os_stream` variable to set the stream to `stable` (default), `testing`, or `next`
   * Deprecate `os_image` variable. Manual image uploads are no longer needed
 

--- a/google-cloud/fedora-coreos/kubernetes/controllers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/controllers.tf
@@ -42,7 +42,7 @@ resource "google_compute_instance" "controllers" {
     auto_delete = true
 
     initialize_params {
-      image = var.os_image == "" ? data.google_compute_image.fedora-coreos.self_link : var.os_image
+      image = data.google_compute_image.fedora-coreos.self_link
       size  = var.disk_size
     }
   }

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -52,13 +52,6 @@ variable "os_stream" {
   default     = "stable"
 }
 
-# Deprecated
-variable "os_image" {
-  type        = string
-  description = "Fedora CoreOS image for compute instances (e.g. fedora-coreos)"
-  default     = ""
-}
-
 variable "disk_size" {
   type        = number
   description = "Size of the disk in GB"

--- a/google-cloud/fedora-coreos/kubernetes/workers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers.tf
@@ -9,7 +9,6 @@ module "workers" {
   worker_count = var.worker_count
   machine_type = var.worker_type
   os_stream    = var.os_stream
-  os_image     = var.os_image
   disk_size    = var.disk_size
   preemptible  = var.worker_preemptible
 

--- a/google-cloud/fedora-coreos/kubernetes/workers/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/variables.tf
@@ -40,13 +40,6 @@ variable "os_stream" {
   default     = "stable"
 }
 
-# Deprecated
-variable "os_image" {
-  type        = string
-  description = "Fedora CoreOS image for compute instances (e.g. fedora-coreos)"
-  default     = ""
-}
-
 variable "disk_size" {
   type        = number
   description = "Size of the disk in GB"

--- a/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
@@ -43,7 +43,7 @@ resource "google_compute_instance_template" "worker" {
   disk {
     auto_delete  = true
     boot         = true
-    source_image = var.os_image == "" ? data.google_compute_image.fedora-coreos.self_link : var.os_image
+    source_image = data.google_compute_image.fedora-coreos.self_link
     disk_size_gb = var.disk_size
   }
 


### PR DESCRIPTION
* In v1.18.3, the `os_stream` variable was added to select a Fedora CoreOS image stream (stable, testing, next) on AWS and Google Cloud (which publish official streams)
* Remove `os_image` variable deprecated in v1.18.3. Manually uploaded images are no longer needed
