### PR TITLE
Improve AWS autoscaling group and launch config names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,11 @@ version: 1.0.0
 ...
 ```
 
+### AWS
+
+* Rename worker autoscaling group `${cluster_name}-worker`
+* Rename launch configuration `${cluster_name}-worker`
+
 ### Google
 
 * Fix bug provisioning clusters with multiple controller nodes ([#1195](https://github.com/poseidon/typhoon/pull/1195))

--- a/aws/fedora-coreos/kubernetes/workers/ami.tf
+++ b/aws/fedora-coreos/kubernetes/workers/ami.tf
@@ -1,3 +1,7 @@
+locals {
+  ami_id = var.arch == "arm64" ? data.aws_ami.fedora-coreos-arm[0].image_id : data.aws_ami.fedora-coreos.image_id
+}
+
 data "aws_ami" "fedora-coreos" {
   most_recent = true
   owners      = ["125523088429"]

--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -1,6 +1,6 @@
 # Workers AutoScaling Group
 resource "aws_autoscaling_group" "workers" {
-  name = "${var.name}-worker ${aws_launch_configuration.worker.name}"
+  name = "${var.name}-worker"
 
   # count
   desired_capacity          = var.worker_count
@@ -42,7 +42,8 @@ resource "aws_autoscaling_group" "workers" {
 
 # Worker template
 resource "aws_launch_configuration" "worker" {
-  image_id          = var.arch == "arm64" ? data.aws_ami.fedora-coreos-arm[0].image_id : data.aws_ami.fedora-coreos.image_id
+  name_prefix       = "${var.name}-worker"
+  image_id          = local.ami_id
   instance_type     = var.instance_type
   spot_price        = var.spot_price > 0 ? var.spot_price : null
   enable_monitoring = false

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,6 +1,6 @@
 # Workers AutoScaling Group
 resource "aws_autoscaling_group" "workers" {
-  name = "${var.name}-worker ${aws_launch_configuration.worker.name}"
+  name = "${var.name}-worker"
 
   # count
   desired_capacity          = var.worker_count
@@ -42,6 +42,7 @@ resource "aws_autoscaling_group" "workers" {
 
 # Worker template
 resource "aws_launch_configuration" "worker" {
+  name_prefix       = "${var.name}-worker"
   image_id          = local.ami_id
   instance_type     = var.instance_type
   spot_price        = var.spot_price > 0 ? var.spot_price : null


### PR DESCRIPTION
* Rename launch configuration to use a name_prefix named after the cluster and worker to improve identifiability
* Shorten AWS autoscaling group name to not include the launch config id. Years ago this used to be needed to update the ASG but the AWS provider detects changes to the launch configuration just fine