### PR TITLE
Update outputs.tf for bare-metal/flatcar-linux to include kubeconfig output

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/outputs.tf
+++ b/bare-metal/flatcar-linux/kubernetes/outputs.tf
@@ -3,6 +3,13 @@ output "kubeconfig-admin" {
   sensitive = true
 }
 
+# Outputs for workers
+
+output "kubeconfig" {
+  value     = module.bootstrap.kubeconfig-kubelet
+  sensitive = true
+}
+
 # Outputs for debug
 
 output "assets_dist" {


### PR DESCRIPTION
This PR adds the `kubeconfig` output to the bare-metal/flatcar-linux outputs.tf in order to fix support for separately defined worker modules.

Before this change, that functionality was broken as described in https://github.com/poseidon/typhoon/issues/1386

## Testing

`terraform plan` using my patched outputs.tf completes.

rel: 1386
