### PR TITLE
Discontinue Docker automated build publishing

### DIFF
--- a/docs/topics/security.md
+++ b/docs/topics/security.md
@@ -62,9 +62,9 @@ The Kubelet image is published to Quay.io and Dockerhub.
 Two tag styles indicate the build strategy used.
 
 * Typhoon internal infra publishes single and multi-arch images (e.g. `v1.18.4`, `v1.18.4-amd64`, `v1.18.4-arm64`, `v1.18.4-2-g23228e6-amd64`, `v1.18.4-2-g23228e6-arm64`)
-* Quay and Dockerhub automated builds publish verifiable images (e.g. `build-SHA` on Quay, `build-TAG` on Dockerhub)
+* Quay automated builds publish verifiable images (e.g. `build-SHA` on Quay)
 
-The Typhoon-built Kubelet image is used as the official image. Automated builds provide an alternative image for those preferring to trust images built by Quay/Dockerhub (albeit lacking multi-arch). To use the fallback registry or an alternative tag, see [customization](/advanced/customization/#system-images).
+The Typhoon-built Kubelet image is used as the official image. Automated builds provide an alternative image for those preferring to trust images built by Quay (albeit lacking multi-arch). To use the fallback registry or an alternative tag, see [customization](/advanced/customization/#system-images).
 
 ### flannel-cni
 


### PR DESCRIPTION
* Poseidon infra publishes official multi-arch container images for Kubelet to both Quay and Dockerhub (fallback) and continues to do so. There are no changes to the official images used in Typhoon
* Automated builds by Quay and Dockerhub added separately tagged images for those not able to trust our own images and preferring to trust Quay/Dockerhub. Going forward, we're ending the use of Dockerhub automated builds. Docker has moved automated builds to paid plans, even for open source projects (we're not petitioning for a special exemption given these are our unofficial images, just not worth the hassle). Those still needing Kubelet images built externally (i.e. not Poseidon Labs) would still be able to use the Quay images tagged `build-SHA`

Blog: https://www.docker.com/blog/changes-to-docker-hub-autobuilds/