### PR TITLE
Add default tags for AWS resources

### DIFF
--- a/aws/container-linux/kubernetes/controllers.tf
+++ b/aws/container-linux/kubernetes/controllers.tf
@@ -17,9 +17,9 @@ resource "aws_route53_record" "etcds" {
 resource "aws_instance" "controllers" {
   count = var.controller_count
 
-  tags = {
+  tags = merge(var.default_tags, {
     Name = "${var.cluster_name}-controller-${count.index}"
-  }
+  })
 
   instance_type = var.controller_type
 

--- a/aws/container-linux/kubernetes/network.tf
+++ b/aws/container-linux/kubernetes/network.tf
@@ -9,25 +9,25 @@ resource "aws_vpc" "network" {
   enable_dns_support               = true
   enable_dns_hostnames             = true
 
-  tags = {
+  tags = merge(var.default_tags, {
     "Name" = var.cluster_name
-  }
+  })
 }
 
 resource "aws_internet_gateway" "gateway" {
   vpc_id = aws_vpc.network.id
 
-  tags = {
+  tags = merge(var.default_tags, {
     "Name" = var.cluster_name
-  }
+  })
 }
 
 resource "aws_route_table" "default" {
   vpc_id = aws_vpc.network.id
 
-  tags = {
+  tags = merge(var.default_tags, {
     "Name" = var.cluster_name
-  }
+  })
 }
 
 resource "aws_route" "egress-ipv4" {
@@ -55,9 +55,9 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch         = true
   assign_ipv6_address_on_creation = true
 
-  tags = {
+  tags = merge(var.default_tags, {
     "Name" = "${var.cluster_name}-public-${count.index}"
-  }
+  })
 }
 
 resource "aws_route_table_association" "public" {

--- a/aws/container-linux/kubernetes/nlb.tf
+++ b/aws/container-linux/kubernetes/nlb.tf
@@ -22,6 +22,10 @@ resource "aws_lb" "nlb" {
   subnets = aws_subnet.public.*.id
 
   enable_cross_zone_load_balancing = true
+
+  tags = merge(var.default_tags, {
+    Name = "${var.cluster_name}-nlb"
+  })
 }
 
 # Forward TCP apiserver traffic to controllers
@@ -81,6 +85,8 @@ resource "aws_lb_target_group" "controllers" {
     # Interval between health checks required to be 10 or 30
     interval = 10
   }
+
+  tags = var.default_tags
 }
 
 # Attach controller instances to apiserver NLB

--- a/aws/container-linux/kubernetes/security.tf
+++ b/aws/container-linux/kubernetes/security.tf
@@ -8,9 +8,9 @@ resource "aws_security_group" "controller" {
 
   vpc_id = aws_vpc.network.id
 
-  tags = {
+  tags = merge(var.default_tags, {
     "Name" = "${var.cluster_name}-controller"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "controller-icmp" {
@@ -296,9 +296,9 @@ resource "aws_security_group" "worker" {
 
   vpc_id = aws_vpc.network.id
 
-  tags = {
+  tags = merge(var.default_tags, {
     "Name" = "${var.cluster_name}-worker"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "worker-icmp" {

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -4,9 +4,9 @@ variable "cluster_name" {
 }
 
 variable "default_tags" {
-  type = list(string)
+  type = map(string)
   description = "list of default AWS resources tags"
-  default = []
+  default = {}
 }
 
 # AWS

--- a/aws/container-linux/kubernetes/variables.tf
+++ b/aws/container-linux/kubernetes/variables.tf
@@ -3,6 +3,12 @@ variable "cluster_name" {
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
+variable "default_tags" {
+  type = list(string)
+  description = "list of default AWS resources tags"
+  default = []
+}
+
 # AWS
 
 variable "dns_zone" {

--- a/aws/container-linux/kubernetes/workers.tf
+++ b/aws/container-linux/kubernetes/workers.tf
@@ -20,5 +20,6 @@ module "workers" {
   cluster_domain_suffix = var.cluster_domain_suffix
   snippets              = var.worker_snippets
   node_labels           = var.worker_node_labels
+  default_tags          = var.default_tags
 }
 

--- a/aws/container-linux/kubernetes/workers/ingress.tf
+++ b/aws/container-linux/kubernetes/workers/ingress.tf
@@ -21,6 +21,8 @@ resource "aws_lb_target_group" "workers-http" {
     # Interval between health checks required to be 10 or 30
     interval = 10
   }
+
+  tags = var.default_tags
 }
 
 resource "aws_lb_target_group" "workers-https" {
@@ -44,5 +46,7 @@ resource "aws_lb_target_group" "workers-https" {
     # Interval between health checks required to be 10 or 30
     interval = 10
   }
+
+  tags = var.default_tags
 }
 

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   description = "Unique name for the worker pool"
 }
 
+variable "default_tags" {
+  type        = list(string)
+  description = "list of default AWS resources tags"
+  default     = []
+}
+
 # AWS
 
 variable "vpc_id" {

--- a/aws/container-linux/kubernetes/workers/variables.tf
+++ b/aws/container-linux/kubernetes/workers/variables.tf
@@ -4,9 +4,9 @@ variable "name" {
 }
 
 variable "default_tags" {
-  type        = list(string)
+  type        = map(string)
   description = "list of default AWS resources tags"
-  default     = []
+  default     = {}
 }
 
 # AWS

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -33,13 +33,13 @@ resource "aws_autoscaling_group" "workers" {
   # used. Disable wait to avoid issues and align with other clouds.
   wait_for_capacity_timeout = "0"
 
-  tags = [
+  tags = merge(var.default_tags, [
     {
       key                 = "Name"
       value               = "${var.name}-worker"
       propagate_at_launch = true
     },
-  ]
+  ])
 }
 
 # Worker template

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -1,4 +1,5 @@
 # Workers AutoScaling Group
+
 resource "aws_autoscaling_group" "workers" {
   name = "${var.name}-worker ${aws_launch_configuration.worker.name}"
 
@@ -33,13 +34,21 @@ resource "aws_autoscaling_group" "workers" {
   # used. Disable wait to avoid issues and align with other clouds.
   wait_for_capacity_timeout = "0"
 
-  tags = merge(var.default_tags, [
-    {
-      key                 = "Name"
-      value               = "${var.name}-worker"
+  tag {
+    key                 = "Name"
+    value               = "${var.name}-worker"
+    propagate_at_launch = ture
+  }
+
+  dynamic "tag" {
+    for_each = var.default_tags
+
+    content {
+      key                 = tag.key
+      value               = tag.values
       propagate_at_launch = true
-    },
-  ])
+    }
+  }
 }
 
 # Worker template

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -45,7 +45,7 @@ resource "aws_autoscaling_group" "workers" {
 
     content {
       key                 = tag.key
-      value               = tag.values
+      value               = tag.value
       propagate_at_launch = true
     }
   }

--- a/aws/container-linux/kubernetes/workers/workers.tf
+++ b/aws/container-linux/kubernetes/workers/workers.tf
@@ -37,7 +37,7 @@ resource "aws_autoscaling_group" "workers" {
   tag {
     key                 = "Name"
     value               = "${var.name}-worker"
-    propagate_at_launch = ture
+    propagate_at_launch = true
   }
 
   dynamic "tag" {


### PR DESCRIPTION
High level description of the change.

* Add possibility to add default tags to all tag aware AWS resources in container linux

It's very useful from AWS perspective - you can use it to estimate costs for example. 

## Testing

Describe your work to validate the change works.
You need to apply it into aws environment with module source part to: typhoon//aws/container-linux/kubernetes
All resources like load balancer, vpc, subnets, machines, target groups, etc should be tagged with tags you provide in `default_tags` parameter of module. 
