### PR TITLE
Fix SELinux label of bootstrap-secrets on non-bootstrapping controllers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@ Notable changes between versions.
 
 ### Fedora CoreOS
 
+* Fix SELinux label of bootstrap-secrets on non-bootstrapping controllers ([#808](https://github.com/poseidon/typhoon/pull/808))
+
 * Fix support for Flannel with Fedora CoreOS ([#795](https://github.com/poseidon/typhoon/pull/795))
   * Configure `flannel.1` link to select its own MAC address to solve flannel
   pod-to-pod traffic drops starting with default link changes in Fedora CoreOS

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,11 @@ Notable changes between versions.
 
 ## Latest
 
-### v1.18.8
+### Fedora CoreOS
+
+* Fix SELinux label of bootstrap-secrets on non-bootstrapping controllers ([#808](https://github.com/poseidon/typhoon/pull/808))
+
+## v1.18.8
 
 * Kubernetes [v1.18.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#v1188)
 * Migrate from Terraform v0.12.x to v0.13.x ([#804](https://github.com/poseidon/typhoon/pull/804)) (**action required**)
@@ -32,8 +36,6 @@ Notable changes between versions.
 * Require `terraform-provider-digitalocean` v1.20+ for Terraform v0.12.x
 
 ### Fedora CoreOS
-
-* Fix SELinux label of bootstrap-secrets on non-bootstrapping controllers ([#808](https://github.com/poseidon/typhoon/pull/808))
 
 * Fix support for Flannel with Fedora CoreOS ([#795](https://github.com/poseidon/typhoon/pull/795))
   * Configure `flannel.1` link to select its own MAC address to solve flannel

--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -160,7 +160,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
-          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
+          chcon -R -u system_u -t container_file_t /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -160,6 +160,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
+          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/azure/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -159,6 +159,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
+          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/azure/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -159,7 +159,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
-          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
+          chcon -R -u system_u -t container_file_t /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -170,6 +170,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
+          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -170,7 +170,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
-          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
+          chcon -R -u system_u -t container_file_t /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/digital-ocean/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -166,7 +166,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
-          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
+          chcon -R -u system_u -t container_file_t /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/digital-ocean/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -166,6 +166,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
+          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -159,6 +159,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
+          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -159,7 +159,7 @@ storage:
           mv manifests /opt/bootstrap/assets/manifests
           mv manifests-networking/* /opt/bootstrap/assets/manifests/
           rm -rf assets auth static-manifests tls manifests-networking
-          chcon -R -u system_u /etc/kubernetes/bootstrap-secrets
+          chcon -R -u system_u -t container_file_t /etc/kubernetes/bootstrap-secrets
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:


### PR DESCRIPTION
There's already a [merged PR](https://github.com/poseidon/typhoon/pull/708) addressing the same problem on the controller that runs `bootstrap` service. However, on other controllers, Docker pods `kube-apiserver`, `kube-scheduler`, and `kube-controller-manager` still cannot read files from `/etc/kubernetes/bootstrap-secrets` (on host) due to the wrong SELinux file label (specifically `user` field).

On the controller that has run `bootstrap` service:
```
[root@ip-10-20-139-198 ~]$ ls -alZ /etc/kubernetes
total 16
drwxr-xr-x.  5 root root system_u:object_r:container_file_t:s0   91 Aug 18 03:16 .
drwxr-xr-x. 80 root root system_u:object_r:etc_t:s0            4096 Aug 18 03:13 ..
drwxr-xr-x.  2 root root system_u:object_r:container_file_t:s0  220 Aug 18 03:16 bootstrap-secrets
-rw-r--r--.  1 root root system_u:object_r:container_file_t:s0 1147 Aug 18 03:13 ca.crt
drwxr-xr-x.  3 root root system_u:object_r:container_file_t:s0   19 Aug 18 03:12 cni
-rw-r--r--.  1 root root system_u:object_r:container_file_t:s0 1815 Aug 18 03:11 kubeconfig
drwxr-xr-x.  2 root root system_u:object_r:container_file_t:s0   96 Aug 18 03:16 manifests
```

On the controllers that don't run `bootstrap` service:
```
[root@ip-10-20-144-57 scoop-ops]# ls -alZ /etc/kubernetes
total 16
drwxr-xr-x.  5 root root system_u:object_r:container_file_t:s0       91 Aug 18 03:16 .
drwxr-xr-x. 80 root root system_u:object_r:etc_t:s0                4096 Aug 18 03:13 ..
drwxr-xr-x.  2 root root unconfined_u:object_r:container_file_t:s0  220 Aug 18 03:16 bootstrap-secrets
-rw-r--r--.  1 root root system_u:object_r:container_file_t:s0     1147 Aug 18 03:13 ca.crt
drwxr-xr-x.  3 root root system_u:object_r:container_file_t:s0       19 Aug 18 03:13 cni
-rw-r--r--.  1 root root system_u:object_r:container_file_t:s0     1815 Aug 18 03:11 kubeconfig
drwxr-xr-x.  2 root root system_u:object_r:container_file_t:s0       96 Aug 18 03:16 manifests
```

See the difference in `user` field (`system_u` vs `unconfined_u`). This PR updates the user field to `system_u` on all controllers. On `aws/fedora-coreos`, I've verified this fixes all the permission denials on files under `/etc/kubernetes/secrets` (container) from `kube-apiserver`, `kube-scheduler`, and `kube-controller-manager` containers.