### PR TITLE
Mark bootstrap token as sensitive in plan/apply

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Notable changes between versions.
 
 * Update etcd from v3.4.14 to [v3.4.15](https://github.com/etcd-io/etcd/releases/tag/v3.4.15)
 * Update Calico from v3.17.3 to [v3.18.1](https://github.com/projectcalico/calico/releases/tag/v3.18.1)
+* Mark bootstrap token as sensitive in Terraform plans ([#949](https://github.com/poseidon/typhoon/pull/949))
 
 ### Flatcar Linux
 

--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=adcba1c21115019d284259f2ea35cf358b06bbd8"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fc689b89cf6dd11305915c3fb32c00ce724b8da"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]


### PR DESCRIPTION
* Mark the bootstrap token as sensitive, which is useful when Terraform is run in automated CI/CD systems to avoid showing the token

Rel: https://github.com/poseidon/terraform-render-bootstrap/pull/251