### PR TITLE
Disable LocalStorageCapacityIsolationFSQuotaMonitoring feature

### DIFF
--- a/aws/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/butane/controller.yaml
@@ -149,6 +149,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -118,6 +118,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/aws/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/aws/flatcar-linux/kubernetes/butane/controller.yaml
@@ -150,6 +150,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/aws/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/aws/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -118,6 +118,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/azure/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/butane/controller.yaml
@@ -144,6 +144,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -113,6 +113,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/azure/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/azure/flatcar-linux/kubernetes/butane/controller.yaml
@@ -146,6 +146,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/azure/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/azure/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -114,6 +114,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
@@ -154,6 +154,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/bare-metal/fedora-coreos/kubernetes/butane/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/butane/worker.yaml
@@ -109,6 +109,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
@@ -157,6 +157,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/bare-metal/flatcar-linux/kubernetes/butane/worker.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/worker.yaml
@@ -115,6 +115,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
@@ -151,6 +151,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/digital-ocean/fedora-coreos/kubernetes/butane/worker.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/butane/worker.yaml
@@ -118,6 +118,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/digital-ocean/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/digital-ocean/flatcar-linux/kubernetes/butane/controller.yaml
@@ -155,6 +155,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/digital-ocean/flatcar-linux/kubernetes/butane/worker.yaml
+++ b/digital-ocean/flatcar-linux/kubernetes/butane/worker.yaml
@@ -118,6 +118,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
@@ -143,6 +143,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -112,6 +112,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
@@ -145,6 +145,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/google-cloud/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -113,6 +113,8 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
+          featureGates:
+            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0


### PR DESCRIPTION
* Kubernetes v1.25.0 moved the LocalStorageCapacityIsolationFSQuotaMonitoring feature from alpha to beta, but it breaks Kubelet updating ConfigMaps in Pods, as shown by conformance tests
* Kubernetes is rolling LocalStorageCapacityIsolationFSQuotaMonitoring back to alpha so its not enabled by default, but that will require a release
* Disable the feature gate directly as a workaround for now to make Kubernetes v1.25.0 usable

```
FailedMount: MountVolume.SetUp failed for volume "configmap-volume" : requesting quota on existing directory /var/lib/kubelet/pods/f09fae17-ff16-4a05-aab3-7b897cb5b732/volumes/kubernetes.io~configmap/configmap-volume but different pod 673ad247-abf0-434e-99eb-1c3f57d7fdaa a4568e94-2b2d-438f-a4bd-c9edc814e478
```

Rel:

* https://github.com/kubernetes/kubernetes/pull/112076
* https://github.com/kubernetes/kubernetes/pull/107329