### PR TITLE
Update Calico v3.24.2 to v3.24.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Notable changes between versions.
 
 ## Latest
 
-* Update Calico from v3.24.1 to [v3.24.2](https://github.com/projectcalico/calico/releases/tag/v3.24.2)
+* Update Calico from v3.24.1 to [v3.24.3](https://github.com/projectcalico/calico/releases/tag/v3.24.3)
+* Allow Kubelet kubeconfig to drain nodes, if desired
 
 ### Fedora CoreOS
 

--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=3db4055ccfbd30d1880eaa2c79cf53f9a9d7d3f2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=8fb30b7732f360d3fe6a73a938f835762b01aa03"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]


### PR DESCRIPTION
* https://github.com/projectcalico/calico/releases/tag/v3.24.3
* Add patch to allow Kubelet kubeconfig to drain nodes if desired in addition to just deleting them in shutdown integrations. See https://github.com/poseidon/terraform-render-bootstrap/pull/330