### PR TITLE
Allow for per node install disk in Terraform Installer

### DIFF
--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -130,6 +130,10 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     var.kernel_args,
   ])
 
+  vars = {
+    install_disk = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
+  }
+
   container_linux_config = data.template_file.cached-container-linux-install-configs.*.rendered[count.index]
 }
 

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -130,10 +130,6 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     var.kernel_args,
   ])
 
-  # vars = {
-  #   install_disk = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
-  # }
-
   container_linux_config = data.template_file.cached-container-linux-install-configs.*.rendered[count.index]
 }
 

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -130,9 +130,9 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     var.kernel_args,
   ])
 
-  vars = {
-    install_disk = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
-  }
+  # vars = {
+  #   install_disk = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
+  # }
 
   container_linux_config = data.template_file.cached-container-linux-install-configs.*.rendered[count.index]
 }

--- a/bare-metal/container-linux/kubernetes/profiles.tf
+++ b/bare-metal/container-linux/kubernetes/profiles.tf
@@ -38,7 +38,7 @@ data "template_file" "container-linux-install-configs" {
     os_channel         = local.channel
     os_version         = var.os_version
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
-    install_disk       = var.install_disk
+    install_disk       = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
     ssh_authorized_key = var.ssh_authorized_key
     # only cached-container-linux profile adds -b baseurl
     baseurl_flag = ""
@@ -79,7 +79,7 @@ data "template_file" "cached-container-linux-install-configs" {
     os_channel         = local.channel
     os_version         = var.os_version
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
-    install_disk       = var.install_disk
+    install_disk       = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
     ssh_authorized_key = var.ssh_authorized_key
     # profile uses -b baseurl to install from matchbox cache
     baseurl_flag = "-b ${var.matchbox_http_endpoint}/assets/${local.flavor}"

--- a/bare-metal/container-linux/kubernetes/variables.tf
+++ b/bare-metal/container-linux/kubernetes/variables.tf
@@ -24,27 +24,29 @@ variable "os_version" {
 
 variable "controllers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name           = string
+    mac            = string
+    domain         = string
+    install_disk   = string
   }))
   description = <<EOD
 List of controller machine details (unique name, identifying MAC address, FQDN)
-[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
+[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com", install_disk = "/dev/sda"}]
 EOD
 }
 
 variable "workers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name         = string
+    mac          = string
+    domain       = string
+    install_disk = string
   }))
   description = <<EOD
 List of worker machine details (unique name, identifying MAC address, FQDN)
 [
-  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
-  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
+  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com", install_disk = "/dev/sda"},
+  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com", install_disk = "/dev/sda"}
 ]
 EOD
 }
@@ -124,12 +126,6 @@ variable "cached_install" {
   type        = bool
   description = "Whether Container Linux should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the os_version into matchbox assets."
   default     = false
-}
-
-variable "install_disk" {
-  type        = string
-  default     = "/dev/sda"
-  description = "Disk device to which the install profiles should install Container Linux (e.g. /dev/sda)"
 }
 
 variable "kernel_args" {


### PR DESCRIPTION
I have different disk types on my nodes (nvme disks on one, sda on others).

This change moves the `install_disk` parameter from a global variable into the node specific list.


## Testing

Deployed with my own cluster.
