### PR TITLE
Add Terraform v0.13 input variable validations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Notable changes between versions.
 
 ## Latest
 
+* Add input variable validations ([#880](https://github.com/poseidon/typhoon/pull/880))
+  * Require Terraform v0.13+ ([migration guide](https://typhoon.psdn.io/topics/maintenance/#terraform-versions))
+
 ## v1.19.4
 
 * Kubernetes [v1.19.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#v1194)

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -43,8 +43,13 @@ variable "worker_type" {
 
 variable "os_stream" {
   type        = string
-  description = "Fedora CoreOs image stream for instances (e.g. stable, testing, next)"
+  description = "Fedora CoreOS image stream for instances (e.g. stable, testing, next)"
   default     = "stable"
+
+  validation {
+    condition = contains(["stable", "testing", "next"], var.os_stream)
+    error_message = "The os_stream must be stable, testing, or next."
+  }
 }
 
 variable "disk_size" {
@@ -159,6 +164,11 @@ variable "arch" {
   type        = string
   description = "Container architecture (amd64 or arm64)"
   default     = "amd64"
+
+  validation {
+    condition = var.arch == "amd64" || var.arch == "arm64"
+    error_message = "The arch must be amd64 or arm64."
+  }
 }
 
 variable "daemonset_tolerations" {

--- a/aws/fedora-coreos/kubernetes/versions.tf
+++ b/aws/fedora-coreos/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     aws      = ">= 2.23, <= 4.0"
     template = "~> 2.1"

--- a/aws/fedora-coreos/kubernetes/workers/variables.tf
+++ b/aws/fedora-coreos/kubernetes/workers/variables.tf
@@ -36,8 +36,13 @@ variable "instance_type" {
 
 variable "os_stream" {
   type        = string
-  description = "Fedora CoreOs image stream for instances (e.g. stable, testing, next)"
+  description = "Fedora CoreOS image stream for instances (e.g. stable, testing, next)"
   default     = "stable"
+
+  validation {
+    condition = contains(["stable", "testing", "next"], var.os_stream)
+    error_message = "The os_stream must be stable, testing, or next."
+  }
 }
 
 variable "disk_size" {
@@ -121,4 +126,9 @@ variable "arch" {
   type        = string
   description = "Container architecture (amd64 or arm64)"
   default     = "amd64"
+
+  validation {
+    condition = var.arch == "amd64" || var.arch == "arm64"
+    error_message = "The arch must be amd64 or arm64."
+  }
 }

--- a/aws/fedora-coreos/kubernetes/workers/versions.tf
+++ b/aws/fedora-coreos/kubernetes/workers/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     aws      = ">= 2.23, <= 4.0"
     template = "~> 2.1"

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -45,6 +45,11 @@ variable "os_image" {
   type        = string
   description = "AMI channel for a Container Linux derivative (flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge)"
   default     = "flatcar-stable"
+
+  validation {
+    condition = contains(["flatcar-stable", "flatcar-beta", "flatcar-alpha", "flatcar-edge"], var.os_image)
+    error_message = "The os_image must be flatcar-stable, flatcar-beta, flatcar-alpha, or flatcar-edge."
+  }
 }
 
 variable "disk_size" {

--- a/aws/flatcar-linux/kubernetes/versions.tf
+++ b/aws/flatcar-linux/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     aws      = ">= 2.23, <= 4.0"
     template = "~> 2.1"

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -38,6 +38,11 @@ variable "os_image" {
   type        = string
   description = "AMI channel for a Container Linux derivative (flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge)"
   default     = "flatcar-stable"
+
+  validation {
+    condition = contains(["flatcar-stable", "flatcar-beta", "flatcar-alpha", "flatcar-edge"], var.os_image)
+    error_message = "The os_image must be flatcar-stable, flatcar-beta, flatcar-alpha, or flatcar-edge."
+  }
 }
 
 variable "disk_size" {

--- a/aws/flatcar-linux/kubernetes/workers/versions.tf
+++ b/aws/flatcar-linux/kubernetes/workers/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     aws      = ">= 2.23, <= 4.0"
     template = "~> 2.1"

--- a/azure/fedora-coreos/kubernetes/versions.tf
+++ b/azure/fedora-coreos/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     azurerm  = "~> 2.8"
     template = "~> 2.1"

--- a/azure/fedora-coreos/kubernetes/workers/versions.tf
+++ b/azure/fedora-coreos/kubernetes/workers/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     azurerm  = "~> 2.8"
     template = "~> 2.1"

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -50,6 +50,11 @@ variable "os_image" {
   type        = string
   description = "Channel for a Container Linux derivative (flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge)"
   default     = "flatcar-stable"
+
+  validation {
+    condition = contains(["flatcar-stable", "flatcar-beta", "flatcar-alpha", "flatcar-edge"], var.os_image)
+    error_message = "The os_image must be flatcar-stable, flatcar-beta, flatcar-alpha, or flatcar-edge."
+  }
 }
 
 variable "disk_size" {

--- a/azure/flatcar-linux/kubernetes/versions.tf
+++ b/azure/flatcar-linux/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     azurerm  = "~> 2.8"
     template = "~> 2.1"

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -48,6 +48,11 @@ variable "os_image" {
   type        = string
   description = "Channel for a Container Linux derivative (flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge)"
   default     = "flatcar-stable"
+
+  validation {
+    condition = contains(["flatcar-stable", "flatcar-beta", "flatcar-alpha", "flatcar-edge"], var.os_image)
+    error_message = "The os_image must be flatcar-stable, flatcar-beta, flatcar-alpha, or flatcar-edge."
+  }
 }
 
 variable "priority" {

--- a/azure/flatcar-linux/kubernetes/workers/versions.tf
+++ b/azure/flatcar-linux/kubernetes/workers/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     azurerm  = "~> 2.8"
     template = "~> 2.1"

--- a/bare-metal/fedora-coreos/kubernetes/variables.tf
+++ b/bare-metal/fedora-coreos/kubernetes/variables.tf
@@ -12,8 +12,13 @@ variable "matchbox_http_endpoint" {
 
 variable "os_stream" {
   type        = string
-  description = "Fedora CoreOS release stream (e.g. testing, stable)"
+  description = "Fedora CoreOS release stream (e.g. stable, testing, next)"
   default     = "stable"
+
+  validation {
+    condition = contains(["stable", "testing", "next"], var.os_stream)
+    error_message = "The os_stream must be stable, testing, or next."
+  }
 }
 
 variable "os_version" {

--- a/bare-metal/fedora-coreos/kubernetes/versions.tf
+++ b/bare-metal/fedora-coreos/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     template = "~> 2.1"
     null     = "~> 2.1"

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -13,6 +13,11 @@ variable "matchbox_http_endpoint" {
 variable "os_channel" {
   type        = string
   description = "Channel for a Flatcar Linux (flatcar-stable, flatcar-beta, flatcar-alpha, flatcar-edge)"
+
+  validation {
+    condition = contains(["flatcar-stable", "flatcar-beta", "flatcar-alpha", "flatcar-edge"], var.os_channel)
+    error_message = "The os_channel must be flatcar-stable, flatcar-beta, flatcar-alpha, or flatcar-edge."
+  }
 }
 
 variable "os_version" {

--- a/bare-metal/flatcar-linux/kubernetes/versions.tf
+++ b/bare-metal/flatcar-linux/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     template = "~> 2.1"
     null     = "~> 2.1"

--- a/digital-ocean/fedora-coreos/kubernetes/versions.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     template = "~> 2.1"
     null     = "~> 2.1"

--- a/digital-ocean/flatcar-linux/kubernetes/versions.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     template = "~> 2.1"
     null     = "~> 2.1"

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -50,6 +50,11 @@ variable "os_stream" {
   type        = string
   description = "Fedora CoreOS stream for compute instances (e.g. stable, testing, next)"
   default     = "stable"
+
+  validation {
+    condition = contains(["stable", "testing", "next"], var.os_stream)
+    error_message = "The os_stream must be stable, testing, or next."
+  }
 }
 
 variable "disk_size" {

--- a/google-cloud/fedora-coreos/kubernetes/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     google   = ">= 2.19, < 4.0"
     template = "~> 2.1"

--- a/google-cloud/fedora-coreos/kubernetes/workers/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/variables.tf
@@ -38,6 +38,11 @@ variable "os_stream" {
   type        = string
   description = "Fedora CoreOS stream for compute instances (e.g. stable, testing, next)"
   default     = "stable"
+
+  validation {
+    condition = contains(["stable", "testing", "next"], var.os_stream)
+    error_message = "The os_stream must be stable, testing, or next."
+  }
 }
 
 variable "disk_size" {

--- a/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     google   = ">= 2.19, < 4.0"
     template = "~> 2.1"

--- a/google-cloud/flatcar-linux/kubernetes/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     google   = ">= 2.19, < 4.0"
     template = "~> 2.1"

--- a/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.26, < 0.14.0"
+  required_version = "~> 0.13.0"
   required_providers {
     google   = ">= 2.19, < 4.0"
     template = "~> 2.1"


### PR DESCRIPTION
* Support for migrating from Terraform v0.12.x to v0.13.x was added in v1.18.8
* Require Terraform v0.13+. Drop support for Terraform v0.12