### PR TITLE
Enable boot diagnostics for Azure controller and worker VMs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between versions.
 
 ## Latest
 
+### Azure
+
+* Enable boot diagnostics for controller and worker VMs ([#1351](https://github.com/poseidon/typhoon/pull/1351))
+
 ## v1.27.2
 
 * Kubernetes [v1.27.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v1272)

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -44,6 +44,9 @@ resource "azurerm_linux_virtual_machine" "controllers" {
 
   size        = var.controller_type
   custom_data = base64encode(data.ct_config.controllers.*.rendered[count.index])
+  boot_diagnostics {
+    # defaults to a managed storage account
+  }
 
   # storage
   os_disk {
@@ -72,7 +75,7 @@ resource "azurerm_linux_virtual_machine" "controllers" {
 
   # network
   network_interface_ids = [
-    azurerm_network_interface.controllers.*.id[count.index]
+    azurerm_network_interface.controllers[count.index].id
   ]
 
   # Azure requires setting admin_ssh_key, though Ignition custom_data handles it too

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -17,6 +17,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   computer_name_prefix   = "${var.name}-worker"
   single_placement_group = false
   custom_data            = base64encode(data.ct_config.worker.rendered)
+  boot_diagnostics {
+    # defaults to a managed storage account
+  }
 
   # storage
   os_disk {
@@ -69,6 +72,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   # eviction policy may only be set when priority is Spot
   priority        = var.priority
   eviction_policy = var.priority == "Spot" ? "Delete" : null
+  termination_notification {
+    enabled = true
+  }
 }
 
 # Scale up or down to maintain desired number, tolerating deallocations.


### PR DESCRIPTION
* When invalid Ignition snippets are provided to Typhoon, it can be useful to view Azure's boot logs for the instance, which requires boot diagnostics be enabled
* Also enable termination notices for use with poseidon/scuttle