### PR TITLE
Change default disk_iops on Flatcar Linux

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,12 @@ Notable changes between versions.
 
 ### AWS
 
-* Change controller node default `disk_iops` to 3000 [#1073](https://github.com/poseidon/typhoon/pull/1073)
+* Change controller node default `disk_iops` to 3000 ([#1073](https://github.com/poseidon/typhoon/pull/1073))
 
 ### Fedora CoreOS
 
-* Fix Fedora ARM64 workers to official Fedora CoreOS AMIs [#1072](https://github.com/poseidon/typhoon/pull/1072)
-  * Should have been changed alongside controller AMIs in [#1038](https://github.com/poseidon/typhoon/pull/1038)
+* Fix Fedora ARM64 workers to official Fedora CoreOS AMIs ([#1072](https://github.com/poseidon/typhoon/pull/1072))
+  * Should have been changed alongside controller AMIs in ([#1038](https://github.com/poseidon/typhoon/pull/1038))
   * Old Posidon built ARM64 AMIs have been deleted
 
 ## v1.22.4

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -66,8 +66,8 @@ variable "disk_type" {
 
 variable "disk_iops" {
   type        = number
-  description = "IOPS of the EBS volume (e.g. 100)"
-  default     = 0
+  description = "IOPS of the EBS volume (e.g. 3000)"
+  default     = 3000
 }
 
 variable "worker_price" {


### PR DESCRIPTION
* Same as #1073, but for Flatcar Linux on AWS as well