### PR TITLE
Consolidate the mkdocs to GitHub Pages publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,28 +3,10 @@ on:
   push:
     branches:
       - release-docs
-permissions:
-  contents: write
 jobs:
-  publish:
-    name: publish
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout repo to GitHub Actions runner
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      # Install Python
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-
-      # Install PyPI packages
-      - name: Dependencies
-        run: pip install -r requirements.txt
-
-      # Push to GitHub Pages
-      - name: Push Docs
-        run: |
-          mkdocs gh-deploy --force
+  mkdocs:
+    name: mkdocs
+    uses: poseidon/matchbox/.github/workflows/mkdocs-pages.yaml@main
+    # Add content write for GitHub Pages
+    permissions:
+      contents: write


### PR DESCRIPTION
* Use a shared GitHub Workflow to build the mkdocs site and publish to GitHub Pages (when the release-docs branch is updated)