### PR TITLE
Relax aws Terraform Provider version constraint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Notable changes between versions.
 ## Latest
 
 * Update etcd from v3.5.7 to [v3.5.9](https://github.com/etcd-io/etcd/releases/tag/v3.5.9)
+* Allow upgrading AWS Terraform provider to v5.x ([#1353](https://github.com/poseidon/typhoon/pull/1353))
 
 ### Azure
 

--- a/aws/fedora-coreos/kubernetes/versions.tf
+++ b/aws/fedora-coreos/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    aws  = ">= 2.23, <= 5.0"
+    aws  = ">= 2.23, <= 6.0"
     null = ">= 2.1"
     ct = {
       source  = "poseidon/ct"

--- a/aws/fedora-coreos/kubernetes/workers/versions.tf
+++ b/aws/fedora-coreos/kubernetes/workers/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    aws = ">= 2.23, <= 5.0"
+    aws = ">= 2.23, <= 6.0"
     ct = {
       source  = "poseidon/ct"
       version = "~> 0.13"

--- a/aws/flatcar-linux/kubernetes/versions.tf
+++ b/aws/flatcar-linux/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    aws  = ">= 2.23, <= 5.0"
+    aws  = ">= 2.23, <= 6.0"
     null = ">= 2.1"
     ct = {
       source  = "poseidon/ct"

--- a/aws/flatcar-linux/kubernetes/workers/versions.tf
+++ b/aws/flatcar-linux/kubernetes/workers/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    aws = ">= 2.23, <= 5.0"
+    aws = ">= 2.23, <= 6.0"
     ct = {
       source  = "poseidon/ct"
       version = "~> 0.11"


### PR DESCRIPTION
* aws provider v5.0+ works alright and should be permitted, relax the version constraint for the Typhoon AWS kubernetes module and worker module for Fedora CoreOS and Flatcar Linux