### PR TITLE
Update Terraform provider poseidon/matchbox to v0.5+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between versions.
 
 ## Latest
 
+### Bare-Metal
+
+* Require Terraform provider `poseidon/matchbox` v0.5+
+
 ### Addons
 
 * Update nginx-ingress from v1.0.0 to [v1.0.1](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.0.1)

--- a/bare-metal/fedora-coreos/kubernetes/versions.tf
+++ b/bare-metal/fedora-coreos/kubernetes/versions.tf
@@ -13,7 +13,7 @@ terraform {
 
     matchbox = {
       source  = "poseidon/matchbox"
-      version = "~> 0.4.1"
+      version = "~> 0.5.0"
     }
   }
 }

--- a/bare-metal/flatcar-linux/kubernetes/versions.tf
+++ b/bare-metal/flatcar-linux/kubernetes/versions.tf
@@ -13,7 +13,7 @@ terraform {
 
     matchbox = {
       source  = "poseidon/matchbox"
-      version = "~> 0.4.1"
+      version = "~> 0.5.0"
     }
   }
 }

--- a/docs/fedora-coreos/bare-metal.md
+++ b/docs/fedora-coreos/bare-metal.md
@@ -142,7 +142,7 @@ terraform {
     }
     matchbox = {
       source = "poseidon/matchbox"
-      version = "0.4.1"
+      version = "0.5.0"
     }
   }
 }

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -142,7 +142,7 @@ terraform {
     }
     matchbox = {
       source = "poseidon/matchbox"
-      version = "0.4.1"
+      version = "0.5.0"
     }
   }
 }


### PR DESCRIPTION
* Relax version constraint to allow future minor version releases to be used without a corresponding Typhoon change