### PR TITLE
Prevent NetworkManager from interfering with Calico interfaces

### DIFF
--- a/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -178,6 +178,11 @@ storage:
              echo "Retry applying manifests"
              sleep 5
           done
+    - path: /etc/NetworkManager/conf.d/calico.conf
+      contents:
+        inline: |
+          [keyfile]
+          unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico
     - path: /etc/sysctl.d/max-user-watches.conf
       contents:
         inline: |

--- a/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
@@ -97,6 +97,11 @@ storage:
       contents:
         inline:
           ${domain_name}
+    - path: /etc/NetworkManager/conf.d/calico.conf
+      contents:
+        inline: |
+          [keyfile]
+          unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico
     - path: /etc/sysctl.d/max-user-watches.conf
       contents:
         inline: |
@@ -125,4 +130,3 @@ passwd:
     - name: core
       ssh_authorized_keys:
         - ${ssh_authorized_key}
-


### PR DESCRIPTION
Containers are losing network connectivity, when NetworkManager tries to manage the Calico `cali*` network interfaces. 

```
nmcli
...
cali1a81d481534: connecting (getting IP configuration) to Wired connection 3
        "cali1a81d481534"
        ethernet (veth), EE:EE:EE:EE:EE:EE, sw, mtu 1480
...
```

The fix is to add `/etc/NetworkManager/conf.d/calico.conf` as described in:

https://docs.projectcalico.org/maintenance/troubleshoot/troubleshooting#configure-networkmanager

After the fix and `systemctl restart NetworkManager`:

```
cali1a81d481534: unmanaged
        "cali1a81d481534"
        ethernet (veth), EE:EE:EE:EE:EE:EE, sw, mtu 1480
```