### PR TITLE
Fix Fedora CoreOS AWS AMI query in non-US regions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,12 @@ Notable changes between versions.
   * NLB DNS name has both A and AAAA records
   * NLB to target node traffic is IPv4 (no change)
 
+### Fedora CoreOS
+
+#### AWS
+
+* Fix AMI query for which could fail in some regions ([#887](https://github.com/poseidon/typhoon/pull/887))
+
 ### Addons
 
 * Update Prometheus from v2.22.2 to [v2.23.0-rc.0](https://github.com/prometheus/prometheus/releases/tag/v2.23.0-rc.0)

--- a/aws/fedora-coreos/kubernetes/ami.tf
+++ b/aws/fedora-coreos/kubernetes/ami.tf
@@ -23,6 +23,8 @@ data "aws_ami" "fedora-coreos" {
 # WARNING: These AMIs will be removed when Fedora CoreOS publishes arm64 AMIs
 # and may be removed for any reason before then as well. Do not use.
 data "aws_ami" "fedora-coreos-arm" {
+  count = var.arch == "arm64" ? 1 : 0
+
   most_recent = true
   owners      = ["099663496933"]
 

--- a/aws/fedora-coreos/kubernetes/controllers.tf
+++ b/aws/fedora-coreos/kubernetes/controllers.tf
@@ -22,7 +22,7 @@ resource "aws_instance" "controllers" {
   }
 
   instance_type = var.controller_type
-  ami           = var.arch == "arm64" ? data.aws_ami.fedora-coreos-arm.image_id : data.aws_ami.fedora-coreos.image_id
+  ami           = var.arch == "arm64" ? data.aws_ami.fedora-coreos-arm[0].image_id : data.aws_ami.fedora-coreos.image_id
   user_data     = data.ct_config.controller-ignitions.*.rendered[count.index]
 
   # storage

--- a/aws/fedora-coreos/kubernetes/workers/ami.tf
+++ b/aws/fedora-coreos/kubernetes/workers/ami.tf
@@ -23,6 +23,8 @@ data "aws_ami" "fedora-coreos" {
 # WARNING: These AMIs will be removed when Fedora CoreOS publishes arm64 AMIs
 # and may be removed for any reason before then as well. Do not use.
 data "aws_ami" "fedora-coreos-arm" {
+  count = var.arch == "arm64" ? 1 : 0
+
   most_recent = true
   owners      = ["099663496933"]
 

--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -44,7 +44,7 @@ resource "aws_autoscaling_group" "workers" {
 
 # Worker template
 resource "aws_launch_configuration" "worker" {
-  image_id          = var.arch == "arm64" ? data.aws_ami.fedora-coreos-arm.image_id : data.aws_ami.fedora-coreos.image_id
+  image_id          = var.arch == "arm64" ? data.aws_ami.fedora-coreos-arm[0].image_id : data.aws_ami.fedora-coreos.image_id
   instance_type     = var.instance_type
   spot_price        = var.spot_price > 0 ? var.spot_price : null
   enable_monitoring = false


### PR DESCRIPTION
* A `aws_ami` data source will fail a Terraform plan if no matching AMI is found, even if the AMI is not used. ARM64 images are only published to a few US regions, so the `aws_ami` data query could fail when creating Fedora CoreOS AWS clusters in non-US regions
* Condition `aws_ami` on whether experimental arch `arm64` is chosen
* Recent regression introduced in v1.19.4 https://github.com/poseidon/typhoon/pull/875

Closes https://github.com/poseidon/typhoon/issues/886