### PR TITLE
Update minimum Terraform provider versions

### DIFF
--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/aws/fedora-coreos/kubernetes/versions.tf
+++ b/aws/fedora-coreos/kubernetes/versions.tf
@@ -4,8 +4,8 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     aws      = ">= 2.23, <= 4.0"
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = ">= 2.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/aws/fedora-coreos/kubernetes/workers/versions.tf
+++ b/aws/fedora-coreos/kubernetes/workers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     aws      = ">= 2.23, <= 4.0"
-    template = "~> 2.1"
+    template = "~> 2.2"
 
     ct = {
       source  = "poseidon/ct"

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/aws/flatcar-linux/kubernetes/versions.tf
+++ b/aws/flatcar-linux/kubernetes/versions.tf
@@ -4,8 +4,8 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     aws      = ">= 2.23, <= 4.0"
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = ">= 2.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/aws/flatcar-linux/kubernetes/workers/versions.tf
+++ b/aws/flatcar-linux/kubernetes/workers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     aws      = ">= 2.23, <= 4.0"
-    template = "~> 2.1"
+    template = "~> 2.2"
 
     ct = {
       source  = "poseidon/ct"

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/fedora-coreos/kubernetes/versions.tf
+++ b/azure/fedora-coreos/kubernetes/versions.tf
@@ -4,8 +4,8 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     azurerm  = "~> 2.8"
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = ">= 2.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/azure/fedora-coreos/kubernetes/workers/versions.tf
+++ b/azure/fedora-coreos/kubernetes/workers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     azurerm  = "~> 2.8"
-    template = "~> 2.1"
+    template = "~> 2.2"
 
     ct = {
       source  = "poseidon/ct"

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/flatcar-linux/kubernetes/versions.tf
+++ b/azure/flatcar-linux/kubernetes/versions.tf
@@ -4,8 +4,8 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     azurerm  = "~> 2.8"
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = ">= 2.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/azure/flatcar-linux/kubernetes/workers/versions.tf
+++ b/azure/flatcar-linux/kubernetes/workers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     azurerm  = "~> 2.8"
-    template = "~> 2.1"
+    template = "~> 2.2"
 
     ct = {
       source  = "poseidon/ct"

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/bare-metal/fedora-coreos/kubernetes/versions.tf
+++ b/bare-metal/fedora-coreos/kubernetes/versions.tf
@@ -3,8 +3,8 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = ">= 2.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/bare-metal/flatcar-linux/kubernetes/versions.tf
+++ b/bare-metal/flatcar-linux/kubernetes/versions.tf
@@ -3,8 +3,8 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = ">= 2.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/digital-ocean/fedora-coreos/kubernetes/versions.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/versions.tf
@@ -3,8 +3,8 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = ">= 2.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/digital-ocean/flatcar-linux/kubernetes/versions.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/versions.tf
@@ -3,8 +3,8 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = ">= 2.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/docs/fedora-coreos/aws.md
+++ b/docs/fedora-coreos/aws.md
@@ -51,11 +51,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     aws = {
       source = "hashicorp/aws"
-      version = "3.48.0"
+      version = "3.67.0"
     }
   }
 }

--- a/docs/fedora-coreos/azure.md
+++ b/docs/fedora-coreos/azure.md
@@ -48,11 +48,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "2.68.0"
+      version = "2.88.1"
     }
   }
 }

--- a/docs/fedora-coreos/bare-metal.md
+++ b/docs/fedora-coreos/bare-metal.md
@@ -138,7 +138,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     matchbox = {
       source = "poseidon/matchbox"

--- a/docs/fedora-coreos/digitalocean.md
+++ b/docs/fedora-coreos/digitalocean.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     digitalocean = {
       source = "digitalocean/digitalocean"

--- a/docs/fedora-coreos/google-cloud.md
+++ b/docs/fedora-coreos/google-cloud.md
@@ -52,11 +52,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     google = {
       source = "hashicorp/google"
-      version = "3.75.0"
+      version = "4.3.0"
     }
   }
 }

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -51,11 +51,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     aws = {
       source = "hashicorp/aws"
-      version = "3.48.0"
+      version = "3.67.0"
     }
   }
 }

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -48,11 +48,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "2.68.0"
+      version = "2.88.1"
     }
   }
 }

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -138,7 +138,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     matchbox = {
       source = "poseidon/matchbox"

--- a/docs/flatcar-linux/digitalocean.md
+++ b/docs/flatcar-linux/digitalocean.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     digitalocean = {
       source = "digitalocean/digitalocean"

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -52,11 +52,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.0"
+      version = "0.9.1"
     }
     google = {
       source = "hashicorp/google"
-      version = "3.75.0"
+      version = "4.3.0"
     }
   }
 }

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/fedora-coreos/kubernetes/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/versions.tf
@@ -4,8 +4,8 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     google   = ">= 2.19, < 5.0"
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = "~> 3.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     google   = ">= 2.19, < 5.0"
-    template = "~> 2.1"
+    template = "~> 2.2"
 
     ct = {
       source  = "poseidon/ct"

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5353769db663814d3d91346068f3222709e1c0cd"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=cb1f4410ed8e5793622406e4faa5d1abf2dd0829"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/flatcar-linux/kubernetes/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/versions.tf
@@ -4,8 +4,8 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     google   = ">= 2.19, < 5.0"
-    template = "~> 2.1"
-    null     = "~> 2.1"
+    template = "~> 2.2"
+    null     = ">= 2.1"
 
     ct = {
       source  = "poseidon/ct"

--- a/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     google   = ">= 2.19, < 5.0"
-    template = "~> 2.1"
+    template = "~> 2.2"
 
     ct = {
       source  = "poseidon/ct"


### PR DESCRIPTION
* Update `null` provider to allow use of v3.1.x releases, instead of being stuck on v2.1.2
* Document the recommended versions of Terraform cloud providers
* Update min versions in terraform-render-boostrap https://github.com/poseidon/terraform-render-bootstrap/pull/287