### PR TITLE
Update Prometheus, Grafana, and ingress-nginx addons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,13 @@ Notable changes between versions.
 
 ## Latest
 
+* Kubernetes [v1.24.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#v1243)
+
 ### Addons
 
-* Update Prometheus from v2.36.1 to [v2.36.2](https://github.com/prometheus/prometheus/releases/tag/v2.36.2)
-* Update Grafana from v8.5.6 to [v9.0.2](https://github.com/grafana/grafana/releases/tag/v9.0.2)
+* Update ingress-nginx from v1.2.1 to [v1.3.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.3.0)
+* Update Prometheus from v2.36.1 to [v2.37.0](https://github.com/prometheus/prometheus/releases/tag/v2.37.0)
+* Update Grafana from v8.5.6 to [v9.0.3](https://github.com/grafana/grafana/releases/tag/v9.0.3)
 
 ## v1.24.2
 
@@ -34,7 +37,7 @@ Notable changes between versions.
 
 * Update Prometheus from v2.35.0 to [v2.36.0](https://github.com/prometheus/prometheus/releases/tag/v2.36.0)
 * Update Grafana from v8.5.1 to [v8.5.3](https://github.com/grafana/grafana/releases/tag/v8.5.3)
-* Update nginx-ingress from v1.2.1 to [v1.2.1](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.2.1)
+* Update nginx-ingress from v1.2.0 to [v1.2.1](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.2.1)
 
 ## v1.24.0
 

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: grafana
-          image: docker.io/grafana/grafana:9.0.2
+          image: docker.io/grafana/grafana:9.0.3
           env:
             - name: GF_PATHS_CONFIG
               value: "/etc/grafana/custom.ini"

--- a/addons/nginx-ingress/aws/deployment.yaml
+++ b/addons/nginx-ingress/aws/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.2.1
+          image: k8s.gcr.io/ingress-nginx/controller:v1.3.0
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/nginx-ingress/aws/rbac/role.yaml
+++ b/addons/nginx-ingress/aws/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
       - configmaps
       - pods
       - secrets
+      - endpoints
     verbs:
       - get
   - apiGroups:
@@ -37,3 +38,11 @@ rules:
       - endpoints
     verbs:
       - get
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update

--- a/addons/nginx-ingress/azure/deployment.yaml
+++ b/addons/nginx-ingress/azure/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.2.1
+          image: k8s.gcr.io/ingress-nginx/controller:v1.3.0
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/nginx-ingress/azure/rbac/role.yaml
+++ b/addons/nginx-ingress/azure/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
       - configmaps
       - pods
       - secrets
+      - endpoints
     verbs:
       - get
   - apiGroups:
@@ -32,8 +33,11 @@ rules:
     verbs:
       - create
   - apiGroups:
-      - ""
+      - "coordination.k8s.io"
     resources:
-      - endpoints
+      - leases
     verbs:
+      - create
       - get
+      - update
+

--- a/addons/nginx-ingress/bare-metal/deployment.yaml
+++ b/addons/nginx-ingress/bare-metal/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.2.1
+          image: k8s.gcr.io/ingress-nginx/controller:v1.3.0
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/nginx-ingress/bare-metal/rbac/role.yaml
+++ b/addons/nginx-ingress/bare-metal/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
       - configmaps
       - pods
       - secrets
+      - endpoints
     verbs:
       - get
   - apiGroups:
@@ -32,8 +33,10 @@ rules:
     verbs:
       - create
   - apiGroups:
-      - ""
+      - "coordination.k8s.io"
     resources:
-      - endpoints
+      - leases
     verbs:
+      - create
       - get
+      - update

--- a/addons/nginx-ingress/digital-ocean/daemonset.yaml
+++ b/addons/nginx-ingress/digital-ocean/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.2.1
+          image: k8s.gcr.io/ingress-nginx/controller:v1.3.0
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/nginx-ingress/digital-ocean/rbac/role.yaml
+++ b/addons/nginx-ingress/digital-ocean/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
       - configmaps
       - pods
       - secrets
+      - endpoints
     verbs:
       - get
   - apiGroups:
@@ -32,8 +33,10 @@ rules:
     verbs:
       - create
   - apiGroups:
-      - ""
+      - "coordination.k8s.io"
     resources:
-      - endpoints
+      - leases
     verbs:
+      - create
       - get
+      - update

--- a/addons/nginx-ingress/google-cloud/deployment.yaml
+++ b/addons/nginx-ingress/google-cloud/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.2.1
+          image: k8s.gcr.io/ingress-nginx/controller:v1.3.0
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/nginx-ingress/google-cloud/rbac/role.yaml
+++ b/addons/nginx-ingress/google-cloud/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
       - configmaps
       - pods
       - secrets
+      - endpoints
     verbs:
       - get
   - apiGroups:
@@ -32,8 +33,10 @@ rules:
     verbs:
       - create
   - apiGroups:
-      - ""
+      - "coordination.k8s.io"
     resources:
-      - endpoints
+      - leases
     verbs:
+      - create
       - get
+      - update

--- a/addons/prometheus/deployment.yaml
+++ b/addons/prometheus/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: quay.io/prometheus/prometheus:v2.36.2
+          image: quay.io/prometheus/prometheus:v2.37.0
           args:
             - --web.listen-address=0.0.0.0:9090
             - --config.file=/etc/prometheus/prometheus.yaml


### PR DESCRIPTION
* Update ingress-nginx RBAC Role to include coordination.k8s.io leases permissions that are required with ingress-nginx v1.3.0
