### PR TITLE
Workaround problems in Cilium v1.14 partial kube-proxy replacement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Notable changes between versions.
 ## v1.28.3
 
 * Kubernetes [v1.28.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1283)
+* Workaround problems in Cilium v1.14's partial `kube-proxy` implementation ([#365](https://github.com/poseidon/terraform-render-bootstrap/pull/365))
 
 ## v1.28.2
 

--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=ae571974b0b7a7fcd93c12f635fb8f2d6808ac51"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=720adbeb43a8b2860bf92544600f1fd4f0d2a907"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]


### PR DESCRIPTION
* With Cilium v1.14, Cilium's kube-proxy partial mode changed to either be enabled or disabled (not partial). This somtimes leaves Cilium (and the host) unable to reach the kube-apiserver via the in-cluster Kubernetes Service IP, until the host is rebooted
* As a workaround, configure Cilium to rely on external DNS resolvers to find the IP address of the apiserver. This is less portable and less "clean" than using in-cluster discovery, but also what Cilium wants users to do. Revert this when the upstream issue https://github.com/cilium/cilium/issues/27982 is resolved