### PR TITLE
Remove outdated Terraform migration docs

### DIFF
--- a/docs/topics/maintenance.md
+++ b/docs/topics/maintenance.md
@@ -197,7 +197,7 @@ Typhoon modules have been updated for v0.13.x. Poseidon publishes [providers](/t
 
 | Typhoon Release   | Terraform version   |
 |-------------------|---------------------|
-| v1.21.3 - ?       | v0.13.x, v0.14.4+, v0.15.x, v1.0.x |
+| v1.21.2 - ?       | v0.13.x, v0.14.4+, v0.15.x, v1.0.x |
 | v1.21.1 - v1.21.1 | v0.13.x, v0.14.4+, v0.15.x |
 | v1.20.2 - v1.21.0 | v0.13.x, v0.14.4+   |
 | v1.20.0 - v1.20.2 | v0.13.x             |
@@ -207,77 +207,4 @@ Typhoon modules have been updated for v0.13.x. Poseidon publishes [providers](/t
 | v1.9.2 - v1.10.2  | v0.10.4+ or v0.11.x |
 | v1.7.3 - v1.9.1   | v0.10.x             |
 | v1.6.4 - v1.7.2   | v0.9.x              |
-
-### New Workspace
-
-With a new Terraform workspace, use Terraform v0.15.x and the updated Typhoon [tutorials](/fedora-coreos/aws/#provider).
-
-### Existing Workspace
-
-An existing Terraform workspace may already manage earlier Typhoon clusters created with Terraform v0.12.x.
-
-First, upgrade `terraform-provider-ct` to v0.6.1 following the [guide](#upgrade-terraform-provider-ct) above. As usual, read about how `apply` affects existing cluster nodes when `ct` is upgraded. But `terraform-provider-ct` v0.6.1 is compatible with both Terraform v0.12 and v0.13, so do this first.
-
-```tf
-provider "ct" {
-  version = "0.6.1"
-}
-```
-
-Next, create Typhoon clusters using the `ref` that introduced Terraform v0.13 forward compatibility (`v1.18.8`) or later. You will see a compatibility warning. Use blue/green cluster replacement to shift to these new clusters, then eliminate older clusters.
-
-```
-module "nemo" {
-  source = "git::https://github.com/poseidon/typhoon//digital-ocean/fedora-coreos/kubernetes?ref=v1.18.8"
-  ...
-}
-```
-
-Install Terraform v0.13. Once all clusters in a workspace are on `v1.18.8` or above, you are ready to start using Terraform v0.13.
-
-```
-terraform version
-v0.13.0
-```
-
-Update `providers.tf` to match the Typhoon [tutorials](/fedora-coreos/aws/#provider) and use new `required_providers` block.
-
-```
-terraform init
-terraform 0.13upgrade    # sometimes helpful
-```
-
-!!! note
-    You will see `Could not retrieve the list of available versions for provider -/ct: provider`
-
-In state files, existing clusters use Terraform v0.12 providers (e.g. `-/aws`). Pivot to Terraform v0.13 providers (e.g. `hashicorp/aws`) with the following commands, as applicable. Repeat until `terraform init` no longer shows old-style providers.
-
-```
-terraform state replace-provider -- -/aws hashicorp/aws
-terraform state replace-provider -- -/azurerm hashicorp/azurerm
-terraform state replace-provider -- -/google hashicorp/google
-
-terraform state replace-provider -- -/digitalocean digitalocean/digitalocean
-terraform state replace-provider -- -/ct poseidon/ct
-terraform state replace-provider -- -/matchbox poseidon/matchbox
-
-terraform state replace-provider -- -/local hashicorp/local
-terraform state replace-provider -- -/null hashicorp/null
-terraform state replace-provider -- -/random hashicorp/random
-terraform state replace-provider -- -/template hashicorp/template
-terraform state replace-provider -- -/tls hashicorp/tls
-```
-
-Finally, verify Terraform v0.13 plan shows no diff.
-
-```
-terraform plan
-No changes. Infrastructure is up-to-date.
-```
-
-### v0.12.x
-
-Terraform [v0.12](https://www.hashicorp.com/blog/announcing-terraform-0-12) introduced major changes to the provider plugin protocol and HCL language (first-class expressions, formal list and map types, nullable variables, variable constraints, and short-circuiting ternary operators).
-
-Typhoon modules have been adapted for Terraform v0.12. Provider plugins requirements now enforce v0.12 compatibility. However, some HCL language changes were breaking (list [type hint](https://www.terraform.io/upgrade-guides/0-12.html#referring-to-list-variables) workarounds in v0.11 now have new meaning). Typhoon cannot offer both v0.11 and v0.12 compatibility in the same release. Upcoming releases require upgrading Terraform to v0.12.
 


### PR DESCRIPTION
* Terraform v0.12.x and v0.13.x are now quite outdated, remove the migration docs
