### PR TITLE
Update Matchbox profile to use initramfs and rootfs images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,11 @@ Notable changes between versions.
 
 * Fix AMI query for which could fail in some regions ([#887](https://github.com/poseidon/typhoon/pull/887))
 
+#### Bare-Metal
+
+* Use initramfs and rootfs images as initrd's ([#889](https://github.com/poseidon/typhoon/pull/889))
+  * Requires Fedora CoreOS version with rootfs images (e.g. 32.20200923.3.0+)
+
 ### Addons
 
 * Update Prometheus from v2.22.2 to [v2.23.0-rc.0](https://github.com/prometheus/prometheus/releases/tag/v2.23.0-rc.0)

--- a/bare-metal/fedora-coreos/kubernetes/profiles.tf
+++ b/bare-metal/fedora-coreos/kubernetes/profiles.tf
@@ -1,26 +1,32 @@
 locals {
   remote_kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-kernel-x86_64"
-  remote_initrd = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img"
+  remote_initrd = [
+    "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
+    "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img"
+  ]
+
   remote_args = [
     "ip=dhcp",
     "rd.neednet=1",
-    "initrd=fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
-    "coreos.inst.image_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-metal.x86_64.raw.xz",
-    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.inst.install_dev=${var.install_disk}",
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "coreos.inst.image_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-metal.x86_64.raw.xz",
     "console=tty0",
     "console=ttyS0",
   ]
 
   cached_kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel-x86_64"
-  cached_initrd = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img"
+  cached_initrd = [
+    "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
+    "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img"
+  ]
+
   cached_args = [
     "ip=dhcp",
     "rd.neednet=1",
-    "initrd=fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
-    "coreos.inst.image_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-metal.x86_64.raw.xz",
-    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.inst.install_dev=${var.install_disk}",
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "coreos.inst.image_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-metal.x86_64.raw.xz",
     "console=tty0",
     "console=ttyS0",
   ]
@@ -37,9 +43,7 @@ resource "matchbox_profile" "controllers" {
   name  = format("%s-controller-%s", var.cluster_name, var.controllers.*.name[count.index])
 
   kernel = local.kernel
-  initrd = [
-    local.initrd
-  ]
+  initrd = local.initrd
   args = concat(local.args, var.kernel_args)
 
   raw_ignition = data.ct_config.controller-ignitions.*.rendered[count.index]
@@ -73,9 +77,7 @@ resource "matchbox_profile" "workers" {
   name  = format("%s-worker-%s", var.cluster_name, var.workers.*.name[count.index])
 
   kernel = local.kernel
-  initrd = [
-    local.initrd
-  ]
+  initrd = local.initrd
   args = concat(local.args, var.kernel_args)
 
   raw_ignition = data.ct_config.worker-ignitions.*.rendered[count.index]

--- a/docs/fedora-coreos/bare-metal.md
+++ b/docs/fedora-coreos/bare-metal.md
@@ -160,7 +160,7 @@ module "mercury" {
   cluster_name            = "mercury"
   matchbox_http_endpoint  = "http://matchbox.example.com"
   os_stream               = "stable"
-  os_version              = "31.20200113.3.1"
+  os_version              = "32.20201104.3.0"
 
   # configuration
   k8s_domain_name    = "node1.example.com"
@@ -321,7 +321,7 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/bare-me
 | cluster_name | Unique cluster name | "mercury" |
 | matchbox_http_endpoint | Matchbox HTTP read-only endpoint | "http://matchbox.example.com:port" |
 | os_stream | Fedora CoreOS release stream | "stable" |
-| os_version | Fedora CoreOS version to PXE and install | "31.20200113.3.1" |
+| os_version | Fedora CoreOS version to PXE and install | "32.20201104.3.0" |
 | k8s_domain_name | FQDN resolving to the controller(s) nodes. Workers and kubectl will communicate with this endpoint | "myk8s.example.com" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3Nz..." |
 | controllers | List of controller machine detail objects (unique name, identifying MAC address, FQDN) | `[{name="node1", mac="52:54:00:a1:9c:ae", domain="node1.example.com"}]` |


### PR DESCRIPTION
* Fedora CoreOS stable (after Oct 6) ships separate initramfs and rootfs images, used as initrd's
* Update profiles to match the Matchbox examples, which have already switched to the new profile and to remove the unused kernel args
* Requires Fedora CoreOS version which ships rootfs images (e.g. stable 32.20200923.3.0 or later)

Rel:

* https://github.com/coreos/fedora-coreos-tracker/issues/390#issuecomment-661986987
* https://github.com/poseidon/matchbox/commit/da0df01763693b6391b3f6f9b7a267818075cef8#diff-4541f7b7c174f6ae6270135942c1c65ed9e09ebe81239709f5a9fb34e858ddcf

Supercedes https://github.com/poseidon/typhoon/pull/888