### PR TITLE
Update Cilium to use an init container to install CNI plugins

### DIFF
--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=44315b8c02eb73b8da762ac4a4894fce77ae00d2"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=0a5d722de6931ba3b9993235fc39773390045ff9"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]


### PR DESCRIPTION
* Starting in Cilium v1.13.1, the cilium-cni plugin is installed via an init container rather than by the Cilium agent container

Rel: https://github.com/poseidon/terraform-render-bootstrap/pull/348