### PR TITLE
Update Calico from v3.20.1 to v3.20.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Notable changes between versions.
 
 ## Latest
 
+* Update Calico from v3.20.1 to [v3.20.2](https://github.com/projectcalico/calico/releases/tag/v3.20.2)
+* Use Calico's iptables legacy vs nft auto-detection
+
 ### Bare-Metal
 
 * Require Terraform provider `poseidon/matchbox` v0.5+

--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c6fa09bda1d6328aed034223cf2a97ba74ede097"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0b102c40895361bfe0cf7511a55bd75e8c648460"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]


### PR DESCRIPTION
* Use Calico's iptables legacy vs nft auto-detection