### PR TITLE
Workaround Terraform v1.1 file provisioner regression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Notable changes between versions.
 ## Latest
 
 * Kubernetes [v1.23.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1231)
+* Workaround Terraform v1.1 regression in `file` provisioner ([#1093](https://github.com/poseidon/typhoon/pull/1093))
 
 ### Flatcar Linux
 

--- a/aws/fedora-coreos/kubernetes/ssh.tf
+++ b/aws/fedora-coreos/kubernetes/ssh.tf
@@ -24,7 +24,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {

--- a/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/aws/flatcar-linux/kubernetes/ssh.tf
@@ -24,7 +24,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {

--- a/azure/fedora-coreos/kubernetes/ssh.tf
+++ b/azure/fedora-coreos/kubernetes/ssh.tf
@@ -25,7 +25,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {

--- a/azure/flatcar-linux/kubernetes/ssh.tf
+++ b/azure/flatcar-linux/kubernetes/ssh.tf
@@ -25,7 +25,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {

--- a/bare-metal/fedora-coreos/kubernetes/ssh.tf
+++ b/bare-metal/fedora-coreos/kubernetes/ssh.tf
@@ -28,17 +28,17 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = module.bootstrap.kubeconfig-kubelet
-    destination = "$HOME/kubeconfig"
+    destination = "/home/core/kubeconfig"
   }
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
       "sudo touch /etc/kubernetes",
       "sudo /opt/bootstrap/layout",
     ]
@@ -65,12 +65,12 @@ resource "null_resource" "copy-worker-secrets" {
 
   provisioner "file" {
     content     = module.bootstrap.kubeconfig-kubelet
-    destination = "$HOME/kubeconfig"
+    destination = "/home/core/kubeconfig"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
       "sudo touch /etc/kubernetes",
     ]
   }

--- a/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -29,17 +29,17 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = module.bootstrap.kubeconfig-kubelet
-    destination = "$HOME/kubeconfig"
+    destination = "/home/core/kubeconfig"
   }
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
       "sudo /opt/bootstrap/layout",
     ]
   }
@@ -66,12 +66,12 @@ resource "null_resource" "copy-worker-secrets" {
 
   provisioner "file" {
     content     = module.bootstrap.kubeconfig-kubelet
-    destination = "$HOME/kubeconfig"
+    destination = "/home/core/kubeconfig"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
     ]
   }
 }

--- a/digital-ocean/fedora-coreos/kubernetes/ssh.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/ssh.tf
@@ -25,17 +25,17 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = module.bootstrap.kubeconfig-kubelet
-    destination = "$HOME/kubeconfig"
+    destination = "/home/core/kubeconfig"
   }
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
       "sudo touch /etc/kubernetes",
       "sudo /opt/bootstrap/layout",
     ]
@@ -55,12 +55,12 @@ resource "null_resource" "copy-worker-secrets" {
 
   provisioner "file" {
     content     = module.bootstrap.kubeconfig-kubelet
-    destination = "$HOME/kubeconfig"
+    destination = "/home/core/kubeconfig"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
       "sudo touch /etc/kubernetes",
     ]
   }

--- a/digital-ocean/flatcar-linux/kubernetes/ssh.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/ssh.tf
@@ -25,17 +25,17 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = module.bootstrap.kubeconfig-kubelet
-    destination = "$HOME/kubeconfig"
+    destination = "/home/core/kubeconfig"
   }
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
       "sudo /opt/bootstrap/layout",
     ]
   }
@@ -54,12 +54,12 @@ resource "null_resource" "copy-worker-secrets" {
 
   provisioner "file" {
     content     = module.bootstrap.kubeconfig-kubelet
-    destination = "$HOME/kubeconfig"
+    destination = "/home/core/kubeconfig"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",
     ]
   }
 }

--- a/google-cloud/fedora-coreos/kubernetes/ssh.tf
+++ b/google-cloud/fedora-coreos/kubernetes/ssh.tf
@@ -24,7 +24,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {

--- a/google-cloud/flatcar-linux/kubernetes/ssh.tf
+++ b/google-cloud/flatcar-linux/kubernetes/ssh.tf
@@ -24,7 +24,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   provisioner "file" {
     content     = join("\n", local.assets_bundle)
-    destination = "$HOME/assets"
+    destination = "/home/core/assets"
   }
 
   provisioner "remote-exec" {


### PR DESCRIPTION
* Terraform v1.1 changed the behavior of provisioners and `remote-exec` in a way that breaks support for expansions in commands (including file provisioner, where `destination` is part of an `scp` command)
* Terraform will likely revert the change eventually, but I suspect it will take a while
* Instead, we can stop relying on Terraform's expansion behavior. `/home/core` is a suitable choice for `$HOME` on both Flatcar Linux and Fedora CoreOS (harldink `/var/home/core`)

Rel: https://github.com/hashicorp/terraform/issues/30243
Closes #1091