### PR TITLE
Update node-exporter DaemonSet to fix permission denied

### DIFF
--- a/addons/prometheus/exporters/node-exporter/daemonset.yaml
+++ b/addons/prometheus/exporters/node-exporter/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       hostNetwork: true
@@ -33,8 +35,6 @@ spec:
           - --path.procfs=/host/proc
           - --path.sysfs=/host/sys
           - --path.rootfs=/host/root
-          - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+)($|/)
-          - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
         ports:
           - name: metrics
             containerPort: 9100
@@ -46,6 +46,9 @@ spec:
           limits:
             cpu: 200m
             memory: 100Mi
+        securityContext:
+          seLinuxOptions:
+            type: spc_t
         volumeMounts:
           - name: proc
             mountPath: /host/proc
@@ -55,9 +58,12 @@ spec:
             readOnly: true
           - name: root
             mountPath: /host/root
+            mountPropagation: HostToContainer
             readOnly: true
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/controller
+          operator: Exists
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
         - key: node.kubernetes.io/not-ready
           operator: Exists


### PR DESCRIPTION
* Add toleration to run node-exporter on controller nodes
* Add HostToContainer mount propagation and security context group settings from upstream
* Fix SELinux denied accessing /host/proc/1/mounts. The mounts file is has an SELinux type attribute init_t, but that won't allow running the node-exporter binary so we have to use spc_t. This should be more targeted at just the SELinux issue than making the Pod privileged
* Remove excluded mount points and filesystem types, the defaults are https://github.com/prometheus/node_exporter/blob/v1.3.1/collector/filesystem_linux.go#L35

```
caller=collector.go:169 level=error msg="collector failed" name=filesystem duration_seconds=0.000666766 err="open /host/proc/1/mounts: permission denied"
```

```
[ 3664.880899] audit: type=1400 audit(1659639161.568:4400): avc:  denied  { search } for  pid=28325 comm="node_exporter" name="1" dev="proc" ino=22542 scontext=system_u:system_r:container_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=dir permissive=0
```