### PR TITLE
Relax the provider version constraint for Google Cloud

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ Notable changes between versions.
 * Workaround problems in Cilium v1.14's partial `kube-proxy` implementation ([#365](https://github.com/poseidon/terraform-render-bootstrap/pull/365))
 * Update Calico from v3.26.1 to [v3.26.3](https://github.com/projectcalico/calico/releases/tag/v3.26.3)
 
+### Google Cloud
+
+* Allow upgrading Google Cloud Terraform provider to v5.x
+
 ## v1.28.2
 
 * Kubernetes [v1.28.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1282)

--- a/google-cloud/fedora-coreos/kubernetes/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    google = ">= 2.19, < 5.0"
+    google = ">= 2.19"
     null   = ">= 2.1"
     ct = {
       source  = "poseidon/ct"

--- a/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    google = ">= 2.19, < 5.0"
+    google = ">= 2.19"
     ct = {
       source  = "poseidon/ct"
       version = "~> 0.13"

--- a/google-cloud/flatcar-linux/kubernetes/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    google = ">= 2.19, < 5.0"
+    google = ">= 2.19"
     null   = ">= 2.1"
     ct = {
       source  = "poseidon/ct"

--- a/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    google = ">= 2.19, < 5.0"
+    google = ">= 2.19"
     ct = {
       source  = "poseidon/ct"
       version = "~> 0.11"


### PR DESCRIPTION
* Allow upgrading to the v5.x Google Cloud Terrform Provider
* Relax the version constraint to ease future compatibility, though it does allow users to upgrade prematurely