### PR TITLE
Fix Flatcar Linux nodes on Google Cloud not ignoring image changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@ Notable changes between versions.
 * Allow upgrading Azure Terraform provider to v3.x ([#1144](https://github.com/poseidon/typhoon/pull/1144))
 * Rename `worker_address_prefix` output to `worker_address_prefixes`
 
+### Google Cloud
+
+* Fix issue on Flatcar Linux with controller nodes not ignoring os image changes
+  * Nodes will auto-update, Terraform should not attempt to delete/recreate them
+
 ### Addons
 
 * Update nginx-ingress from v1.1.2 to [v1.1.3](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.1.3)

--- a/google-cloud/flatcar-linux/kubernetes/controllers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/controllers.tf
@@ -59,7 +59,10 @@ resource "google_compute_instance" "controllers" {
   tags           = ["${var.cluster_name}-controller"]
 
   lifecycle {
-    ignore_changes = [metadata]
+    ignore_changes = [
+      metadata,
+      boot_disk[0].initialize_params
+    ]
   }
 }
 


### PR DESCRIPTION
* Add `boot_disk[0].initialize_params` to the ignored fields for the controller nodes
* Nodes will auto-update, Terraform should not attempt to delete and recreate nodes (especially controllers!). Lack of this ignore causes
Terraform to propose deleting controller nodes when Flatcar Linux releases new images
* Matches the configuration on Typhoon Fedora CoreOS (which does not have the issue)