### PR TITLE
Omit -o flag to flatcar-install unless oem_type is defined

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/butane/install.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/install.yaml
@@ -35,7 +35,7 @@ storage:
             -d ${install_disk} \
             -C ${os_channel} \
             -V ${os_version} \
-            -o ${oem_type} \
+            ${oem_flag} \
             ${baseurl_flag} \
             -i ignition.json
           udevadm settle

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -55,7 +55,7 @@ data "ct_config" "install" {
     mac                = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
     install_disk       = var.install_disk
     ssh_authorized_key = var.ssh_authorized_key
-    oem_type           = var.oem_type
+    oem_flag           = var.oem_type != "" ? "-o ${var.oem_type}" : ""
     # only cached profile adds -b baseurl
     baseurl_flag = var.cached_install ? "-b ${var.matchbox_http_endpoint}/assets/flatcar" : ""
   })

--- a/bare-metal/flatcar-linux/kubernetes/worker/butane/install.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/worker/butane/install.yaml
@@ -35,7 +35,7 @@ storage:
             -d ${install_disk} \
             -C ${os_channel} \
             -V ${os_version} \
-            -o ${oem_type} \
+            ${oem_flag} \
             ${baseurl_flag} \
             -i ignition.json
           udevadm settle

--- a/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
@@ -50,7 +50,7 @@ data "ct_config" "install" {
     mac                = var.mac
     install_disk       = var.install_disk
     ssh_authorized_key = var.ssh_authorized_key
-    oem_type           = var.oem_type
+    oem_flag           = var.oem_type != "" ? "-o ${var.oem_type}" : ""
     # only cached profile adds -b baseurl
     baseurl_flag = var.cached_install ? "-b ${var.matchbox_http_endpoint}/assets/flatcar" : ""
   })


### PR DESCRIPTION
High level description of the change.

* The OEM parameter added in #1302 defaults to empty but results in a `-o` flag instead of a `-o ""` flag. This change omits the `-o` flag altogether unless `oem_type` is defined

## Testing

Prior to this change, running in `terraform console`:
```
templatefile("${path.module}/butane/install.yaml", {os_channel = "", os_version = "", ignition_endpoint = "", mac = "", install_disk = "", ssh_authorized_key = "", oem_type = "", baseurl_flag = ""})
```
will demonstrate the `-o` flag being added with no argument

After this change, running in `terraform console`:
```
templatefile("${path.module}/butane/install.yaml", {os_channel = "", os_version = "", ignition_endpoint = "", mac = "", install_disk = "", ssh_authorized_key = "", oem_flag = "", baseurl_flag = ""})
```
demonstrates the flag being omitted