### PR TITLE
Use official Fedora CoreOS AMI for aarch64

### DIFF
--- a/aws/fedora-coreos/kubernetes/ami.tf
+++ b/aws/fedora-coreos/kubernetes/ami.tf
@@ -18,15 +18,11 @@ data "aws_ami" "fedora-coreos" {
     values = ["Fedora CoreOS ${var.os_stream} *"]
   }
 }
-
-# Experimental Fedora CoreOS arm64 / aarch64 AMIs from Poseidon
-# WARNING: These AMIs will be removed when Fedora CoreOS publishes arm64 AMIs
-# and may be removed for any reason before then as well. Do not use.
 data "aws_ami" "fedora-coreos-arm" {
   count = var.arch == "arm64" ? 1 : 0
 
   most_recent = true
-  owners      = ["099663496933"]
+  owners      = ["125523088429"]
 
   filter {
     name   = "architecture"
@@ -39,8 +35,7 @@ data "aws_ami" "fedora-coreos-arm" {
   }
 
   filter {
-    name   = "name"
-    values = ["fedora-coreos-*"]
+    name   = "description"
+    values = ["Fedora CoreOS ${var.os_stream} *"]
   }
 }
-


### PR DESCRIPTION
High level description of the change.

* Use upstream ami for aarch64 Fedora CoreOS repo as the Fedora CoreOS team has starting publish images.

## Testing

`aws ec2 describe-images --owners 125523088429 --filters "Name=architecture,Values=arm64" "Name=description,Values=*Fedora CoreOS*"`

rel: https://github.com/coreos/fedora-coreos-tracker/issues/541 https://getfedora.org/en/coreos?stream=stable
