### PR TITLE
Allow CoreDNS and kube-proxy to be optional components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ Notable changes between versions.
 * Update Calico from v3.26.3 to [v3.27.2](https://github.com/projectcalico/calico/releases/tag/v3.27.2)
   * Fix upstream incompatibility with Fedora CoreOS ([calico#8372](https://github.com/projectcalico/calico/issues/8372))
 * Update flannel from v0.22.2 to [v0.24.2](https://github.com/flannel-io/flannel/releases/tag/v0.24.2)
-* Add an `install_container_networking` variable (default `true`)
+* Add an `install_container_networking` variable (default `true`) ([#1421](https://github.com/poseidon/typhoon/pull/1421))
   * When `true`, the chosen container `networking` provider is installed during cluster bootstrap
   * Set `false` to self-manage the container networking provider. This allows flannel, Calico, or Cilium
   to be managed via Terraform (like any other Kubernetes resources). Nodes will be NotReady until you

--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -13,5 +13,6 @@ module "bootstrap" {
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
+  components            = var.components
 }
 

--- a/aws/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/butane/controller.yaml
@@ -163,7 +163,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -177,8 +177,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests manifests-networking
+          rm -rf assets auth static-manifests tls manifests
           chcon -R -u system_u -t container_file_t /etc/kubernetes/pki
     - path: /opt/bootstrap/apply
       mode: 0544

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -182,3 +182,16 @@ variable "daemonset_tolerations" {
   description = "List of additional taint keys kube-system DaemonSets should tolerate (e.g. ['custom-role', 'gpu-role'])"
   default     = []
 }
+
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -13,5 +13,6 @@ module "bootstrap" {
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
+  components            = var.components
 }
 

--- a/aws/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/aws/flatcar-linux/kubernetes/butane/controller.yaml
@@ -162,7 +162,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -177,8 +177,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests manifests-networking
+          rm -rf assets auth static-manifests tls manifests
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -182,3 +182,16 @@ variable "daemonset_tolerations" {
   description = "List of additional taint keys kube-system DaemonSets should tolerate (e.g. ['custom-role', 'gpu-role'])"
   default     = []
 }
+
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -18,5 +18,6 @@ module "bootstrap" {
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
+  components            = var.components
 }
 

--- a/azure/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/butane/controller.yaml
@@ -158,7 +158,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -172,8 +172,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests-networking manifests
+          rm -rf assets auth static-manifests tls manifests
           chcon -R -u system_u -t container_file_t /etc/kubernetes/pki
     - path: /opt/bootstrap/apply
       mode: 0544

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -152,3 +152,16 @@ variable "daemonset_tolerations" {
   description = "List of additional taint keys kube-system DaemonSets should tolerate (e.g. ['custom-role', 'gpu-role'])"
   default     = []
 }
+
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -18,5 +18,6 @@ module "bootstrap" {
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
+  components            = var.components
 }
 

--- a/azure/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/azure/flatcar-linux/kubernetes/butane/controller.yaml
@@ -158,7 +158,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -173,8 +173,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests-networking manifests
+          rm -rf assets auth static-manifests tls manifests
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -169,3 +169,16 @@ variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   default     = "cluster.local"
 }
+
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]
@@ -13,6 +13,7 @@ module "bootstrap" {
   cluster_domain_suffix           = var.cluster_domain_suffix
   enable_reporting                = var.enable_reporting
   enable_aggregation              = var.enable_aggregation
+  components                      = var.components
 }
 
 

--- a/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
@@ -168,7 +168,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -182,8 +182,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests-networking manifests
+          rm -rf assets auth static-manifests tls manifests
           chcon -R -u system_u -t container_file_t /etc/kubernetes/pki
     - path: /opt/bootstrap/apply
       mode: 0544

--- a/bare-metal/fedora-coreos/kubernetes/variables.tf
+++ b/bare-metal/fedora-coreos/kubernetes/variables.tf
@@ -165,3 +165,15 @@ variable "cluster_domain_suffix" {
   default     = "cluster.local"
 }
 
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]
@@ -13,5 +13,6 @@ module "bootstrap" {
   cluster_domain_suffix           = var.cluster_domain_suffix
   enable_reporting                = var.enable_reporting
   enable_aggregation              = var.enable_aggregation
+  components                      = var.components
 }
 

--- a/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
@@ -169,7 +169,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -184,8 +184,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests-networking manifests
+          rm -rf assets auth static-manifests tls manifests
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -181,3 +181,15 @@ variable "cluster_domain_suffix" {
   default     = "cluster.local"
 }
 
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -16,5 +16,6 @@ module "bootstrap" {
   cluster_domain_suffix = var.cluster_domain_suffix
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
+  components            = var.components
 }
 

--- a/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
@@ -165,7 +165,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -179,8 +179,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests-networking manifests
+          rm -rf assets auth static-manifests tls manifests
           chcon -R -u system_u -t container_file_t /etc/kubernetes/pki
     - path: /opt/bootstrap/apply
       mode: 0544

--- a/digital-ocean/fedora-coreos/kubernetes/variables.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/variables.tf
@@ -112,3 +112,15 @@ variable "cluster_domain_suffix" {
   default     = "cluster.local"
 }
 
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -16,5 +16,6 @@ module "bootstrap" {
   cluster_domain_suffix = var.cluster_domain_suffix
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
+  components            = var.components
 }
 

--- a/digital-ocean/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/digital-ocean/flatcar-linux/kubernetes/butane/controller.yaml
@@ -167,7 +167,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -182,8 +182,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests-networking manifests
+          rm -rf assets auth static-manifests tls manifests
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/digital-ocean/flatcar-linux/kubernetes/variables.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/variables.tf
@@ -112,3 +112,15 @@ variable "cluster_domain_suffix" {
   default     = "cluster.local"
 }
 
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -13,6 +13,7 @@ module "bootstrap" {
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
+  components            = var.components
 
   // temporary
   external_apiserver_port = 443

--- a/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
@@ -157,7 +157,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -171,8 +171,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests-networking manifests
+          rm -rf assets auth static-manifests tls manifests
           chcon -R -u system_u -t container_file_t /etc/kubernetes/pki
     - path: /opt/bootstrap/apply
       mode: 0544

--- a/google-cloud/fedora-coreos/kubernetes/controllers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/controllers.tf
@@ -55,9 +55,9 @@ resource "google_compute_instance" "controllers" {
     }
   }
 
-  can_ip_forward = true
+  can_ip_forward            = true
   allow_stopping_for_update = true
-  tags           = ["${var.cluster_name}-controller"]
+  tags                      = ["${var.cluster_name}-controller"]
 
   lifecycle {
     ignore_changes = [

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -147,3 +147,16 @@ variable "daemonset_tolerations" {
   description = "List of additional taint keys kube-system DaemonSets should tolerate (e.g. ['custom-role', 'gpu-role'])"
   default     = []
 }
+
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=baf406f2616f9536af2e09d969c8b6a87dc3ed17"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=990286021a37985dcf079d4615e1deaa15575e17"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -13,6 +13,7 @@ module "bootstrap" {
   enable_reporting      = var.enable_reporting
   enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
+  components            = var.components
 
   // temporary
   external_apiserver_port = 443

--- a/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
@@ -157,7 +157,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -e
-          mkdir -p -- auth tls/etcd tls/k8s static-manifests manifests/coredns manifests-networking
+          mkdir -p -- auth tls/{etcd,k8s} static-manifests manifests/{coredns,kube-proxy,network}
           awk '/#####/ {filename=$2; next} {print > filename}' assets
           mkdir -p /etc/ssl/etcd/etcd
           mkdir -p /etc/kubernetes/pki
@@ -172,8 +172,7 @@ storage:
           mv static-manifests/* /etc/kubernetes/manifests/
           mkdir -p /opt/bootstrap/assets
           mv manifests /opt/bootstrap/assets/manifests
-          mv manifests-networking/* /opt/bootstrap/assets/manifests/ 2>/dev/null || true
-          rm -rf assets auth static-manifests tls manifests-networking manifests
+          rm -rf assets auth static-manifests tls manifests
     - path: /opt/bootstrap/apply
       mode: 0544
       contents:

--- a/google-cloud/flatcar-linux/kubernetes/controllers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/controllers.tf
@@ -31,8 +31,8 @@ resource "google_compute_instance" "controllers" {
 
   name = "${var.cluster_name}-controller-${count.index}"
   # use a zone in the region and wrap around (e.g. controllers > zones)
-  zone         = element(local.zones, count.index)
-  machine_type = var.controller_type
+  zone                      = element(local.zones, count.index)
+  machine_type              = var.controller_type
   allow_stopping_for_update = true
 
   metadata = {

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -147,3 +147,16 @@ variable "daemonset_tolerations" {
   description = "List of additional taint keys kube-system DaemonSets should tolerate (e.g. ['custom-role', 'gpu-role'])"
   default     = []
 }
+
+variable "components" {
+  description = "Configure pre-installed cluster components"
+  # Component configs are passed through to terraform-render-bootstrap,
+  # which handles type enforcement and defines defaults
+  # https://github.com/poseidon/terraform-render-bootstrap/blob/main/variables.tf#L95
+  type = object({
+    enable     = optional(bool)
+    coredns    = optional(map(any))
+    kube_proxy = optional(map(any))
+  })
+  default = null
+}


### PR DESCRIPTION
* Allow for more minimal base cluster setups, that manage CoreDNS or kube-proxy as applications, with rolling updates, or deploy systems. Or in the case of kube-proxy, its becoming more common to not install it and instead use Cilium
* Add a `components` pass-through variable to configure pre-installed components like kube-proxy and CoreDNS. These components can be disabled (individually or together) to allow for managing components with separate plan/apply processes or automations
* terraform-render-bootstrap manifest assets are now structured as manifests/{coredns,kube-proxy,network} so adapt the controller layout scripts accordingly
* This is similar to some changes in v1.29.2 that allowed for the container networking provider manifests to be skipped

```tf
module "cluster" {
  ...

  # Configure pre-installed components (defaults shown)
  components = {
    enable = true
    coredns = {
      enable = true
    }
    kube_proxy = {
      enable = true
    }
  }
}
```

Related: https://github.com/poseidon/typhoon/pull/1419, https://github.com/poseidon/typhoon/pull/1421