### PR TITLE
Remove workaround for v1.25.0 ConfigMap rendering issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ Notable changes between versions.
 * Update Calico from v3.23.3 to [v3.24.1](https://github.com/projectcalico/calico/releases/tag/v3.24.1)
 * Revert Kubelet Graceful Node Shutdown on worker nodes ([#1227](https://github.com/poseidon/typhoon/pull/1227))
   * Fix issue where non-critical pods are left in Error/Completed state on node shutdown
+* Remove feature flag disable workaround for [kubernetes/kubernetes#112081](https://github.com/kubernetes/kubernetes/issues/112081)
+  * Kubernetes [reverted](https://github.com/kubernetes/kubernetes/pull/112078) `LocalStorageCapacityIsolationFSQuotaMonitoring` back to alpha
 
 ### Addons
 

--- a/aws/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/butane/controller.yaml
@@ -151,8 +151,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -119,8 +119,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/aws/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/aws/flatcar-linux/kubernetes/butane/controller.yaml
@@ -150,8 +150,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/aws/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/aws/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -118,8 +118,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/azure/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/butane/controller.yaml
@@ -146,8 +146,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -114,8 +114,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/azure/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/azure/flatcar-linux/kubernetes/butane/controller.yaml
@@ -146,8 +146,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/azure/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/azure/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -114,8 +114,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
@@ -171,8 +171,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/bare-metal/fedora-coreos/kubernetes/butane/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/butane/worker.yaml
@@ -125,8 +125,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
@@ -157,8 +157,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/bare-metal/flatcar-linux/kubernetes/butane/worker.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/worker.yaml
@@ -115,8 +115,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
@@ -153,8 +153,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/digital-ocean/fedora-coreos/kubernetes/butane/worker.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/butane/worker.yaml
@@ -119,8 +119,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/digital-ocean/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/digital-ocean/flatcar-linux/kubernetes/butane/controller.yaml
@@ -155,8 +155,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/digital-ocean/flatcar-linux/kubernetes/butane/worker.yaml
+++ b/digital-ocean/flatcar-linux/kubernetes/butane/worker.yaml
@@ -118,8 +118,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
@@ -145,8 +145,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -113,8 +113,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0

--- a/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
@@ -145,8 +145,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s

--- a/google-cloud/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -113,8 +113,6 @@ storage:
             - ${cluster_dns_service_ip}
           clusterDomain: ${cluster_domain_suffix}
           healthzPort: 0
-          featureGates:
-            LocalStorageCapacityIsolationFSQuotaMonitoring: false
           rotateCertificates: true
           staticPodPath: /etc/kubernetes/manifests
           readOnlyPort: 0


### PR DESCRIPTION
* LocalStorageCapacityIsolationFSQuotaMonitoring was reverted back to alpha in v1.25.1, so we don't need to explicitly disable it anymore

Rel: https://github.com/kubernetes/kubernetes/issues/112081

