### PR TITLE
Update Fedora CoreOS Config version from v1.1.0 to v1.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ Notable changes between versions.
   * Enable `kube-scheduler` and `kube-controller-manager` separate authn/z kubeconfig
   * Change `kube-controller-manager` to mount `/var/lib/kubelet/volumeplugins` directly
   * Remove unused `cloud-provider` flags
+* Update Fedora CoreOS Config version from v1.1.0 to v1.2.0
+  * Require [poseidon/ct](https://github.com/poseidon/terraform-provider-ct) Terraform provider v0.8+ ([notes](https://typhoon.psdn.io/topics/maintenance/#upgrade-terraform-provider-ct))
+  * Require any [snippets](https://typhoon.psdn.io/advanced/customization/#hosts) customizations to update to v1.2.0
 
 ### AWS
 

--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: etcd-member.service

--- a/aws/fedora-coreos/kubernetes/versions.tf
+++ b/aws/fedora-coreos/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: docker.service

--- a/aws/fedora-coreos/kubernetes/workers/versions.tf
+++ b/aws/fedora-coreos/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/aws/flatcar-linux/kubernetes/versions.tf
+++ b/aws/flatcar-linux/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/aws/flatcar-linux/kubernetes/workers/versions.tf
+++ b/aws/flatcar-linux/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/azure/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: etcd-member.service

--- a/azure/fedora-coreos/kubernetes/versions.tf
+++ b/azure/fedora-coreos/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/azure/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/azure/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: docker.service

--- a/azure/fedora-coreos/kubernetes/workers/versions.tf
+++ b/azure/fedora-coreos/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/azure/flatcar-linux/kubernetes/versions.tf
+++ b/azure/flatcar-linux/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/azure/flatcar-linux/kubernetes/workers/versions.tf
+++ b/azure/flatcar-linux/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: etcd-member.service

--- a/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: docker.service

--- a/bare-metal/fedora-coreos/kubernetes/versions.tf
+++ b/bare-metal/fedora-coreos/kubernetes/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
 
     matchbox = {

--- a/bare-metal/flatcar-linux/kubernetes/versions.tf
+++ b/bare-metal/flatcar-linux/kubernetes/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
 
     matchbox = {

--- a/digital-ocean/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: etcd-member.service

--- a/digital-ocean/fedora-coreos/kubernetes/fcc/worker.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/fcc/worker.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: docker.service

--- a/digital-ocean/fedora-coreos/kubernetes/versions.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
 
     digitalocean = {

--- a/digital-ocean/flatcar-linux/kubernetes/versions.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
 
     digitalocean = {

--- a/docs/fedora-coreos/aws.md
+++ b/docs/fedora-coreos/aws.md
@@ -51,11 +51,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     aws = {
       source = "hashicorp/aws"
-      version = "3.33.0"
+      version = "3.36.0"
     }
   }
 }

--- a/docs/fedora-coreos/azure.md
+++ b/docs/fedora-coreos/azure.md
@@ -48,11 +48,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "2.52.0"
+      version = "2.55.0"
     }
   }
 }

--- a/docs/fedora-coreos/bare-metal.md
+++ b/docs/fedora-coreos/bare-metal.md
@@ -138,7 +138,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     matchbox = {
       source = "poseidon/matchbox"

--- a/docs/fedora-coreos/digitalocean.md
+++ b/docs/fedora-coreos/digitalocean.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     digitalocean = {
       source = "digitalocean/digitalocean"

--- a/docs/fedora-coreos/google-cloud.md
+++ b/docs/fedora-coreos/google-cloud.md
@@ -52,11 +52,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     google = {
       source = "hashicorp/google"
-      version = "3.60.0"
+      version = "3.63.0"
     }
   }
 }

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -51,11 +51,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     aws = {
       source = "hashicorp/aws"
-      version = "3.33.0"
+      version = "3.36.0"
     }
   }
 }

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -48,11 +48,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "2.52.0"
+      version = "2.55.0"
     }
   }
 }

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -138,7 +138,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     matchbox = {
       source = "poseidon/matchbox"

--- a/docs/flatcar-linux/digitalocean.md
+++ b/docs/flatcar-linux/digitalocean.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     digitalocean = {
       source = "digitalocean/digitalocean"

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -52,11 +52,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.8.0"
     }
     google = {
       source = "hashicorp/google"
-      version = "3.60.0"
+      version = "3.63.0"
     }
   }
 }

--- a/docs/topics/maintenance.md
+++ b/docs/topics/maintenance.md
@@ -140,8 +140,8 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
--     version = "0.6.1"
-+     version = "0.7.1"
+-     version = "0.7.1"
++     version = "0.8.0"
     }
     ...
   }

--- a/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: etcd-member.service

--- a/google-cloud/fedora-coreos/kubernetes/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 systemd:
   units:
     - name: docker.service

--- a/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/google-cloud/flatcar-linux/kubernetes/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }

--- a/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.6"
+      version = "~> 0.8"
     }
   }
 }


### PR DESCRIPTION
* Require [poseidon/ct](https://github.com/poseidon/terraform-provider-ct) Terraform provider v0.8+
* Require any [snippets](https://typhoon.psdn.io/advanced/customization/#hosts) customizations to update to v1.2.0

See upgrade [notes](https://typhoon.psdn.io/topics/maintenance/#upgrade-terraform-provider-ct)