### PR TITLE
Workaround to allow use of ed25519 keys on Azure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,12 @@ Notable changes between versions.
 * Kubernetes [v1.28.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1282)
 * Update Cilium from v1.14.1 to [v1.14.2](https://github.com/cilium/cilium/releases/tag/v1.14.2)
 
+### Azure
+
+* Add optional `azure_authorized_key` variable
+  * Azure obtusely inspects public keys, requires RSA keys, and forbids more secure key formats (e.g. ed25519)
+  * Allow passing a dummy RSA key via `azure_authorized_key` (delete the private key) to satisfy Azure validations, then the usual `ssh_authorized_key` variable can new newer formats (e.g. ed25519)
+
 ## v1.28.1
 
 * Kubernetes [v1.28.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1281)

--- a/azure/fedora-coreos/kubernetes/controllers.tf
+++ b/azure/fedora-coreos/kubernetes/controllers.tf
@@ -1,3 +1,11 @@
+locals {
+  # Typhoon ssh_authorized_key supports RSA or a newer formats (e.g. ed25519).
+  # However, Azure requires an older RSA key to pass validations. To use a
+  # newer key format, pass a dummy RSA key as the azure_authorized_key and
+  # delete the associated private key so it's never used.
+  azure_authorized_key = var.azure_authorized_key == "" ? var.ssh_authorized_key : var.azure_authorized_key
+}
+
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "azurerm_dns_a_record" "etcds" {
   count               = var.controller_count
@@ -55,7 +63,7 @@ resource "azurerm_linux_virtual_machine" "controllers" {
   admin_username = "core"
   admin_ssh_key {
     username   = "core"
-    public_key = var.ssh_authorized_key
+    public_key = local.azure_authorized_key
   }
 
   lifecycle {

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -82,6 +82,12 @@ variable "ssh_authorized_key" {
   description = "SSH public key for user 'core'"
 }
 
+variable "azure_authorized_key" {
+  type        = string
+  description = "Optionally, pass a dummy RSA key to satisfy Azure validations (then use an ed25519 key set above)"
+  default     = ""
+}
+
 variable "networking" {
   type        = string
   description = "Choice of networking provider (flannel, calico, or cilium)"

--- a/azure/fedora-coreos/kubernetes/workers.tf
+++ b/azure/fedora-coreos/kubernetes/workers.tf
@@ -17,6 +17,7 @@ module "workers" {
   # configuration
   kubeconfig            = module.bootstrap.kubeconfig-kubelet
   ssh_authorized_key    = var.ssh_authorized_key
+  azure_authorized_key  = var.azure_authorized_key
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
   snippets              = var.worker_snippets

--- a/azure/fedora-coreos/kubernetes/workers/variables.tf
+++ b/azure/fedora-coreos/kubernetes/workers/variables.tf
@@ -73,6 +73,12 @@ variable "ssh_authorized_key" {
   description = "SSH public key for user 'core'"
 }
 
+variable "azure_authorized_key" {
+  type        = string
+  description = "Optionally, pass a dummy RSA key to satisfy Azure validations (then use an ed25519 key set above)"
+  default     = ""
+}
+
 variable "service_cidr" {
   type        = string
   description = <<EOD

--- a/azure/fedora-coreos/kubernetes/workers/workers.tf
+++ b/azure/fedora-coreos/kubernetes/workers/workers.tf
@@ -1,3 +1,7 @@
+locals {
+  azure_authorized_key = var.azure_authorized_key == "" ? var.ssh_authorized_key : var.azure_authorized_key
+}
+
 # Workers scale set
 resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   resource_group_name = var.resource_group_name
@@ -22,7 +26,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   admin_username = "core"
   admin_ssh_key {
     username   = "core"
-    public_key = var.ssh_authorized_key
+    public_key = var.azure_authorized_key
   }
 
   # network

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -20,6 +20,12 @@ locals {
   channel      = split("-", var.os_image)[1]
   offer_suffix = var.arch == "arm64" ? "corevm" : "free"
   urn          = var.arch == "arm64" ? local.channel : "${local.channel}-gen2"
+
+  # Typhoon ssh_authorized_key supports RSA or a newer formats (e.g. ed25519).
+  # However, Azure requires an older RSA key to pass validations. To use a
+  # newer key format, pass a dummy RSA key as the azure_authorized_key and
+  # delete the associated private key so it's never used.
+  azure_authorized_key = var.azure_authorized_key == "" ? var.ssh_authorized_key : var.azure_authorized_key
 }
 
 # Controller availability set to spread controllers
@@ -82,7 +88,7 @@ resource "azurerm_linux_virtual_machine" "controllers" {
   admin_username = "core"
   admin_ssh_key {
     username   = "core"
-    public_key = var.ssh_authorized_key
+    public_key = local.azure_authorized_key
   }
 
   lifecycle {

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -88,6 +88,12 @@ variable "ssh_authorized_key" {
   description = "SSH public key for user 'core'"
 }
 
+variable "azure_authorized_key" {
+  type        = string
+  description = "Optionally, pass a dummy RSA key to satisfy Azure validations (then use an ed25519 key set above)"
+  default     = ""
+}
+
 variable "networking" {
   type        = string
   description = "Choice of networking provider (flannel, calico, or cilium)"

--- a/azure/flatcar-linux/kubernetes/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers.tf
@@ -17,6 +17,7 @@ module "workers" {
   # configuration
   kubeconfig            = module.bootstrap.kubeconfig-kubelet
   ssh_authorized_key    = var.ssh_authorized_key
+  azure_authorized_key  = var.azure_authorized_key
   service_cidr          = var.service_cidr
   cluster_domain_suffix = var.cluster_domain_suffix
   snippets              = var.worker_snippets

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -79,6 +79,12 @@ variable "ssh_authorized_key" {
   description = "SSH public key for user 'core'"
 }
 
+variable "azure_authorized_key" {
+  type        = string
+  description = "Optionally, pass a dummy RSA key to satisfy Azure validations (then use an ed25519 key set above)"
+  default     = ""
+}
+
 variable "service_cidr" {
   type        = string
   description = <<EOD

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -3,6 +3,8 @@ locals {
   channel      = split("-", var.os_image)[1]
   offer_suffix = var.arch == "arm64" ? "corevm" : "free"
   urn          = var.arch == "arm64" ? local.channel : "${local.channel}-gen2"
+
+  azure_authorized_key = var.azure_authorized_key == "" ? var.ssh_authorized_key : var.azure_authorized_key
 }
 
 # Workers scale set
@@ -48,7 +50,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   admin_username = "core"
   admin_ssh_key {
     username   = "core"
-    public_key = var.ssh_authorized_key
+    public_key = local.azure_authorized_key
   }
 
   # network


### PR DESCRIPTION
* Allow passing a dummy RSA key to Azure to satisfy its obtuse requirements (recommend deleting the corresponding private key)
* Then `ssh_authorized_key` can be used to provide Fedora CoreOS or Flatcar Linux with a modern ed25519 public key to set in the authorized_keys via Ignition

Rel: https://github.com/Azure/AzureVM/issues/26