### PR TITLE
Remove unused ETCD_UNSUPPORTED_ARCH variable

### DIFF
--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -220,7 +220,6 @@ storage:
           ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt
           ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key
           ETCD_PEER_CLIENT_CERT_AUTH=true
-          ETCD_UNSUPPORTED_ARCH=arm64
     - path: /etc/fedora-coreos/iptables-legacy.stamp
     - path: /etc/containerd/config.toml
       overwrite: true


### PR DESCRIPTION
* etcd used to require a special variable to use the arm64 container image, but this is no longer required