### PR TITLE
Update kube-state-metrics from v2.0.0-alpha.1 to v2.0.0-alpha.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Notable changes between versions.
 
 ### Addons
 
+* Update kube-state-metrics from v2.0.0-alpha.1 to [v2.0.0-alpha.2](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.0.0-alpha.2)
 * Update Grafana from v7.2.1 to [v7.3.0](https://github.com/grafana/grafana/releases/tag/v7.3.0)
 
 ## v1.19.3

--- a/addons/prometheus/exporters/kube-state-metrics/cluster-role.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/cluster-role.yaml
@@ -90,6 +90,7 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingresses
   verbs:
   - list
   - watch

--- a/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v2.0.0-alpha.1
+        image: quay.io/coreos/kube-state-metrics:v2.0.0-alpha.2
         ports:
           - name: metrics
             containerPort: 8080


### PR DESCRIPTION
* https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.0.0-alpha.2