### PR TITLE
Set kubeconfig and asset_dist as sensitive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Notable changes between versions.
 
 * Add input variable validations ([#880](https://github.com/poseidon/typhoon/pull/880))
   * Require Terraform v0.13+ ([migration guide](https://typhoon.psdn.io/topics/maintenance/#terraform-versions))
+* Set output sensitive to suppress console display for some cases ([#885](https://github.com/poseidon/typhoon/pull/885))
 
 ### AWS
 

--- a/aws/fedora-coreos/kubernetes/outputs.tf
+++ b/aws/fedora-coreos/kubernetes/outputs.tf
@@ -1,5 +1,6 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for Kubernetes Ingress
@@ -32,7 +33,8 @@ output "worker_security_groups" {
 }
 
 output "kubeconfig" {
-  value = module.bootstrap.kubeconfig-kubelet
+  value     = module.bootstrap.kubeconfig-kubelet
+  sensitive = true
 }
 
 # Outputs for custom load balancing
@@ -55,6 +57,7 @@ output "worker_target_group_https" {
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 

--- a/aws/flatcar-linux/kubernetes/outputs.tf
+++ b/aws/flatcar-linux/kubernetes/outputs.tf
@@ -1,5 +1,6 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for Kubernetes Ingress
@@ -32,7 +33,8 @@ output "worker_security_groups" {
 }
 
 output "kubeconfig" {
-  value = module.bootstrap.kubeconfig-kubelet
+  value     = module.bootstrap.kubeconfig-kubelet
+  sensitive = true
 }
 
 # Outputs for custom load balancing
@@ -55,6 +57,7 @@ output "worker_target_group_https" {
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 

--- a/azure/fedora-coreos/kubernetes/outputs.tf
+++ b/azure/fedora-coreos/kubernetes/outputs.tf
@@ -1,5 +1,6 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for Kubernetes Ingress
@@ -32,7 +33,8 @@ output "security_group_id" {
 }
 
 output "kubeconfig" {
-  value = module.bootstrap.kubeconfig-kubelet
+  value     = module.bootstrap.kubeconfig-kubelet
+  sensitive = true
 }
 
 # Outputs for custom firewalling
@@ -61,6 +63,7 @@ output "backend_address_pool_id" {
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 

--- a/azure/flatcar-linux/kubernetes/outputs.tf
+++ b/azure/flatcar-linux/kubernetes/outputs.tf
@@ -1,5 +1,6 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for Kubernetes Ingress
@@ -32,7 +33,8 @@ output "security_group_id" {
 }
 
 output "kubeconfig" {
-  value = module.bootstrap.kubeconfig-kubelet
+  value     = module.bootstrap.kubeconfig-kubelet
+  sensitive = true
 }
 
 # Outputs for custom firewalling
@@ -61,6 +63,7 @@ output "backend_address_pool_id" {
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 

--- a/bare-metal/fedora-coreos/kubernetes/outputs.tf
+++ b/bare-metal/fedora-coreos/kubernetes/outputs.tf
@@ -1,10 +1,12 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 

--- a/bare-metal/flatcar-linux/kubernetes/outputs.tf
+++ b/bare-metal/flatcar-linux/kubernetes/outputs.tf
@@ -1,10 +1,12 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 

--- a/digital-ocean/fedora-coreos/kubernetes/outputs.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/outputs.tf
@@ -1,5 +1,6 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for Kubernetes Ingress
@@ -32,7 +33,8 @@ output "workers_ipv6" {
 # Outputs for worker pools
 
 output "kubeconfig" {
-  value = module.bootstrap.kubeconfig-kubelet
+  value     = module.bootstrap.kubeconfig-kubelet
+  sensitive = true
 }
 
 # Outputs for custom firewalls
@@ -57,6 +59,7 @@ output "vpc_id" {
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 

--- a/digital-ocean/flatcar-linux/kubernetes/outputs.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/outputs.tf
@@ -1,5 +1,6 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for Kubernetes Ingress
@@ -32,7 +33,8 @@ output "workers_ipv6" {
 # Outputs for worker pools
 
 output "kubeconfig" {
-  value = module.bootstrap.kubeconfig-kubelet
+  value     = module.bootstrap.kubeconfig-kubelet
+  sensitive = true
 }
 
 # Outputs for custom firewalls
@@ -57,6 +59,7 @@ output "vpc_id" {
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 

--- a/google-cloud/fedora-coreos/kubernetes/outputs.tf
+++ b/google-cloud/fedora-coreos/kubernetes/outputs.tf
@@ -1,5 +1,6 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for Kubernetes Ingress
@@ -21,7 +22,8 @@ output "network_name" {
 }
 
 output "kubeconfig" {
-  value = module.bootstrap.kubeconfig-kubelet
+  value     = module.bootstrap.kubeconfig-kubelet
+  sensitive = true
 }
 
 # Outputs for custom firewalling
@@ -45,6 +47,7 @@ output "worker_target_pool" {
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 

--- a/google-cloud/flatcar-linux/kubernetes/outputs.tf
+++ b/google-cloud/flatcar-linux/kubernetes/outputs.tf
@@ -1,5 +1,6 @@
 output "kubeconfig-admin" {
-  value = module.bootstrap.kubeconfig-admin
+  value     = module.bootstrap.kubeconfig-admin
+  sensitive = true
 }
 
 # Outputs for Kubernetes Ingress
@@ -21,7 +22,8 @@ output "network_name" {
 }
 
 output "kubeconfig" {
-  value = module.bootstrap.kubeconfig-kubelet
+  value     = module.bootstrap.kubeconfig-kubelet
+  sensitive = true
 }
 
 # Outputs for custom firewalling
@@ -45,6 +47,7 @@ output "worker_target_pool" {
 # Outputs for debug
 
 output "assets_dist" {
-  value = module.bootstrap.assets_dist
+  value     = module.bootstrap.assets_dist
+  sensitive = true
 }
 


### PR DESCRIPTION
* Mark `kubeconfig` and `asset_dist` as `sensitive` to prevent the Terraform CLI displaying these values, esp. for CI systems
* In particular, external tools or tfvars style uses (not recommended) reportedly display all outputs and are improved by setting sensitive
* For Terraform v0.14, outputs referencing sensitive fields must also be annotated as sensitive

Closes https://github.com/poseidon/typhoon/issues/884