### PR TITLE
Add workaround to strip "search ." from resolv.conf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@ Notable changes between versions.
 ## Latest
 
 * Kubernetes [v1.25.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#v1250)
-  * Disable LocalStorageCapacityIsolationFSQuotaMonitoring feature gate ([#1220](https://github.com/poseidon/typhoon/pull/1220))
+  * Disable LocalStorageCapacityIsolationFSQuotaMonitoring feature gate ([#1220](https://github.com/poseidon/typhoon/pull/1220), fixes [kubernetes#112081](https://github.com/kubernetes/kubernetes/issues/112081))
+  * Add workaround to revert adding "search ." to containers' `/etc/resolv.conf` ([#1224](https://github.com/poseidon/typhoon/pull/1224), fixes [kubernetes#112135](https://github.com/kubernetes/kubernetes/issues/112135))
 * Migrate most Kubelet flags to KubeletConfiguration file ([#1219](https://github.com/poseidon/typhoon/pull/1219))
 * Configure Kubelet Graceful Node Shutdown ([#1222](https://github.com/poseidon/typhoon/pull/1222))
   * Allow up to 30s for critical pods to gracefully shutdown on node shutdown

--- a/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
@@ -124,6 +124,21 @@ systemd:
             $${KUBELET_IMAGE}
         ExecStartPost=/bin/touch /opt/bootstrap/bootstrap.done
         ExecStartPost=-/usr/bin/podman stop bootstrap
+    - name: fix-resolv-conf-search.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Remove search . from /etc/resolv.conf
+        DefaultDependencies=no
+        Requires=systemd-resolved.service
+        After=systemd-resolved.service
+        BindsTo=systemd-resolved.service
+        [Service]
+        Type=oneshot
+        ExecStartPre=/usr/bin/sleep 5
+        ExecStart=/usr/bin/sed -i -e "s/^search .$//" /run/systemd/resolve/resolv.conf
+        [Install]
+        WantedBy=multi-user.target
 storage:
   directories:
     - path: /var/lib/etcd

--- a/bare-metal/fedora-coreos/kubernetes/butane/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/butane/worker.yaml
@@ -81,6 +81,21 @@ systemd:
         PathExists=/etc/kubernetes/kubeconfig
         [Install]
         WantedBy=multi-user.target
+    - name: fix-resolv-conf-search.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Remove search . from /etc/resolv.conf
+        DefaultDependencies=no
+        Requires=systemd-resolved.service
+        After=systemd-resolved.service
+        BindsTo=systemd-resolved.service
+        [Service]
+        Type=oneshot
+        ExecStartPre=/usr/bin/sleep 5
+        ExecStart=/usr/bin/sed -i -e "s/^search .$//" /run/systemd/resolve/resolv.conf
+        [Install]
+        WantedBy=multi-user.target
 storage:
   directories:
     - path: /etc/kubernetes


### PR DESCRIPTION
* systemd adds "search ." to hosts `/run/systemd/resolve/resolv.conf` on hosts with a fqdn hostname
* Kubelet v1.25 began propagating `search .` from the host node into containers' `/etc/resolv.conf`
* musl-based DNS resolvers don't behave correctly when `search .` is used in their `/etc/resolv.conf`. This breaks Alpine images
* Adapt the same workaround used by Openshift to strip the `search .`
* This only applies to bare-metal Typhoon nodes (where hostnames are set to fqdn's), nodes on cloud platforms aren't affected in the Typhoon configuration

Kubernetes tracking issue: https://github.com/kubernetes/kubernetes/issues/112135

Rel:

* https://github.com/systemd/systemd/pull/17201
* https://github.com/kubernetes/kubernetes/pull/109441
* https://github.com/kubernetes/kubernetes/issues/112135
* https://github.com/coreos/fedora-coreos-tracker/issues/1287
* https://github.com/openshift/okd-machine-os/pull/159