### PR TITLE
Update docs on flatcar-linux bare-metal kubernetes worker module usage.

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -60,7 +60,7 @@ data "ct_config" "install" {
     baseurl_flag = var.cached_install ? "-b ${var.matchbox_http_endpoint}/assets/flatcar" : ""
   })
   strict = true
-  install_snippets = lookup(var.install_snippets, var.controllers.*.name[count.index], [])
+  snippets = lookup(var.install_snippets, var.controllers.*.name[count.index], [])
 }
 
 # Match each controller by MAC

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -60,6 +60,7 @@ data "ct_config" "install" {
     baseurl_flag = var.cached_install ? "-b ${var.matchbox_http_endpoint}/assets/flatcar" : ""
   })
   strict = true
+  install_snippets = lookup(var.install_snippets, var.controllers.*.name[count.index], [])
 }
 
 # Match each controller by MAC

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -61,6 +61,12 @@ variable "snippets" {
   default     = {}
 }
 
+variable "install_snippets" {
+  type        = map(list(string))
+  description = "Map from machine names to lists of Container Linux Config snippets to run during install phase"
+  default     = {}
+}
+
 variable "worker_node_labels" {
   type        = map(list(string))
   description = "Map from worker names to lists of initial node labels"

--- a/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/matchbox.tf
@@ -55,6 +55,7 @@ data "ct_config" "install" {
     baseurl_flag = var.cached_install ? "-b ${var.matchbox_http_endpoint}/assets/flatcar" : ""
   })
   strict = true
+  snippets = var.install_snippets
 }
 
 # Match a worker to a profile by MAC

--- a/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/worker/variables.tf
@@ -60,6 +60,12 @@ variable "snippets" {
   default     = []
 }
 
+variable "install_snippets" {
+  type        = list(string)
+  description = "List of Butane snippets to run with the install command"
+  default     = []
+}
+
 variable "node_labels" {
   type        = list(string)
   description = "List of initial node labels"

--- a/bare-metal/flatcar-linux/kubernetes/workers.tf
+++ b/bare-metal/flatcar-linux/kubernetes/workers.tf
@@ -22,6 +22,7 @@ module "workers" {
   node_labels           = lookup(var.worker_node_labels, var.workers[count.index].name, [])
   node_taints           = lookup(var.worker_node_taints, var.workers[count.index].name, [])
   snippets              = lookup(var.snippets, var.workers[count.index].name, [])
+  install_snippets      = lookup(var.install_snippets, var.workers[count.index].name, [])
 
   # optional
   download_protocol = var.download_protocol

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -194,7 +194,7 @@ Workers with similar features can be defined inline using the `workers` field as
 
 ```tf
 module "mercury-node1" {
-  source = "git::https://github.com/poseidon/typhoon//bare-metal/fedora-coreos/kubernetes/worker?ref=v1.27.4"
+  source = "git::https://github.com/poseidon/typhoon//bare-metal/flatcar-linux/kubernetes/worker?ref=v1.27.4"
 
   # bare-metal
   cluster_name = "mercury"
@@ -206,13 +206,13 @@ module "mercury-node1" {
   name               = "node2"
   mac                = "52:54:00:b2:2f:86"
   domain             = "node2.example.com"
-  kubeconfig         = module.mercury.kubeconfig
+  kubeconfig         = module.mercury.kubeconfig-admin
   ssh_authorized_key = "ssh-rsa AAAAB3Nz..."
 
   # optional
   snippets       = []
   node_labels    = []
-  node_tains     = []
+  node_taints    = []
   install_disk   = "/dev/vda"
   cached_install = false
 }


### PR DESCRIPTION
Correctif typos in flatcar-linux bare-metal kubernetes worker module doc.

* code example corrections (typo)

## Testing

Run the doc, and you will see, that now it quite works.
