### PR TITLE
Relax terraform-provider-ct version constraint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ Notable changes between versions.
 * Update Calico from v3.16.5 to v3.17.0 ([#890](https://github.com/poseidon/typhoon/pull/890))
   * Enable Calico MTU auto-detection
   * Remove [workaround](https://github.com/poseidon/typhoon/pull/724) to Calico cni-plugin [issue](https://github.com/projectcalico/cni-plugin/issues/874)
+* Relax `terraform-provider-ct` version constraint to v0.6+ ([#893](https://github.com/poseidon/typhoon/pull/893))
+  * Allow upgrading `terraform-provider-ct` to v0.7.x ([warn](https://typhoon.psdn.io/topics/maintenance/#upgrade-terraform-provider-ct))
 
 ### AWS
 

--- a/aws/fedora-coreos/kubernetes/versions.tf
+++ b/aws/fedora-coreos/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/aws/fedora-coreos/kubernetes/workers/versions.tf
+++ b/aws/fedora-coreos/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/aws/flatcar-linux/kubernetes/versions.tf
+++ b/aws/flatcar-linux/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/aws/flatcar-linux/kubernetes/workers/versions.tf
+++ b/aws/flatcar-linux/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/azure/fedora-coreos/kubernetes/versions.tf
+++ b/azure/fedora-coreos/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/azure/fedora-coreos/kubernetes/workers/versions.tf
+++ b/azure/fedora-coreos/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/azure/flatcar-linux/kubernetes/versions.tf
+++ b/azure/flatcar-linux/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/azure/flatcar-linux/kubernetes/workers/versions.tf
+++ b/azure/flatcar-linux/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/bare-metal/fedora-coreos/kubernetes/versions.tf
+++ b/bare-metal/fedora-coreos/kubernetes/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
 
     matchbox = {

--- a/bare-metal/flatcar-linux/kubernetes/versions.tf
+++ b/bare-metal/flatcar-linux/kubernetes/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
 
     matchbox = {

--- a/digital-ocean/fedora-coreos/kubernetes/versions.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
 
     digitalocean = {

--- a/digital-ocean/flatcar-linux/kubernetes/versions.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
 
     digitalocean = {

--- a/docs/fedora-coreos/aws.md
+++ b/docs/fedora-coreos/aws.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     aws = {
       source = "hashicorp/aws"

--- a/docs/fedora-coreos/azure.md
+++ b/docs/fedora-coreos/azure.md
@@ -48,7 +48,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     azurerm = {
       source = "hashicorp/azurerm"

--- a/docs/fedora-coreos/bare-metal.md
+++ b/docs/fedora-coreos/bare-metal.md
@@ -138,7 +138,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     matchbox = {
       source = "poseidon/matchbox"

--- a/docs/fedora-coreos/digitalocean.md
+++ b/docs/fedora-coreos/digitalocean.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     digitalocean = {
       source = "digitalocean/digitalocean"

--- a/docs/fedora-coreos/google-cloud.md
+++ b/docs/fedora-coreos/google-cloud.md
@@ -52,7 +52,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     google = {
       source = "hashicorp/google"

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     aws = {
       source = "hashicorp/aws"

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -48,7 +48,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     azurerm = {
       source = "hashicorp/azurerm"

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -138,7 +138,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     matchbox = {
       source = "poseidon/matchbox"

--- a/docs/flatcar-linux/digitalocean.md
+++ b/docs/flatcar-linux/digitalocean.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     digitalocean = {
       source = "digitalocean/digitalocean"

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -52,7 +52,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.7.1"
     }
     google = {
       source = "hashicorp/google"

--- a/docs/topics/maintenance.md
+++ b/docs/topics/maintenance.md
@@ -129,34 +129,22 @@ Typhoon supports multi-controller clusters, so it is possible to upgrade a clust
 
 ### Upgrade terraform-provider-ct
 
-The [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin parses, validates, and converts Container Linux Configs into Ignition user-data for provisioning instances. Since Typhoon v1.12.2+, the plugin can be updated in-place so that on apply, only workers will be replaced.
-
-Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
-
-```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.5.0/terraform-provider-ct-v0.6.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.6.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.6.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.6.1
-```
-
-Binary names are versioned. This enables the ability to upgrade different plugins and have clusters pin different versions.
-
-```
-$ tree ~/.terraform.d/
-/home/user/.terraform.d/
-└── plugins
-    ├── terraform-provider-ct_v0.2.1
-    ├── terraform-provider-ct_v0.3.0
-    ├── terraform-provider-ct_v0.6.1
-    └── terraform-provider-matchbox_v0.4.1
-```
-
+The [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin parses, validates, and converts Fedora CoreOS or Flatcar Linux Configs into Ignition user-data for provisioning instances. Since Typhoon v1.12.2+, the plugin can be updated in-place so that on apply, only workers will be replaced.
 
 Update the version of the `ct` plugin in each Terraform working directory. Typhoon clusters managed in the working directory **must** be v1.12.2 or higher.
 
-```tf
-provider "ct" {
-  version = "0.6.1"
+```diff
+provider "ct" {}
+
+terraform {
+  required_providers {
+    ct = {
+      source  = "poseidon/ct"
+-     version = "0.6.1"
++     version = "0.7.1"
+    }
+    ...
+  }
 }
 ```
 
@@ -168,7 +156,6 @@ terraform plan
 ```
 
 Apply the change. Worker nodes' user-data will be changed and workers will be replaced. Rollout happens slightly differently on each platform:
-
 
 #### AWS
 

--- a/google-cloud/fedora-coreos/kubernetes/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/google-cloud/flatcar-linux/kubernetes/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }

--- a/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6.1"
+      version = "~> 0.6"
     }
   }
 }


### PR DESCRIPTION
* Allow terraform-provider-ct versions v0.6+ (e.g. v0.7.1). Before, only v0.6.x point updates were allowed
* READ the docs before updating `terraform-provider-ct`, as changing worker user-data is handled differently by different cloud platforms