### PR TITLE
Fix bug provisioning multi-controller clusters on Google Cloud

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,11 @@ Notable changes between versions.
 ## Latest
 
 * Update Calico from v3.23.1 to [v3.23.3](https://github.com/projectcalico/calico/releases/tag/v3.23.3)
-* Remove use of deprecated Terraform [template](https://registry.terraform.io/providers/hashicorp/template) provider
+* Remove use of deprecated Terraform [template](https://registry.terraform.io/providers/hashicorp/template) provider ([#1194](https://github.com/poseidon/typhoon/pull/1194))
+
+### Google
+
+* Fix bug provisioning clusters with multiple controller nodes ([#1195](https://github.com/poseidon/typhoon/pull/1195))
 
 ## v1.24.3
 

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -4,7 +4,7 @@ module "bootstrap" {
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers          = google_dns_record_set.etcds.*.name
+  etcd_servers          = [for fqdn in google_dns_record_set.etcds.*.name : trimsuffix(fqdn, ".")]
   networking            = var.networking
   network_mtu           = 1440
   pod_cidr              = var.pod_cidr

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -4,7 +4,7 @@ module "bootstrap" {
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers          = google_dns_record_set.etcds.*.name
+  etcd_servers          = [for fqdn in google_dns_record_set.etcds.*.name : trimsuffix(fqdn, ".")]
   networking            = var.networking
   network_mtu           = 1440
   pod_cidr              = var.pod_cidr


### PR DESCRIPTION
* Google Cloud Terraform provider resource google_dns_record_set's name field provides the full domain name with a trailing ".". This isn't a new behavior, Google has behaved this way as long as I can remember
* etcd domain names are passed to the bootstrap module to generate TLS certificates. What seems to be new(ish?) is that etcd peers see `example.foo` and `example.foo.` as different domains during TLS SANs validation. As a result, clusters with multiple controller nodes fail to run etcd-member, which manifests as cluster provisioning hanging. Single controller/master clusters (default) are unaffected
* Fix etcd-member.service error in multi-controller clusters:

```
"error":"x509: certificate is valid for conformance-etcd0.redacted.,
conform-etcd1.redacted., conform-etcd2.redacted., not conform-etcd1.redacted"}
```