### PR TITLE
Change default `disk_iops` from unset to 3000

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,16 @@ Notable changes between versions.
 
 ## Latest
 
+### AWS
+
+* Change controller node default `disk_iops` to 3000 [#1073](https://github.com/poseidon/typhoon/pull/1073)
+
+### Fedora CoreOS
+
+* Fix Fedora ARM64 workers to official Fedora CoreOS AMIs [#1072](https://github.com/poseidon/typhoon/pull/1072)
+  * Should have been changed alongside controller AMIs in [#1038](https://github.com/poseidon/typhoon/pull/1038)
+  * Old Posidon built ARM64 AMIs have been deleted
+
 ## v1.22.4
 
 * Kubernetes [v1.22.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#v1224)

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -66,8 +66,8 @@ variable "disk_type" {
 
 variable "disk_iops" {
   type        = number
-  description = "IOPS of the EBS volume (e.g. 100)"
-  default     = 0
+  description = "IOPS of the EBS volume (e.g. 3000)"
+  default     = 3000
 }
 
 variable "worker_price" {


### PR DESCRIPTION
* Since v1.21.3 switched controllers default disk type from `gp2` to `gp3`, an iops diff has been shown (harmless, but
annoying)
* Controller nodes default to a 30GB `gp3` disk. `gp3` disks do respect `iops` and the corresponding default is 3000