### PR TITLE
Fix AWS launch template to retain support for IMDVv1

### DIFF
--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -78,6 +78,11 @@ resource "aws_launch_template" "worker" {
   # network
   vpc_security_group_ids = var.security_groups
 
+  # metadata
+  metadata_options {
+    http_tokens = "optional"
+  }
+
   # spot
   dynamic "instance_market_options" {
     for_each = var.spot_price > 0 ? [1] : []

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -78,6 +78,11 @@ resource "aws_launch_template" "worker" {
   # network
   vpc_security_group_ids = var.security_groups
 
+  # metadata
+  metadata_options {
+    http_tokens = "optional"
+  }
+
   # spot
   dynamic "instance_market_options" {
     for_each = var.spot_price > 0 ? [1] : []


### PR DESCRIPTION
* AWS has recently started defaulting launch templates to IMDSv2 being "required". aws_launch_template is supposed to default to "optional" but it doesn't.
* Requiring IMDSv2 sessions breaks a number of applications which don't use AWS SDKs and were never meant to be complex applications (e.g. shell scripts and the like)
