### PR TITLE
Support using a different install disk target per node on baremetal

### DIFF
--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -4,7 +4,7 @@ module "bootstrap" {
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]
-  etcd_servers                    = var.controllers.*.domain
+  etcd_servers                    = var.controllers[*].domain
   networking                      = var.networking
   network_mtu                     = var.network_mtu
   network_ip_autodetection_method = var.network_ip_autodetection_method

--- a/bare-metal/fedora-coreos/kubernetes/groups.tf
+++ b/bare-metal/fedora-coreos/kubernetes/groups.tf
@@ -2,21 +2,21 @@
 
 resource "matchbox_group" "controller" {
   count   = length(var.controllers)
-  name    = format("%s-%s", var.cluster_name, var.controllers.*.name[count.index])
-  profile = matchbox_profile.controllers.*.name[count.index]
+  name    = format("%s-%s", var.cluster_name, var.controllers[count.index].name)
+  profile = matchbox_profile.controllers[count.index].name
 
   selector = {
-    mac = var.controllers.*.mac[count.index]
+    mac = var.controllers[count.index].mac
   }
 }
 
 resource "matchbox_group" "worker" {
   count   = length(var.workers)
-  name    = format("%s-%s", var.cluster_name, var.workers.*.name[count.index])
-  profile = matchbox_profile.workers.*.name[count.index]
+  name    = format("%s-%s", var.cluster_name, var.workers[count.index].name)
+  profile = matchbox_profile.workers[count.index].name
 
   selector = {
-    mac = var.workers.*.mac[count.index]
+    mac = var.workers[count.index].mac
   }
 }
 

--- a/bare-metal/fedora-coreos/kubernetes/profiles.tf
+++ b/bare-metal/fedora-coreos/kubernetes/profiles.tf
@@ -7,7 +7,6 @@ locals {
   remote_args = [
     "initrd=main",
     "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
-    "coreos.inst.install_dev=${var.install_disk}",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
   ]
 
@@ -19,7 +18,6 @@ locals {
   cached_args = [
     "initrd=main",
     "coreos.live.rootfs_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
-    "coreos.inst.install_dev=${var.install_disk}",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
   ]
 
@@ -36,7 +34,7 @@ resource "matchbox_profile" "controllers" {
 
   kernel = local.kernel
   initrd = local.initrd
-  args   = concat(local.args, var.kernel_args)
+  args   = concat(local.args, ["coreos.inst.install_dev=${var.controllers.*.install_disk[count.index]}"], var.kernel_args)
 
   raw_ignition = data.ct_config.controllers.*.rendered[count.index]
 }
@@ -63,7 +61,7 @@ resource "matchbox_profile" "workers" {
 
   kernel = local.kernel
   initrd = local.initrd
-  args   = concat(local.args, var.kernel_args)
+  args   = concat(local.args, ["coreos.inst.install_dev=${var.workers.*.install_disk[count.index]}"], var.kernel_args)
 
   raw_ignition = data.ct_config.workers.*.rendered[count.index]
 }

--- a/bare-metal/fedora-coreos/kubernetes/ssh.tf
+++ b/bare-metal/fedora-coreos/kubernetes/ssh.tf
@@ -21,7 +21,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = var.controllers.*.domain[count.index]
+    host    = var.controllers[count.index].domain
     user    = "core"
     timeout = "60m"
   }
@@ -58,7 +58,7 @@ resource "null_resource" "copy-worker-secrets" {
 
   connection {
     type    = "ssh"
-    host    = var.workers.*.domain[count.index]
+    host    = var.workers[count.index].domain
     user    = "core"
     timeout = "60m"
   }

--- a/bare-metal/fedora-coreos/kubernetes/variables.tf
+++ b/bare-metal/fedora-coreos/kubernetes/variables.tf
@@ -30,24 +30,26 @@ variable "os_version" {
 
 variable "controllers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name         = string
+    mac          = string
+    domain       = string
+    install_disk = optional(string, "/dev/sda")
   }))
   description = <<EOD
-List of controller machine details (unique name, identifying MAC address, FQDN)
+List of controller machine details (unique name, identifying MAC address, FQDN, install disk)
 [{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
 EOD
 }
 
 variable "workers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name         = string
+    mac          = string
+    domain       = string
+    install_disk = optional(string, "/dev/sda")
   }))
   description = <<EOD
-List of worker machine details (unique name, identifying MAC address, FQDN)
+List of worker machine details (unique name, identifying MAC address, FQDN, install disk)
 [
   { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
   { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
@@ -124,12 +126,6 @@ variable "cached_install" {
   type        = bool
   description = "Whether Fedora CoreOS should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the os_version into matchbox assets."
   default     = false
-}
-
-variable "install_disk" {
-  type        = string
-  description = "Disk device to install Fedora CoreOS (e.g. sda)"
-  default     = "sda"
 }
 
 variable "kernel_args" {

--- a/bare-metal/fedora-coreos/kubernetes/versions.tf
+++ b/bare-metal/fedora-coreos/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.13.0, < 2.0.0"
+  required_version = ">= 1.3.0, < 2.0.0"
   required_providers {
     null = ">= 2.1"
     ct = {

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -4,7 +4,7 @@ module "bootstrap" {
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]
-  etcd_servers                    = var.controllers.*.domain
+  etcd_servers                    = var.controllers[*].domain
   networking                      = var.networking
   network_mtu                     = var.network_mtu
   network_ip_autodetection_method = var.network_ip_autodetection_method

--- a/bare-metal/flatcar-linux/kubernetes/groups.tf
+++ b/bare-metal/flatcar-linux/kubernetes/groups.tf
@@ -1,20 +1,20 @@
 resource "matchbox_group" "install" {
   count = length(var.controllers) + length(var.workers)
 
-  name = format("install-%s", concat(var.controllers.*.name, var.workers.*.name)[count.index])
+  name = format("install-%s", concat(var.controllers[*].name, var.workers[*].name)[count.index])
 
   # pick Matchbox profile (Flatcar upstream or Matchbox image cache)
-  profile = var.cached_install ? matchbox_profile.cached-flatcar-install.*.name[count.index] : matchbox_profile.flatcar-install.*.name[count.index]
+  profile = var.cached_install ? matchbox_profile.cached-flatcar-install[count.index].name : matchbox_profile.flatcar-install[count.index].name
 
   selector = {
-    mac = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
+    mac = concat(var.controllers[*].mac, var.workers[*].mac)[count.index]
   }
 }
 
 resource "matchbox_group" "controller" {
   count   = length(var.controllers)
   name    = format("%s-%s", var.cluster_name, var.controllers[count.index].name)
-  profile = matchbox_profile.controllers.*.name[count.index]
+  profile = matchbox_profile.controllers[count.index].name
 
   selector = {
     mac = var.controllers[count.index].mac
@@ -25,7 +25,7 @@ resource "matchbox_group" "controller" {
 resource "matchbox_group" "worker" {
   count   = length(var.workers)
   name    = format("%s-%s", var.cluster_name, var.workers[count.index].name)
-  profile = matchbox_profile.workers.*.name[count.index]
+  profile = matchbox_profile.workers[count.index].name
 
   selector = {
     mac = var.workers[count.index].mac

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -54,7 +54,7 @@ data "ct_config" "install" {
     os_version         = var.os_version
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
     mac                = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
-    install_disk       = var.install_disk
+    install_disk       = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
     ssh_authorized_key = var.ssh_authorized_key
     # only cached profile adds -b baseurl
     baseurl_flag = ""
@@ -70,7 +70,7 @@ data "ct_config" "cached-install" {
     os_version         = var.os_version
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
     mac                = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
-    install_disk       = var.install_disk
+    install_disk       = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
     ssh_authorized_key = var.ssh_authorized_key
     # profile uses -b baseurl to install from matchbox cache
     baseurl_flag = "-b ${var.matchbox_http_endpoint}/assets/flatcar"

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -6,7 +6,7 @@ locals {
 // Flatcar Linux install profile (from release.flatcar-linux.net)
 resource "matchbox_profile" "flatcar-install" {
   count = length(var.controllers) + length(var.workers)
-  name  = format("%s-flatcar-install-%s", var.cluster_name, concat(var.controllers.*.name, var.workers.*.name)[count.index])
+  name  = format("%s-flatcar-install-%s", var.cluster_name, concat(var.controllers[*].name, var.workers[*].name)[count.index])
 
   kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
 
@@ -21,14 +21,14 @@ resource "matchbox_profile" "flatcar-install" {
     var.kernel_args,
   ])
 
-  raw_ignition = data.ct_config.install.*.rendered[count.index]
+  raw_ignition = data.ct_config.install[count.index].rendered
 }
 
 // Flatcar Linux Install profile (from matchbox /assets cache)
 // Note: Admin must have downloaded os_version into matchbox assets/flatcar.
 resource "matchbox_profile" "cached-flatcar-install" {
   count = length(var.controllers) + length(var.workers)
-  name  = format("%s-cached-flatcar-linux-install-%s", var.cluster_name, concat(var.controllers.*.name, var.workers.*.name)[count.index])
+  name  = format("%s-cached-flatcar-linux-install-%s", var.cluster_name, concat(var.controllers[*].name, var.workers[*].name)[count.index])
 
   kernel = "/assets/flatcar/${var.os_version}/flatcar_production_pxe.vmlinuz"
 
@@ -43,7 +43,7 @@ resource "matchbox_profile" "cached-flatcar-install" {
     var.kernel_args,
   ])
 
-  raw_ignition = data.ct_config.cached-install.*.rendered[count.index]
+  raw_ignition = data.ct_config.cached-install[count.index].rendered
 }
 
 # Flatcar Linux install
@@ -53,8 +53,8 @@ data "ct_config" "install" {
     os_channel         = local.channel
     os_version         = var.os_version
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
-    mac                = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
-    install_disk       = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
+    mac                = concat(var.controllers[*].mac, var.workers[*].mac)[count.index]
+    install_disk       = concat(var.controllers[*].install_disk, var.workers[*].install_disk)[count.index]
     ssh_authorized_key = var.ssh_authorized_key
     # only cached profile adds -b baseurl
     baseurl_flag = ""
@@ -69,8 +69,8 @@ data "ct_config" "cached-install" {
     os_channel         = local.channel
     os_version         = var.os_version
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
-    mac                = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
-    install_disk       = concat(var.controllers.*.install_disk, var.workers.*.install_disk)[count.index]
+    mac                = concat(var.controllers[*].mac, var.workers[*].mac)[count.index]
+    install_disk       = concat(var.controllers[*].install_disk, var.workers[*].install_disk)[count.index]
     ssh_authorized_key = var.ssh_authorized_key
     # profile uses -b baseurl to install from matchbox cache
     baseurl_flag = "-b ${var.matchbox_http_endpoint}/assets/flatcar"
@@ -81,43 +81,43 @@ data "ct_config" "cached-install" {
 // Kubernetes Controller profiles
 resource "matchbox_profile" "controllers" {
   count        = length(var.controllers)
-  name         = format("%s-controller-%s", var.cluster_name, var.controllers.*.name[count.index])
-  raw_ignition = data.ct_config.controllers.*.rendered[count.index]
+  name         = format("%s-controller-%s", var.cluster_name, var.controllers[count.index].name)
+  raw_ignition = data.ct_config.controllers[count.index].rendered
 }
 
 # Flatcar Linux controllers
 data "ct_config" "controllers" {
   count = length(var.controllers)
   content = templatefile("${path.module}/butane/controller.yaml", {
-    domain_name            = var.controllers.*.domain[count.index]
-    etcd_name              = var.controllers.*.name[count.index]
-    etcd_initial_cluster   = join(",", formatlist("%s=https://%s:2380", var.controllers.*.name, var.controllers.*.domain))
+    domain_name            = var.controllers[count.index].domain
+    etcd_name              = var.controllers[count.index].name
+    etcd_initial_cluster   = join(",", formatlist("%s=https://%s:2380", var.controllers[*].name, var.controllers[*].domain))
     cluster_dns_service_ip = module.bootstrap.cluster_dns_service_ip
     cluster_domain_suffix  = var.cluster_domain_suffix
     ssh_authorized_key     = var.ssh_authorized_key
   })
   strict   = true
-  snippets = lookup(var.snippets, var.controllers.*.name[count.index], [])
+  snippets = lookup(var.snippets, var.controllers[count.index].name, [])
 }
 
 // Kubernetes Worker profiles
 resource "matchbox_profile" "workers" {
   count        = length(var.workers)
-  name         = format("%s-worker-%s", var.cluster_name, var.workers.*.name[count.index])
-  raw_ignition = data.ct_config.workers.*.rendered[count.index]
+  name         = format("%s-worker-%s", var.cluster_name, var.workers[count.index].name)
+  raw_ignition = data.ct_config.workers[count.index].rendered
 }
 
 # Flatcar Linux workers
 data "ct_config" "workers" {
   count = length(var.workers)
   content = templatefile("${path.module}/butane/worker.yaml", {
-    domain_name            = var.workers.*.domain[count.index]
+    domain_name            = var.workers[count.index].domain
     cluster_dns_service_ip = module.bootstrap.cluster_dns_service_ip
     cluster_domain_suffix  = var.cluster_domain_suffix
     ssh_authorized_key     = var.ssh_authorized_key
-    node_labels            = join(",", lookup(var.worker_node_labels, var.workers.*.name[count.index], []))
-    node_taints            = join(",", lookup(var.worker_node_taints, var.workers.*.name[count.index], []))
+    node_labels            = join(",", lookup(var.worker_node_labels, var.workers[count.index].name, []))
+    node_taints            = join(",", lookup(var.worker_node_taints, var.workers[count.index].name, []))
   })
   strict   = true
-  snippets = lookup(var.snippets, var.workers.*.name[count.index], [])
+  snippets = lookup(var.snippets, var.workers[count.index].name, [])
 }

--- a/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -22,7 +22,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = var.controllers.*.domain[count.index]
+    host    = var.controllers[count.index].domain
     user    = "core"
     timeout = "60m"
   }
@@ -59,7 +59,7 @@ resource "null_resource" "copy-worker-secrets" {
 
   connection {
     type    = "ssh"
-    host    = var.workers.*.domain[count.index]
+    host    = var.workers[count.index].domain
     user    = "core"
     timeout = "60m"
   }

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -29,24 +29,26 @@ variable "os_version" {
 
 variable "controllers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name         = string
+    mac          = string
+    domain       = string
+    install_disk = optional(string, "/dev/sda")
   }))
   description = <<EOD
-List of controller machine details (unique name, identifying MAC address, FQDN)
+List of controller machine details (unique name, identifying MAC address, FQDN, install disk)
 [{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
 EOD
 }
 
 variable "workers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name         = string
+    mac          = string
+    domain       = string
+    install_disk = optional(string, "/dev/sda")
   }))
   description = <<EOD
-List of worker machine details (unique name, identifying MAC address, FQDN)
+List of worker machine details (unique name, identifying MAC address, FQDN, install disk)
 [
   { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
   { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
@@ -129,12 +131,6 @@ variable "cached_install" {
   type        = bool
   description = "Whether Flatcar Linux should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the os_version into matchbox assets."
   default     = false
-}
-
-variable "install_disk" {
-  type        = string
-  default     = "/dev/sda"
-  description = "Disk device to which the install profiles should install Flatcar Linux (e.g. /dev/sda)"
 }
 
 variable "kernel_args" {

--- a/bare-metal/flatcar-linux/kubernetes/versions.tf
+++ b/bare-metal/flatcar-linux/kubernetes/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.13.0, < 2.0.0"
+  required_version = ">= 1.3.0, < 2.0.0"
   required_providers {
     null = ">= 2.1"
     ct = {


### PR DESCRIPTION
Support using a different install disk target per node during baremetal installations.
In my use case, my controller node uses /dev/sda but the worker nodes use /dev/nvme0n1

* Breaking changes: deprecate `var.install_disk` and require Terraform >= 1.3.0.
  * The Terraform version is to support the [optional object type attribute](https://developer.hashicorp.com/terraform/language/expressions/type-constraints#optional-object-type-attributes) that now holds the install disk target value.
* Refactoring to resolve `terraform_deprecated_index` warnings from `tflint`
  * Legacy "attribute-only" splat expressions have been deprecated for a while: https://developer.hashicorp.com/terraform/language/expressions/splat#legacy-attribute-only-splat-expressions

## Testing

I've installed my own baremetal cluster (flatcar linux) using this branch


