### PR TITLE
Update Terraform migration guide SHA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,9 @@ Notable changes between versions.
 
 ## Latest
 
-* Migrate from Terraform v0.12.x to v0.13.x (action required)
-  * Recommend Terraform v0.13.x ([migration guide](https://github.com/poseidon/typhoon/blob/260033e978f03d068b79e553e7c428a64b22a475/docs/topics/maintenance.md#terraform-versions))
-    * Support automatic install of poseidon's provider plugins
-    * [poseidon/ct](https://registry.terraform.io/providers/poseidon/ct/latest)
-    * [poseidon/matchbox](https://registry.terraform.io/providers/poseidon/matchbox/latest)
+* Migrate from Terraform v0.12.x to v0.13.x ([#804](https://github.com/poseidon/typhoon/pull/804)) (**action required**)
+  * Recommend Terraform v0.13.x ([migration guide](https://github.com/poseidon/typhoon/blob/5e70d7e2c8c71c37d9a0896a0945188f009011f9/docs/topics/maintenance.md#terraform-versions))
+  * Support automatic install of poseidon's provider plugins ([poseidon/ct](https://registry.terraform.io/providers/poseidon/ct/latest), [poseidon/matchbox](https://registry.terraform.io/providers/poseidon/matchbox/latest))
   * Require Terraform v0.12.26+ (migration compatibility)
   * Require `terraform-provider-ct` v0.6.1
   * Require `terraform-provider-matchbox` v0.4.1
@@ -16,7 +14,7 @@ Notable changes between versions.
 * Update CoreDNS from v1.6.7 to [v1.7.0](https://coredns.io/2020/06/15/coredns-1.7.0-release/)
 * Update Cilium from v1.8.1 to [v1.8.2](https://github.com/cilium/cilium/releases/tag/v1.8.2)
 * Update [coreos/flannel-cni](https://github.com/coreos/flannel-cni) to [poseidon/flannel-cni](https://github.com/poseidon/flannel-cni) ([#798](https://github.com/poseidon/typhoon/pull/798))
-  * Update CNI plugins and fix CVEs with Flannel (non-default)
+  * Update CNI plugins and fix CVEs with Flannel CNI (non-default)
   * Transition to a poseidon maintained container image
 
 ### AWS

--- a/docs/topics/maintenance.md
+++ b/docs/topics/maintenance.md
@@ -211,9 +211,8 @@ Typhoon modules have been updated for v0.13.x, but retain compatibility with v0.
 
 | Typhoon Release   | Terraform version   |
 |-------------------|---------------------|
-| ?                 | v0.13.x             |
-| ?                 | v0.12.26+, v0.13.x  |
-| v1.15.0 - ?       | v0.12.x             |
+| v1.18.7 - ?       | v0.12.26+, v0.13.x  |
+| v1.15.0 - v1.18.6 | v0.12.x             |
 | v1.10.3 - v1.15.0 | v0.11.x             |
 | v1.9.2 - v1.10.2  | v0.10.4+ or v0.11.x |
 | v1.7.3 - v1.9.1   | v0.10.x             |
@@ -235,16 +234,16 @@ provider "ct" {
 }
 ```
 
-Next, create Typhoon clusters using the `ref` that introduced Terraform v0.13 forward compatibility (SHA) or later. You will see a compatibility warning. Use blue/green cluster replacement to shift to these new clusters, then eliminate older clusters.
+Next, create Typhoon clusters using the `ref` that introduced Terraform v0.13 forward compatibility (`5e70d7e2c8c71c37d9a0896a0945188f009011f9`) or later. You will see a compatibility warning. Use blue/green cluster replacement to shift to these new clusters, then eliminate older clusters.
 
 ```
 module "nemo" {
-  source = "git::https://github.com/poseidon/typhoon//digital-ocean/fedora-coreos/kubernetes?ref=SHA"
+  source = "git::https://github.com/poseidon/typhoon//digital-ocean/fedora-coreos/kubernetes?ref=5e70d7e2c8c71c37d9a0896a0945188f009011f9"
   ...
 }
 ```
 
-Install Terraform v0.13. Once all clusters in a workspace are on SHA or above, you are ready to start using Terraform v0.13.
+Install Terraform v0.13. Once all clusters in a workspace are on `5e70d7e2c8c71c37d9a0896a0945188f009011f9` or above, you are ready to start using Terraform v0.13.
 
 ```
 terraform version


### PR DESCRIPTION
* Mention the first master branch SHA that introduced Terraform v0.13 forward compatibility
* Link the migration guide on Github until a release is available and website docs are published