### PR TITLE
Switch addons images from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,12 @@ Notable changes between versions.
 ## Latest
 
 * Kubernetes [v1.25.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#v1252)
+* Switch Kubernetes registry from `k8s.gcr.io` to `registry.k8s.io` for addons
 
 ### Addons
 
 * Update Prometheus from v2.38.0 to [v2.39.1](https://github.com/prometheus/prometheus/releases/tag/v2.39.1)
+* Update Grafana from v9.1.6 to [v9.1.7](https://github.com/grafana/grafana/releases/tag/v9.1.7)
 
 ## v1.25.1
 

--- a/addons/grafana/deployment.yaml
+++ b/addons/grafana/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: grafana
-          image: docker.io/grafana/grafana:9.1.6
+          image: docker.io/grafana/grafana:9.1.7
           env:
             - name: GF_PATHS_CONFIG
               value: "/etc/grafana/custom.ini"

--- a/addons/nginx-ingress/aws/deployment.yaml
+++ b/addons/nginx-ingress/aws/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.3.1
+          image: registry.k8s.io/ingress-nginx/controller:v1.3.1
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/nginx-ingress/azure/deployment.yaml
+++ b/addons/nginx-ingress/azure/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.3.1
+          image: registry.k8s.io/ingress-nginx/controller:v1.3.1
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/nginx-ingress/bare-metal/deployment.yaml
+++ b/addons/nginx-ingress/bare-metal/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.3.1
+          image: registry.k8s.io/ingress-nginx/controller:v1.3.1
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/nginx-ingress/digital-ocean/daemonset.yaml
+++ b/addons/nginx-ingress/digital-ocean/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.3.1
+          image: registry.k8s.io/ingress-nginx/controller:v1.3.1
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/nginx-ingress/google-cloud/deployment.yaml
+++ b/addons/nginx-ingress/google-cloud/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.3.1
+          image: registry.k8s.io/ingress-nginx/controller:v1.3.1
           args:
             - /nginx-ingress-controller
             - --controller-class=k8s.io/public

--- a/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
+++ b/addons/prometheus/exporters/kube-state-metrics/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.6.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
         ports:
           - name: metrics
             containerPort: 8080


### PR DESCRIPTION
* Switch addon manifests to use the new Kubernetes image registry

Rel:

* https://github.com/poseidon/typhoon/pull/1206
* https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#moved-container-registry-service-from-k8sgcrio-to-registryk8sio