### PR TITLE
Fix delete-node service for Flatcar nodes

### DIFF
--- a/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml
+++ b/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml
@@ -90,6 +90,8 @@ systemd:
       contents: |
         [Unit]
         Description=Delete Kubernetes node on shutdown
+        Requires=docker.service
+        After=docker.service
         [Service]
         Environment=KUBELET_IMAGE=quay.io/poseidon/kubelet:v1.20.5
         Type=oneshot

--- a/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml
+++ b/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml
@@ -86,6 +86,8 @@ systemd:
       contents: |
         [Unit]
         Description=Delete Kubernetes node on shutdown
+        Requires=docker.service
+        After=docker.service
         [Service]
         Environment=KUBELET_IMAGE=quay.io/poseidon/kubelet:v1.20.5
         Type=oneshot

--- a/digital-ocean/flatcar-linux/kubernetes/cl/worker.yaml
+++ b/digital-ocean/flatcar-linux/kubernetes/cl/worker.yaml
@@ -95,6 +95,8 @@ systemd:
       contents: |
         [Unit]
         Description=Delete Kubernetes node on shutdown
+        Requires=docker.service
+        After=docker.service
         [Service]
         Environment=KUBELET_IMAGE=quay.io/poseidon/kubelet:v1.20.5
         Type=oneshot

--- a/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml
@@ -86,6 +86,8 @@ systemd:
       contents: |
         [Unit]
         Description=Delete Kubernetes node on shutdown
+        Requires=docker.service
+        After=docker.service
         [Service]
         Environment=KUBELET_IMAGE=quay.io/poseidon/kubelet:v1.20.5
         Type=oneshot


### PR DESCRIPTION
Remove `Node` resource from Kubernetes API when node is terminated.

* Ensure the `delete-node.service` ExecStop command runs before `docker.service` is stopped.

## Testing

* Tested on AWS only.
* Starting from a working cluster, run `watch -n3 kubectl get node`.
* Created worker pool based on my branch.
* Ensure worker nodes appear with `Ready` status.
* Terminate worker node in EC2 console.
* Ensure terminated node is removed from kube API.

rel: #958
