### PR TITLE
Remove iSCSI mounts from Kubelet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@ Notable changes between versions.
   * NLB DNS name has both A and AAAA records
   * NLB to target node traffic is IPv4 (no change)
 
+### Bare-Metal
+
+* Remove iSCSI `/etc/iscsi` and `iscsadm` mounts from Kubelet ()
+
 ### Fedora CoreOS
 
 #### AWS

--- a/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -74,8 +74,6 @@ systemd:
           --volume /var/log:/var/log \
           --volume /var/run/lock:/var/run/lock:z \
           --volume /opt/cni/bin:/opt/cni/bin:z \
-          --volume /etc/iscsi:/etc/iscsi \
-          --volume /sbin/iscsiadm:/sbin/iscsiadm \
           $${KUBELET_IMAGE} \
           --anonymous-auth=false \
           --authentication-token-webhook \

--- a/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
@@ -47,8 +47,6 @@ systemd:
           --volume /var/log:/var/log \
           --volume /var/run/lock:/var/run/lock:z \
           --volume /opt/cni/bin:/opt/cni/bin:z \
-          --volume /etc/iscsi:/etc/iscsi \
-          --volume /sbin/iscsiadm:/sbin/iscsiadm \
           $${KUBELET_IMAGE} \
           --anonymous-auth=false \
           --authentication-token-webhook \

--- a/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml
@@ -88,8 +88,6 @@ systemd:
           -v /var/lib/kubelet:/var/lib/kubelet:rshared \
           -v /var/log:/var/log \
           -v /opt/cni/bin:/opt/cni/bin \
-          -v /etc/iscsi:/etc/iscsi \
-          -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm \
           $${KUBELET_IMAGE} \
           --anonymous-auth=false \
           --authentication-token-webhook \

--- a/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml
@@ -63,8 +63,6 @@ systemd:
           -v /var/lib/kubelet:/var/lib/kubelet:rshared \
           -v /var/log:/var/log \
           -v /opt/cni/bin:/opt/cni/bin \
-          -v /etc/iscsi:/etc/iscsi \
-          -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm \
           $${KUBELET_IMAGE} \
           --anonymous-auth=false \
           --authentication-token-webhook \


### PR DESCRIPTION
* Remove Kubelet `/etc/iscsi` and `iscsiadm` host mounts that were added on bare-metal, since these no longer work on either Fedora CoreOS or Flatcar Linux with newer `iscsiadm`
* These special mounts on bare-metal date back to #350 which added them to provide a way to use iSCSI in Kubernetes v1.10
* Today, storage should be handled by external CSI providers which handle different storage systems, which doesn't rely on Kubelet storage utils

Close #907