### PR TITLE
Enable Network Load Balancer (NLB) dualstack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,13 @@ Notable changes between versions.
 * Add input variable validations ([#880](https://github.com/poseidon/typhoon/pull/880))
   * Require Terraform v0.13+ ([migration guide](https://typhoon.psdn.io/topics/maintenance/#terraform-versions))
 
+### AWS
+
+* Enable Network Load Balancer (NLB) dualstack ([#883](https://github.com/poseidon/typhoon/pull/883))
+  * NLB subnets assigned both IPv4 and IPv6 addresses
+  * NLB DNS name has both A and AAAA records
+  * NLB to target node traffic is IPv4 (no change)
+
 ### Addons
 
 * Update Prometheus from v2.22.1 to [v2.22.2](https://github.com/prometheus/prometheus/releases/tag/v2.22.2)

--- a/aws/fedora-coreos/kubernetes/nlb.tf
+++ b/aws/fedora-coreos/kubernetes/nlb.tf
@@ -17,6 +17,7 @@ resource "aws_route53_record" "apiserver" {
 resource "aws_lb" "nlb" {
   name               = "${var.cluster_name}-nlb"
   load_balancer_type = "network"
+  ip_address_type    = "dualstack"
   internal           = false
 
   subnets = aws_subnet.public.*.id

--- a/aws/flatcar-linux/kubernetes/nlb.tf
+++ b/aws/flatcar-linux/kubernetes/nlb.tf
@@ -17,6 +17,7 @@ resource "aws_route53_record" "apiserver" {
 resource "aws_lb" "nlb" {
   name               = "${var.cluster_name}-nlb"
   load_balancer_type = "network"
+  ip_address_type    = "dualstack"
   internal           = false
 
   subnets = aws_subnet.public.*.id

--- a/docs/architecture/aws.md
+++ b/docs/architecture/aws.md
@@ -98,11 +98,9 @@ resource "aws_route" "peering" {
 
 ## IPv6
 
-AWS Network Load Balancers do not support `dualstack`.
-
 | IPv6 Feature            | Supported |
 |-------------------------|-----------|
 | Node IPv6 address       | Yes       |
 | Node Outbound IPv6      | Yes       |
-| Kubernetes Ingress IPv6 | No        |
+| Kubernetes Ingress IPv6 | Yes       |
 


### PR DESCRIPTION
* NLB subnets assigned both IPv4 and IPv6 addresses
* NLB DNS name has both A and AAAA records
* NLB to target node traffic is IPv4 (no change), no change to security groups needed
* Ingresses exposed through the recommended Nginx Ingress Controller addon will be accessible via
IPv4 or IPv6. No change is needed to the app's CNAME to NLB record

Related:
* https://aws.amazon.com/about-aws/whats-new/2020/11/network-load-balancer-supports-ipv6/
* Now both GCP and AWS (new) support exposing Ingress via IPv6