### PR TITLE
Fix/Ingress on gcp doesnt work by default.

### DIFF
--- a/addons/nginx-ingress/google-cloud/rbac/cluster-role.yaml
+++ b/addons/nginx-ingress/google-cloud/rbac/cluster-role.yaml
@@ -59,4 +59,11 @@ rules:
       - get
       - list
       - watch
-
+  - apiGroups: 
+      - discovery.k8s.io
+    resources:
+      - "endpointslices"
+    verbs: 
+      - get
+      - list
+      - watch


### PR DESCRIPTION
High level description of the change.

When deployed to GCP I hit this issue;


 k8s.io/client-go@v0.25.3/tools/cache/reflector.go:169: Failed to watch *v1.EndpointSlice: failed to list *v1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:ingress:default" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope 


I added the extra cluster rbacs to the ingress class and all seems to now work.

## Testing

I deployed on GCP and was able to route ingress traffic to a contianer in the cluster.

