### PR TITLE
 coreos.live.rootfs_url to support new separated initramfs for PXE booting

### DIFF
--- a/bare-metal/fedora-coreos/kubernetes/profiles.tf
+++ b/bare-metal/fedora-coreos/kubernetes/profiles.tf
@@ -8,6 +8,7 @@ locals {
     "coreos.inst.image_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-metal.x86_64.raw.xz",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.inst.install_dev=${var.install_disk}",
+    "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
     "console=tty0",
     "console=ttyS0",
   ]
@@ -21,6 +22,7 @@ locals {
     "coreos.inst.image_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-metal.x86_64.raw.xz",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.inst.install_dev=${var.install_disk}",
+    "coreos.live.rootfs_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
     "console=tty0",
     "console=ttyS0",
   ]


### PR DESCRIPTION
Fedora CoreOS PXE initramfs image has been separated into two images: initramfs and rootfs. Both of them needed for PXE boot which brakes the current setup.  The new rootfs artefact can be specified as either a second element in the initrd array or as a kernel argument `coreos.live.rootfs_url=`. 
More information [here](https://github.com/coreos/fedora-coreos-tracker/issues/390#issuecomment-659791267) 

This PR contains the latter. I didn't see that one would load faster than the other in my environment. In the Fedora CoreOS [PXE guide](https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/) noted that the kernel argument `coreos.live.rootfs_url` requires at least 2GiB RAM while the initrd option requires at least 3GiB RAM. 

