### PR TITLE
Update Grafana from v7.1.1 to v7.1.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,14 +14,14 @@ Notable changes between versions.
 ### Fedora CoreOS
 
 * Fix support for Flannel with Fedora CoreOS ([#795](https://github.com/poseidon/typhoon/pull/795))
-  * Fedora CoreOS fixes to align network interface defaults altered MAC address assignment for
-  the `flannel.1` interface in a way that caused flannel to drop pod-to-pod traffic
-  * Configure flannel interfaces explicitly
+  * Configure `flannel.1` link to select its own MAC address to solve flannel
+  pod-to-pod traffic drops starting with default link changes in Fedora CoreOS
+  32.20200629.3.0 ([details](https://github.com/coreos/fedora-coreos-tracker/issues/574#issuecomment-665487296))
 
 #### Addons
 
 * Update Prometheus from v2.19.2 to [v2.20.0](https://github.com/prometheus/prometheus/releases/tag/v2.20.0)
-* Update Grafana from v7.0.6 to [v7.1.1](https://github.com/grafana/grafana/releases/tag/v7.1.1)
+* Update Grafana from v7.0.6 to [v7.1.3](https://github.com/grafana/grafana/releases/tag/v7.1.3)
 
 ## v1.18.6
 

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: docker.io/grafana/grafana:7.1.1
+          image: docker.io/grafana/grafana:7.1.3
           env:
             - name: GF_PATHS_CONFIG
               value: "/etc/grafana/custom.ini"


### PR DESCRIPTION
* https://github.com/grafana/grafana/releases/tag/v7.1.3
* https://github.com/grafana/grafana/releases/tag/v7.1.2