### PR TITLE
Add notice about upstream Fedora CoreOS changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Notable changes between versions.
 
 * Kubernetes [v1.20.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#v1201)
 
+### Fedora CoreOS
+
+* Fedora CoreOS 33 has stronger crypto defaults ([**notice**](https://docs.fedoraproject.org/en-US/fedora-coreos/faq/#_why_does_ssh_stop_working_after_upgrading_to_fedora_33), [#915](https://github.com/poseidon/typhoon/issues/915))
+  * Use a non-RSA SSH key or add the workaround provided in upstream [Fedora docs](https://docs.fedoraproject.org/en-US/fedora-coreos/faq/#_why_does_ssh_stop_working_after_upgrading_to_fedora_33) as a [snippet](https://typhoon.psdn.io/advanced/customization/#fedora-coreos) (**action required**)
+
 ## v1.20.0
 
 * Kubernetes [v1.20.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#v1200)

--- a/docs/fedora-coreos/digitalocean.md
+++ b/docs/fedora-coreos/digitalocean.md
@@ -217,7 +217,7 @@ resource "digitalocean_domain" "zone-for-clusters" {
 DigitalOcean droplets are created with your SSH public key "fingerprint" (i.e. MD5 hash) to allow access. If your SSH public key is at `~/.ssh/id_rsa`, find the fingerprint with,
 
 ```bash
-ssh-keygen -E md5 -lf ~/.ssh/id_rsa.pub | awk '{print $2}'
+ssh-keygen -E md5 -lf ~/.ssh/id_ed25519.pub | awk '{print $2}'
 MD5:d7:9d:79:ae:56:32:73:79:95:88:e3:a2:ab:5d:45:e7
 ```
 
@@ -225,7 +225,7 @@ If you use `ssh-agent` (e.g. Yubikey for SSH), find the fingerprint with,
 
 ```
 ssh-add -l -E md5
-2048 MD5:d7:9d:79:ae:56:32:73:79:95:88:e3:a2:ab:5d:45:e7 cardno:000603633110 (RSA)
+256 MD5:20:d0:eb:ad:50:b0:09:6d:4b:ba:ad:7c:9c:c1:39:24 foo@xample.com (ED25519)
 ```
 
 Digital Ocean requires the SSH public key be uploaded to your account, so you may also find the fingerprint under Settings -> Security. Finally, if you don't have an SSH key, [create one now](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/).

--- a/docs/topics/maintenance.md
+++ b/docs/topics/maintenance.md
@@ -197,7 +197,8 @@ Typhoon modules have been updated for v0.13.x, but retain compatibility with v0.
 
 | Typhoon Release   | Terraform version   |
 |-------------------|---------------------|
-| v1.18.8 - ?       | v0.12.26+, v0.13.x  |
+| v1.20.0 - ?       | v0.13.x             |
+| v1.18.8 - v1.19.4 | v0.12.26+, v0.13.x  |
 | v1.15.0 - v1.18.8 | v0.12.x             |
 | v1.10.3 - v1.15.0 | v0.11.x             |
 | v1.9.2 - v1.10.2  | v0.10.4+ or v0.11.x |


### PR DESCRIPTION
* Highlight that short-term, use of Fedora CoreOS will require non-RSA SSH keys or a workaround snippet
* See https://github.com/poseidon/typhoon/issues/915