### PR TITLE
Expose flatcar-install OEM parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Notable changes between versions.
 ### Bare-Metal
 
 * Add a `worker` module to allow customizing individual worker nodes ([#1295](https://github.com/poseidon/typhoon/pull/1295))
+* Expose `-o OEM` parameter of `flatcar-install` script ([#1302](https://github.com/poseidon/typhoon/pull/1302))
 
 ## v1.26.1
 

--- a/bare-metal/flatcar-linux/kubernetes/butane/install.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/install.yaml
@@ -35,6 +35,7 @@ storage:
             -d ${install_disk} \
             -C ${os_channel} \
             -V ${os_version} \
+            -o ${oem_type} \
             ${baseurl_flag} \
             -i ignition.json
           udevadm settle

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -55,6 +55,7 @@ data "ct_config" "install" {
     mac                = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
     install_disk       = var.install_disk
     ssh_authorized_key = var.ssh_authorized_key
+    oem_type           = var.oem_type
     # only cached profile adds -b baseurl
     baseurl_flag = var.cached_install ? "-b ${var.matchbox_http_endpoint}/assets/flatcar" : ""
   })

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -156,6 +156,17 @@ variable "enable_aggregation" {
   default     = true
 }
 
+variable "oem_type" {
+  type        = string
+  description = <<EOD
+An OEM type to install with flatcar-install. Find available types by looking for Flatcar image files
+ending in `image.bin.bz2`. The OEM identifier is contained in the filename.
+E.g., `flatcar_production_vmware_raw_image.bin.bz2` leads to `vmware_raw`.
+See: https://www.flatcar.org/docs/latest/installing/bare-metal/installing-to-disk/#choose-a-channel
+EOD
+  default     = ""
+}
+
 # unofficial, undocumented, unsupported
 
 variable "cluster_domain_suffix" {

--- a/bare-metal/flatcar-linux/kubernetes/worker/butane/install.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/worker/butane/install.yaml
@@ -35,6 +35,7 @@ storage:
             -d ${install_disk} \
             -C ${os_channel} \
             -V ${os_version} \
+            -o ${oem_type} \
             ${baseurl_flag} \
             -i ignition.json
           udevadm settle

--- a/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
@@ -50,6 +50,7 @@ data "ct_config" "install" {
     mac                = var.mac
     install_disk       = var.install_disk
     ssh_authorized_key = var.ssh_authorized_key
+    oem_type           = var.oem_type
     # only cached profile adds -b baseurl
     baseurl_flag = var.cached_install ? "-b ${var.matchbox_http_endpoint}/assets/flatcar" : ""
   })

--- a/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
@@ -98,6 +98,12 @@ variable "kernel_args" {
   default     = []
 }
 
+variable "oem_type" {
+  type        = string
+  default     = ""
+  description = "An OEM type to install with flatcar-install."
+}
+
 # unofficial, undocumented, unsupported
 
 variable "service_cidr" {

--- a/bare-metal/flatcar-linux/kubernetes/workers.tf
+++ b/bare-metal/flatcar-linux/kubernetes/workers.tf
@@ -28,5 +28,6 @@ module "workers" {
   cached_install    = var.cached_install
   install_disk      = var.install_disk
   kernel_args       = var.kernel_args
+  oem_type          = var.oem_type
 }
 

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -383,4 +383,4 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/bare-me
 | kernel_args | Additional kernel args to provide at PXE boot | [] | ["kvm-intel.nested=1"] |
 | worker_node_labels | Map from worker name to list of initial node labels | {} | {"node2" = ["role=special"]} |
 | worker_node_taints | Map from worker name to list of initial node taints | {} | {"node2" = ["role=special:NoSchedule"]} |
-
+| oem_type | An OEM type to install with `flatcar-install`. | "" | "vmware_raw" |


### PR DESCRIPTION
By exposing this parameter it is possible to install OEM specific software during the `flatcar-install` invocation.

## Testing

I installed a Kubernetes cluster on vSphere VMs and used the newly exposed flag to install the vmware OEM files. Now vSphere no longer complains that the vSphere tools are not installed and it is possible to see the assigned hostname and IPs in the vSphere UI. This also enables the vSphere Terraform provider to wait for IP assignment.

When using `cached_install = true` Matchbox also needs to serve these files otherwise the `installer.service` fails:
```
https://${channel}.release.flatcar-linux.net/amd64-usr/${version}/flatcar_production_${oem_type}_image.bin.bz2
https://${channel}.release.flatcar-linux.net/amd64-usr/${version}/flatcar_production_${oem_type}_image.bin.bz2.sig
```
