### PR TITLE
Add support for devince binding

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -73,6 +73,20 @@ variable "worker_node_taints" {
   default     = {}
 }
 
+variable "worker_bind_devices" {
+  type        = list(object({
+    source = string
+    target = string
+  }))
+  description = <<EOD
+  List of devices to bind on kubelet container for direct storage usage
+  [
+    { source = "/dev/sdb", target = "/dev/sdb" },
+    { source = "/dev/sdc", target = "/dev/sdc" }
+  ]
+  EOD
+}
+
 # configuration
 
 variable "k8s_domain_name" {

--- a/bare-metal/flatcar-linux/kubernetes/worker/butane/worker.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/worker/butane/worker.yaml
@@ -77,6 +77,9 @@ systemd:
           --register-with-taints=${taint} \
           %{~ endfor ~}
           --node-labels=node.kubernetes.io/node
+          %{~ for device in compact(split(",", node_devices)) ~}
+          --device=${device.source}:${device.target}
+          %{~ endfor ~}
         ExecStart=docker logs -f kubelet
         ExecStop=docker stop kubelet
         ExecStopPost=docker rm kubelet

--- a/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
@@ -81,6 +81,7 @@ data "ct_config" "worker" {
     cluster_domain_suffix  = var.cluster_domain_suffix
     node_labels            = join(",", var.node_labels)
     node_taints            = join(",", var.node_taints)
+    node_devices           = var.node_devices
   })
   strict   = true
   snippets = var.snippets

--- a/bare-metal/flatcar-linux/kubernetes/workers.tf
+++ b/bare-metal/flatcar-linux/kubernetes/workers.tf
@@ -22,6 +22,7 @@ module "workers" {
   node_labels           = lookup(var.worker_node_labels, var.workers[count.index].name, [])
   node_taints           = lookup(var.worker_node_taints, var.workers[count.index].name, [])
   snippets              = lookup(var.snippets, var.workers[count.index].name, [])
+  node_devices          = lookup(var.worker_bind_devices, var.workers[count.index].name, [])
 
   # optional
   download_protocol = var.download_protocol


### PR DESCRIPTION
In some cases we need to use block devices directly (Physical volume storage).

This new variable allows the user to mount devices with the --device option for flatcar baremetal.

How to use :

add a list of objects like this to the cluster definition :
```
worker_bind_devices = [
  { source = "/dev/sdb" target = "/dev/sdb" },
  { source = "/dev/sdc" target = "/dev/sdd" },
  { source = "/dev/sdd" target = "/dev/sdd" }
]
```
This will bind the source device on the target directory in evry node.

High level description of the change.

* Specific change
* Specific change

## Testing

Describe your work to validate the change works.

rel: issue number (if applicable)
