### PR TITLE
Workaround systemd 248 path units not working reliably

### DIFF
--- a/bare-metal/fedora-coreos/kubernetes/ssh.tf
+++ b/bare-metal/fedora-coreos/kubernetes/ssh.tf
@@ -39,6 +39,7 @@ resource "null_resource" "copy-controller-secrets" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo touch /etc/kubernetes",
       "sudo /opt/bootstrap/layout",
     ]
   }
@@ -70,6 +71,7 @@ resource "null_resource" "copy-worker-secrets" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo touch /etc/kubernetes",
     ]
   }
 }

--- a/digital-ocean/fedora-coreos/kubernetes/ssh.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/ssh.tf
@@ -36,6 +36,7 @@ resource "null_resource" "copy-controller-secrets" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo touch /etc/kubernetes",
       "sudo /opt/bootstrap/layout",
     ]
   }
@@ -60,6 +61,7 @@ resource "null_resource" "copy-worker-secrets" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo touch /etc/kubernetes",
     ]
   }
 }
@@ -84,4 +86,3 @@ resource "null_resource" "bootstrap" {
     ]
   }
 }
-


### PR DESCRIPTION
* On FCOS 34 / systemd 248, `kubelet.path` won't activate (stuck waiting) when `/etc/kubernetes/kubeconfig` exists, even with manual prodding of the file. The root cause isn't known, but a workaround is to delay `/etc/kubernetes` directory creation
or to touch the directory later
* Fix DigitalOcean worker node kubelet.service being enabled immediately. On bare-metal and DigitalOcean, the kubeconfig
should activate the Kubelet, so it doesn't crashloop needlessly (nice to have, not required)

Rel: https://github.com/coreos/fedora-coreos-tracker/issues/861