### PR TITLE
Set provider ID for AWS nodes

### DIFF
--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -50,9 +50,12 @@ systemd:
       contents: |
         [Unit]
         Description=Kubelet (System Container)
+        Requires=afterburn.service
+        After=afterburn.service
         Wants=rpc-statd.service
         [Service]
         Environment=KUBELET_IMAGE=quay.io/poseidon/kubelet:v1.20.4
+        EnvironmentFile=/run/metadata/afterburn
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
@@ -93,6 +96,7 @@ systemd:
           --network-plugin=cni \
           --node-labels=node.kubernetes.io/controller="true" \
           --pod-manifest-path=/etc/kubernetes/manifests \
+          --provider-id=aws:///$${AFTERBURN_AWS_AVAILABILITY_ZONE}/$${AFTERBURN_AWS_INSTANCE_ID} \
           --read-only-port=0 \
           --register-with-taints=node-role.kubernetes.io/controller=:NoSchedule \
           --rotate-certificates \

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -23,9 +23,12 @@ systemd:
       contents: |
         [Unit]
         Description=Kubelet (System Container)
+        Requires=afterburn.service
+        After=afterburn.service
         Wants=rpc-statd.service
         [Service]
         Environment=KUBELET_IMAGE=quay.io/poseidon/kubelet:v1.20.4
+        EnvironmentFile=/run/metadata/afterburn
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
@@ -72,6 +75,7 @@ systemd:
           --register-with-taints=${taint} \
           %{~ endfor ~}
           --pod-manifest-path=/etc/kubernetes/manifests \
+          --provider-id=aws:///$${AFTERBURN_AWS_AVAILABILITY_ZONE}/$${AFTERBURN_AWS_INSTANCE_ID} \
           --read-only-port=0 \
           --rotate-certificates \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml
@@ -53,9 +53,12 @@ systemd:
         Description=Kubelet (System Container)
         Requires=docker.service
         After=docker.service
+        Requires=coreos-metadata.service
+        After=coreos-metadata.service
         Wants=rpc-statd.service
         [Service]
         Environment=KUBELET_IMAGE=quay.io/poseidon/kubelet:v1.20.4
+        EnvironmentFile=/run/metadata/coreos
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
@@ -93,6 +96,7 @@ systemd:
           --network-plugin=cni \
           --node-labels=node.kubernetes.io/controller="true" \
           --pod-manifest-path=/etc/kubernetes/manifests \
+          --provider-id=aws:///$${COREOS_EC2_AVAILABILITY_ZONE}/$${COREOS_EC2_INSTANCE_ID} \
           --read-only-port=0 \
           --register-with-taints=node-role.kubernetes.io/controller=:NoSchedule \
           --rotate-certificates \

--- a/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml
+++ b/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml
@@ -25,9 +25,12 @@ systemd:
         Description=Kubelet
         Requires=docker.service
         After=docker.service
+        Requires=coreos-metadata.service
+        After=coreos-metadata.service
         Wants=rpc-statd.service
         [Service]
         Environment=KUBELET_IMAGE=quay.io/poseidon/kubelet:v1.20.4
+        EnvironmentFile=/run/metadata/coreos
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
@@ -71,6 +74,7 @@ systemd:
           --node-labels=${label} \
           %{~ endfor ~}
           --pod-manifest-path=/etc/kubernetes/manifests \
+          --provider-id=aws:///$${COREOS_EC2_AVAILABILITY_ZONE}/$${COREOS_EC2_INSTANCE_ID} \
           --read-only-port=0 \
           --rotate-certificates \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins


### PR DESCRIPTION
Sets the provider ID for controller and worker nodes on AWS to `aws:///<az>/<instance id>`.

* Use `afterburn.service` on Fedora and `coreos-metadata.service` on Flatcar to write instance metadata to file.
* Read instance metadata file in `kubelet.service`.
* Set `--provider-id` in kubelet arguments.

## Testing

* Provisioned two clusters on AWS, one each of Fedora and Flatcar.
* Checked kubectl describe node had a correct value for ProviderID in the format `aws:///<az>/<instance id>` for both controllers and workers.

## Rationale

Autoscaling can be pretty essential for many cluster operators.
Without a provider ID, it is impossible (as far as I know) to use tools such as [cluster-autoscaler](kubernetes/autoscaler).

I understand this change isn't ideal as it makes use of the instance metadata service only available on AWS EC2 instances.
However, given there is an `aws` subdirectory, we already have some explicit notion of which cloud provider we're running against.

## Alternative options

* Autoscale some other way, but nothing comes readily to mind.
* Set hostname in kubelet to the value of `hostname --fqdn`.
  This would maybe provide the option for running with an external cloud-controller-manager as it will match the node name to the EC2 instance and set `providerID` accordingly.
  But then we might need a way to set `--cloud-provider=external` as well, not sure.
