### PR TITLE
Migrate AWS launch configurations to launch templates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ Notable changes between versions.
 * Update Cilium from v1.12.3 to [v1.12.4](https://github.com/cilium/cilium/releases/tag/v1.12.4)
 * Update flannel from v0.15.1 to [v0.20.1](https://github.com/flannel-io/flannel/releases/tag/v0.20.1)
 
+### AWS
+
+* Migrate AWS launch configurations to launch templates
+  * Starting Dec 31, 2022 AWS won't add new instance types/families to launch configurations
+
 ### Addons
 
 * Update Prometheus from v2.40.1 to [v2.40.2](https://github.com/prometheus/prometheus/releases/tag/v2.40.2)

--- a/aws/fedora-coreos/kubernetes/controllers.tf
+++ b/aws/fedora-coreos/kubernetes/controllers.tf
@@ -31,6 +31,7 @@ resource "aws_instance" "controllers" {
     volume_size = var.disk_size
     iops        = var.disk_iops
     encrypted   = true
+    tags        = {}
   }
 
   # network

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -32,6 +32,7 @@ resource "aws_instance" "controllers" {
     volume_size = var.disk_size
     iops        = var.disk_iops
     encrypted   = true
+    tags        = {}
   }
 
   # network


### PR DESCRIPTION
* Same features, but AWS will soon require launch templates
* Starting Dec 31, 2022 AWS will not add new instance types (e.g. graviton 4) to launch configuration support

Rel: https://aws.amazon.com/blogs/compute/amazon-ec2-auto-scaling-will-no-longer-add-support-for-new-ec2-features-to-launch-configurations/