### PR TITLE
Mask docker.service to prevent socket activation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,12 +7,13 @@ Notable changes between versions.
 ### Fedora CoreOS
 
 * Switch Kubernetes Container Runtime from `docker` to `containerd` ([#1101](https://github.com/poseidon/typhoon/pull/1101))
+* Mask `docker.service` to prevent it from being socket activated ([#1105](https://github.com/poseidon/typhoon/pull/1105))
 
 ### Flatcar Linux
 
 #### AWS
 
-* Add experimental Flatcar Linux ARM64 support ([#1102](https://github.com/poseidon/typhoon/pull/1102))
+* Add experimental Flatcar Linux ARM64 support ([docs](https://typhoon.psdn.io/advanced/arm64/), [#1102](https://github.com/poseidon/typhoon/pull/1102))
   * Add `arch` variable to AWS `kubernetes` and `workers` modules
   * Allow arm64 full-cluster or mixed/hybrid cluster with arm64 workers
   * Requires `flannel` or `cilium` CNI provider

--- a/aws/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -31,6 +31,8 @@ systemd:
         WantedBy=multi-user.target
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |

--- a/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -5,6 +5,8 @@ systemd:
   units:
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |

--- a/azure/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -31,6 +31,8 @@ systemd:
         WantedBy=multi-user.target
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |

--- a/azure/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/azure/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -5,6 +5,8 @@ systemd:
   units:
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |

--- a/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -31,6 +31,8 @@ systemd:
         WantedBy=multi-user.target
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |

--- a/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/fcc/worker.yaml
@@ -5,6 +5,8 @@ systemd:
   units:
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |

--- a/digital-ocean/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -31,6 +31,8 @@ systemd:
         WantedBy=multi-user.target
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |

--- a/digital-ocean/fedora-coreos/kubernetes/fcc/worker.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/fcc/worker.yaml
@@ -5,6 +5,8 @@ systemd:
   units:
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |

--- a/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/fcc/controller.yaml
@@ -31,6 +31,8 @@ systemd:
         WantedBy=multi-user.target
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |

--- a/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/fcc/worker.yaml
@@ -5,6 +5,8 @@ systemd:
   units:
     - name: containerd.service
       enabled: true
+    - name: docker.service
+      mask: true
     - name: wait-for-dns.service
       enabled: true
       contents: |


### PR DESCRIPTION
* Kubelet now uses `containerd` as the container runtime, but `docker.service` still starts when `docker.sock` is probed bc
the service is socket activated. Prevent this by masking the `docker.service` unit
