### PR TITLE
Fix: duplicate kernel_args added to bare-metal workers

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
@@ -36,7 +36,7 @@ resource "matchbox_profile" "install" {
   name   = format("%s-install-%s", var.cluster_name, var.name)
   kernel = local.kernel
   initrd = local.initrd
-  args   = concat(local.args, var.kernel_args)
+  args   = local.args
 
   raw_ignition = data.ct_config.install.rendered
 }


### PR DESCRIPTION
High level description of the change.

* `var.kernel_args` is already included in `local.args` so concat-ing it again results in duplicate arguments on bare-metal workers

## Testing

Noted that passed in `kernel_args` were showing up twice in terraform plan output
