### PR TITLE
Update Grafana liveness and readiness probes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@ version: 1.0.0
 
 * Fix bug provisioning clusters with multiple controller nodes ([#1195](https://github.com/poseidon/typhoon/pull/1195))
 
+### Addons
+
+* Update Grafana from v9.0.3 to [v9.0.5](https://github.com/grafana/grafana/releases/tag/v9.0.5)
+
 ## v1.24.3
 
 * Kubernetes [v1.24.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#v1243)

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: grafana
-          image: docker.io/grafana/grafana:9.0.3
+          image: docker.io/grafana/grafana:9.0.5
           env:
             - name: GF_PATHS_CONFIG
               value: "/etc/grafana/custom.ini"
@@ -32,15 +32,22 @@ spec:
             - name: http
               containerPort: 8080
           livenessProbe:
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: 8080
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 5
+            successThreshold: 1
           readinessProbe:
             httpGet:
-              path: /api/health
+              scheme: HTTP
+              path: /robots.txt
               port: 8080
             initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
* Use the liveness and readiness probes that Grafana recommends
* Update Grafana from v9.0.3 to v9.0.5