### PR TITLE
[docs] fix broken link on landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ Typhoon is available for [Fedora CoreOS](https://getfedora.org/coreos/).
 | Azure         | Fedora CoreOS | [azure/fedora-coreos/kubernetes](fedora-coreos/azure.md) | alpha |
 | Bare-Metal    | Fedora CoreOS | [bare-metal/fedora-coreos/kubernetes](fedora-coreos/bare-metal.md) | stable |
 | DigitalOcean  | Fedora CoreOS | [digital-ocean/fedora-coreos/kubernetes](fedora-coreos/digitalocean.md) | beta |
-| Google Cloud  | Fedora CoreOS | [google-cloud/fedora-coreos/kubernetes](fedora-coreos/google-cloud/kubernetes) | stable |
+| Google Cloud  | Fedora CoreOS | [google-cloud/fedora-coreos/kubernetes](fedora-coreos/google-cloud.md) | stable |
 
 Typhoon is available for [Flatcar Linux](https://www.flatcar-linux.org/releases/).
 


### PR DESCRIPTION
The link for "Fedora CoreOS on Google Cloud" was pointing to the wrong place, producing a 404. I clicked it because it said `stable` as opposed to Flatcar Linux's `beta`. I got a good chuckle out of the latter working while stable doesn't.

This PR fixes that. Have a nice weekend :rocket: 