### PR TITLE
Relex terraform-provider-matchbox version constraint

### DIFF
--- a/bare-metal/container-linux/kubernetes/versions.tf
+++ b/bare-metal/container-linux/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    matchbox = "~> 0.3.0"
+    matchbox = "~> 0.3"
     ct       = "~> 0.4"
     template = "~> 2.1"
     null     = "~> 2.1"

--- a/bare-metal/fedora-coreos/kubernetes/versions.tf
+++ b/bare-metal/fedora-coreos/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    matchbox = "~> 0.3.0"
+    matchbox = "~> 0.3"
     ct       = "~> 0.4"
     template = "~> 2.1"
     null     = "~> 2.1"


### PR DESCRIPTION
* Allow use of terraform-provider-matchbox v0.3+ (which allows v0.3.0 <= version < v1.0) for any pre 1.0 release
* Before, the requirement was v0.3.0 <= version < v0.4.0

Related: https://github.com/poseidon/terraform-provider-matchbox/releases/tag/v0.4.0