### PR TITLE
Remove freenode IRC from help section

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Typhoon is strict about minimalism, maturity, and scope. These are not in scope:
 
 ## Help
 
-Schedule a meeting via [Github Sponsors](https://github.com/sponsors/poseidon?frequency=one-time) to discuss your use case. You can also ask questions on the IRC #typhoon channel on [freenode.net](http://freenode.net/) (unmonitored).
+Schedule a meeting via [Github Sponsors](https://github.com/sponsors/poseidon?frequency=one-time) to discuss your use case.
 
 ## Motivation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,7 +120,7 @@ kube-system   kube-scheduler-controller-0               1/1    Running   0      
 
 ## Help
 
-Schedule a meeting via [Github Sponsors](https://github.com/sponsors/poseidon?frequency=one-time) to discuss your use case. You can also ask questions on the IRC #typhoon channel on [freenode.net](http://freenode.net/) (unmonitored).
+Schedule a meeting via [Github Sponsors](https://github.com/sponsors/poseidon?frequency=one-time) to discuss your use case.
 
 ## Motivation
 


### PR DESCRIPTION
* Due to the takeover of freenode.net IRC, the channel there should no longer be used