### PR TITLE
Switch to using Flatcar Linux images on Google Cloud

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,14 @@ Notable changes between versions.
 
 * Kubernetes [v1.23.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1233)
 
+### Flatcar Linux
+
+#### Google Cloud
+
+* Switch to using official Kinvolk Flatcar Linux images
+* Promote Typhoon on Flatcar Linux / Google Cloud to stable
+* Change `os_image` to `flatcar-stable`, `flatcar-beta`, or `flatcar-alpha` (**action required**)
+
 ## v1.23.2
 
 * Kubernetes [v1.23.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1232)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Typhoon is available for [Flatcar Linux](https://www.flatcar-linux.org/releases/
 | Azure         | Flatcar Linux    | [azure/flatcar-linux/kubernetes](azure/flatcar-linux/kubernetes) | alpha |
 | Bare-Metal    | Flatcar Linux    | [bare-metal/flatcar-linux/kubernetes](bare-metal/flatcar-linux/kubernetes) | stable |
 | DigitalOcean | Flatcar Linux  | [digital-ocean/flatcar-linux/kubernetes](digital-ocean/flatcar-linux/kubernetes) | beta |
-| Google Cloud  | Flatcar Linux  | [google-cloud/flatcar-linux/kubernetes](google-cloud/flatcar-linux/kubernetes) | beta |
+| Google Cloud  | Flatcar Linux  | [google-cloud/flatcar-linux/kubernetes](google-cloud/flatcar-linux/kubernetes) | stable |
 
 | Platform      | Operating System | Terraform Module | Status |
 |---------------|------------------|------------------|--------|

--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -246,7 +246,7 @@ Create a cluster following the Google Cloud [tutorial](../flatcar-linux/google-c
       # optional
       worker_count = 2
       machine_type = "n1-standard-16"
-      os_image     = "flatcar-linux-2303-4-0"    # custom
+      os_image     = "flatcar-stable"
       preemptible  = true
     }
     ```

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -67,25 +67,6 @@ Additional configuration options are described in the `google` provider [docs](h
 !!! tip
     Regions are listed in [docs](https://cloud.google.com/compute/docs/regions-zones/regions-zones) or with `gcloud compute regions list`. A project may contain multiple clusters across different regions.
 
-### Flatcar Linux Images
-
-Flatcar Linux publishes Google Cloud images, but does not yet upload them. Google Cloud allows [custom boot images](https://cloud.google.com/compute/docs/images/import-existing-image) to be uploaded to a bucket and imported into your project.
-
-[Download](https://www.flatcar-linux.org/releases/) the Flatcar Linux GCE gzipped tarball and upload it to a Google Cloud storage bucket.
-
-```
-gsutil list
-gsutil cp flatcar_production_gce.tar.gz gs://BUCKET
-```
-
-Create a Compute Engine image from the file.
-
-```
-gcloud compute images create flatcar-linux-2303-4-0 --source-uri gs://BUCKET_NAME/flatcar_production_gce.tar.gz
-```
-
-Set the [os_image](#variables) in the next step.
-
 ## Cluster
 
 Define a Kubernetes cluster using the module `google-cloud/flatcar-linux/kubernetes`.
@@ -101,7 +82,6 @@ module "yavin" {
   dns_zone_name = "example-zone"
 
   # configuration
-  os_image           = "flatcar-linux-2303-4-0"
   ssh_authorized_key = "ssh-rsa AAAAB3Nz..."
 
   # optional
@@ -206,7 +186,6 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/google-
 | region | Google Cloud region | "us-central1" |
 | dns_zone | Google Cloud DNS zone | "google-cloud.example.com" |
 | dns_zone_name | Google Cloud DNS zone name | "example-zone" |
-| os_image | Container Linux image for compute instances | "flatcar-linux-2303-4-0" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3NZ..." |
 
 Check the list of valid [regions](https://cloud.google.com/compute/docs/regions-zones/regions-zones) and list Container Linux [images](https://cloud.google.com/compute/docs/images) with `gcloud compute images list | grep coreos`.
@@ -236,6 +215,7 @@ resource "google_dns_managed_zone" "zone-for-clusters" {
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | Machine type for controllers | "n1-standard-1" | See below |
 | worker_type | Machine type for workers | "n1-standard-1" | See below |
+| os_image | Flatcar Linux image for compute instances | "flatcar-stable" | flatcar-stable, flatcar-beta, flatcar-alpha |
 | disk_size | Size of the disk in GB | 30 | 100 |
 | worker_preemptible | If enabled, Compute Engine will terminate workers randomly within 24 hours | false | true |
 | controller_snippets | Controller Container Linux Config snippets | [] | [example](/advanced/customization/) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ Typhoon is available for [Flatcar Linux](https://www.flatcar-linux.org/releases/
 | Azure         | Flatcar Linux    | [azure/flatcar-linux/kubernetes](flatcar-linux/azure.md) | alpha |
 | Bare-Metal    | Flatcar Linux    | [bare-metal/flatcar-linux/kubernetes](flatcar-linux/bare-metal.md) | stable |
 | DigitalOcean | Flatcar Linux  | [digital-ocean/flatcar-linux/kubernetes](flatcar-linux/digitalocean.md) | beta |
-| Google Cloud  | Flatcar Linux  | [google-cloud/flatcar-linux/kubernetes](flatcar-linux/google-cloud.md) | beta |
+| Google Cloud  | Flatcar Linux  | [google-cloud/flatcar-linux/kubernetes](flatcar-linux/google-cloud.md) | stable |
 
 | Platform      | Operating System | Terraform Module | Status |
 |---------------|------------------|------------------|--------|

--- a/google-cloud/flatcar-linux/kubernetes/controllers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/controllers.tf
@@ -42,7 +42,7 @@ resource "google_compute_instance" "controllers" {
     auto_delete = true
 
     initialize_params {
-      image = var.os_image
+      image = data.google_compute_image.flatcar-linux.self_link
       size  = var.disk_size
     }
   }

--- a/google-cloud/flatcar-linux/kubernetes/image.tf
+++ b/google-cloud/flatcar-linux/kubernetes/image.tf
@@ -1,0 +1,6 @@
+# Flatcar Linux most recent image from channel
+data "google_compute_image" "flatcar-linux" {
+  project = "kinvolk-public"
+  family  = "${var.os_image}"
+}
+

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -48,7 +48,13 @@ variable "worker_type" {
 
 variable "os_image" {
   type        = string
-  description = "Flatcar Linux image for compute instances (e.g. custom-image)"
+  description = "Flatcar Linux image for compute instances (flatcar-stable, flatcar-beta, flatcar-alpha)"
+  default     = "flatcar-stable"
+
+  validation {
+    condition     = contains(["flatcar-stable", "flatcar-beta", "flatcar-alpha"], var.os_image)
+    error_message = "The os_image must be flatcar-stable, flatcar-beta, or flatcar-alpha."
+  }
 }
 
 variable "disk_size" {

--- a/google-cloud/flatcar-linux/kubernetes/workers/image.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/image.tf
@@ -1,0 +1,5 @@
+# Flatcar Linux most recent image from channel
+data "google_compute_image" "flatcar-linux" {
+  project = "kinvolk-public"
+  family  = "${var.os_image}"
+}

--- a/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
@@ -36,7 +36,13 @@ variable "machine_type" {
 
 variable "os_image" {
   type        = string
-  description = "Flatcar Linux image for compute instanges (e.g. gcloud compute images list)"
+  description = "Flatcar Linux image for compute instances (flatcar-stable, flatcar-beta, flatcar-alpha)"
+  default     = "flatcar-stable"
+
+  validation {
+    condition     = contains(["flatcar-stable", "flatcar-beta", "flatcar-alpha"], var.os_image)
+    error_message = "The os_image must be flatcar-stable, flatcar-beta, or flatcar-alpha."
+  }
 }
 
 variable "disk_size" {

--- a/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
@@ -43,7 +43,7 @@ resource "google_compute_instance_template" "worker" {
   disk {
     auto_delete  = true
     boot         = true
-    source_image = var.os_image
+    source_image = data.google_compute_image.flatcar-linux.self_link
     disk_size_gb = var.disk_size
   }
 


### PR DESCRIPTION
* Use the official Kinvolk Flatcar Linux image on Google Cloud
* Change `os_image` from a custom image name to `flatcar-stable` (default), `flatcar-beta`, or `flatcar-alpha` (**action required**)
* Change `os_image` from a required to an optional variable
* Promote Typhoon on Flatcar Linux / Google Cloud to stable
* Remove docs about needing to upload a Flatcar Linux image manually on Google Cloud and drop support for custom images