### PR TITLE
Remove labelmap relabel_config for Kubernetes node_name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Notable changes between versions.
 * Kubernetes [v1.19.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#v1191)
   * Change control plane seccomp annotations to GA `seccompProfile` ([#822](https://github.com/poseidon/typhoon/pull/822))
 * Update Cilium from v1.8.2 to [v1.8.3](https://github.com/cilium/cilium/releases/tag/v1.8.3)
-  * Promote Cilium from experimental to general availability
+  * Promote Cilium from experimental to general availability ([#827](https://github.com/poseidon/typhoon/pull/827))
 * Update Calico from v1.15.2 to [v1.15.3](https://github.com/projectcalico/calico/releases/tag/v3.15.3)
 
 ### Fedora CoreOS
@@ -19,6 +19,7 @@ Notable changes between versions.
 
 * Update IngressClass resources to `networking.k8s.io/v1` ([#824](https://github.com/poseidon/typhoon/pull/824))
 * Update Prometheus from v2.20.0 to [v2.21.0](https://github.com/prometheus/prometheus/releases/tag/v2.21.0)
+  * Remove Kubernetes node name labelmap `relabel_config` from etcd, Kubelet, and CAdvisor scrape config ([#828](https://github.com/poseidon/typhoon/pull/828))
 
 ## v1.19.0
 

--- a/addons/prometheus/config.yaml
+++ b/addons/prometheus/config.yaml
@@ -34,7 +34,7 @@ data:
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:
       - role: endpoints
-      
+
       scheme: https
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -74,17 +74,13 @@ data:
     - job_name: 'kubelet'
       kubernetes_sd_configs:
       - role: node
-      
+
       scheme: https
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         # Kubelet certs don't have any fixed IP SANs
         insecure_skip_verify: true
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-      relabel_configs:
-      - action: labelmap
-        regex: __meta_kubernetes_node_name
 
     # Scrape config for Kubelet cAdvisor. Explore metrics from a node by
     # scraping kubelet (127.0.0.1:10250/metrics/cadvisor).
@@ -100,9 +96,6 @@ data:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
-      relabel_configs:
-      - action: labelmap
-        regex: __meta_kubernetes_node_name
       metric_relabel_configs:
       - source_labels: [__name__, image]
         action: drop
@@ -121,13 +114,11 @@ data:
       - source_labels: [__meta_kubernetes_node_label_node_kubernetes_io_controller]
         action: keep
         regex: 'true'
-      - action: labelmap
-        regex: __meta_kubernetes_node_name
       - source_labels: [__meta_kubernetes_node_address_InternalIP]
         action: replace
         target_label: __address__
         replacement: '${1}:2381'
-    
+
     # Scrape config for service endpoints.
     #
     # The relabeling allows the actual service scrape endpoint to be configured
@@ -172,7 +163,7 @@ data:
       - source_labels: [__meta_kubernetes_service_name]
         action: replace
         target_label: job
-      
+
       metric_relabel_configs:
       - source_labels: [__name__]
         action: drop


### PR DESCRIPTION
* Originally, Kubelet and CAdvisor metrics used a labelmap relabel to add Kubernetes SD node labels onto timeseries
* With https://github.com/poseidon/typhoon/pull/596 that relabel was dropped since node labels aren't usually that
valuable. `__meta_kubernetes_node_name` was retained but the field name is empty
* Favor just using Prometheus server-side `instance` in queries that require some node identifier for aggregation or debugging

Fix https://github.com/poseidon/typhoon/issues/823