### PR TITLE
Avoiding having to launch SSH after a node's reboot

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
@@ -124,6 +124,18 @@ systemd:
         ExecStartPost=/bin/touch /opt/bootstrap/bootstrap.done
         [Install]
         WantedBy=multi-user.target
+    - name: bootstrap-layout.service
+      contents: |
+        [Unit]
+        Description=Kubernetes layout
+        Wants=bootstrap.service
+        After=bootstrap.service
+        [Service]
+        Type=oneshot
+        RemainAfterExit=false
+        ExecStart= ${bootstrap_layout}
+        [Install]
+        WantedBy=multi-user.target
 storage:
   directories:
     - path: /var/lib/etcd
@@ -231,6 +243,16 @@ storage:
             ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt
             ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key
             ETCD_PEER_CLIENT_CERT_AUTH=true
+    - path: /home/core/assets
+      mode: 0644
+      contents:
+        inline:
+          ${assets_file}
+    - path: /etc/kubernetes/kubeconfig
+      mode: 0644
+      contents:
+        inline:
+          ${kubeconfig}
 passwd:
   users:
     - name: core

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -156,6 +156,12 @@ variable "enable_aggregation" {
   default     = true
 }
 
+variable "provision_secrets_with_ignition" {
+  type        = bool
+  description = "Enable the SSH service to move files and certificates"
+  default     = false
+}
+
 # unofficial, undocumented, unsupported
 
 variable "cluster_domain_suffix" {

--- a/bare-metal/flatcar-linux/kubernetes/worker/butane/worker.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/worker/butane/worker.yaml
@@ -132,6 +132,11 @@ storage:
       contents:
         inline: |
           fs.inotify.max_user_watches=16184
+    - path: /etc/kubernetes/kubeconfig
+      mode: 0644
+      contents:
+        inline:
+          ${kubeconfig}
 passwd:
   users:
     - name: core

--- a/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
@@ -81,6 +81,7 @@ data "ct_config" "worker" {
     cluster_domain_suffix  = var.cluster_domain_suffix
     node_labels            = join(",", var.node_labels)
     node_taints            = join(",", var.node_taints)
+    kubeconfig             = var.provision_secrets_with_ignition ? (var.kubeconfig) : "" 
   })
   strict   = true
   snippets = var.snippets

--- a/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
@@ -98,6 +98,12 @@ variable "kernel_args" {
   default     = []
 }
 
+variable "provision_secrets_with_ignition" {
+  type        = bool
+  description = "Enable the SSH service to move files and certificates"
+  default     = false
+}
+
 # unofficial, undocumented, unsupported
 
 variable "service_cidr" {


### PR DESCRIPTION
Currently, `terraform apply` has to be run after the nodes have booted, which means that if one node reboots, human intervention will be required to run `terraform apply` again, or else the node won't be instanced and will stay empty, without the information necessary for it to join the cluster again.
This commit aims to change that through the implementation of an "enable_SSH" option, which defaults to true. Disabling this option will put the files originally distributed through SSH in the butane file, which means they will be included in the ignition.json file and so the machine will go get them just like the other instructions in the ignition file.

Fixes #1316