### PR TITLE
Add firewall and security rules for Cilium/Hubble metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Notable changes between versions.
 
 ## Latest
 
+* Add firewall rules and security group rules for Cilium and Hubble metrics ([#1449](https://github.com/poseidon/typhoon/pull/1449))
 * Update Cilium from v1.15.3 to [v1.15.4](https://github.com/cilium/cilium/releases/tag/v1.15.4)
 * Update flannel from v0.24.4 to [v0.25.1](https://github.com/flannel-io/flannel/releases/tag/v0.25.1)
 

--- a/aws/fedora-coreos/kubernetes/security.tf
+++ b/aws/fedora-coreos/kubernetes/security.tf
@@ -92,6 +92,30 @@ resource "aws_security_group_rule" "controller-cilium-health-self" {
   self      = true
 }
 
+resource "aws_security_group_rule" "controller-cilium-metrics" {
+  count = var.networking == "cilium" ? 1 : 0
+
+  security_group_id = aws_security_group.controller.id
+
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9962
+  to_port                  = 9965
+  source_security_group_id = aws_security_group.worker.id
+}
+
+resource "aws_security_group_rule" "controller-cilium-metrics-self" {
+  count = var.networking == "cilium" ? 1 : 0
+
+  security_group_id = aws_security_group.controller.id
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 9962
+  to_port   = 9965
+  self      = true
+}
+
 # IANA VXLAN default
 resource "aws_security_group_rule" "controller-vxlan" {
   count = var.networking == "flannel" ? 1 : 0
@@ -376,6 +400,30 @@ resource "aws_security_group_rule" "worker-cilium-health-self" {
   protocol  = "tcp"
   from_port = 4240
   to_port   = 4240
+  self      = true
+}
+
+resource "aws_security_group_rule" "worker-cilium-metrics" {
+  count = var.networking == "cilium" ? 1 : 0
+
+  security_group_id = aws_security_group.worker.id
+
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9962
+  to_port                  = 9965
+  source_security_group_id = aws_security_group.controller.id
+}
+
+resource "aws_security_group_rule" "worker-cilium-metrics-self" {
+  count = var.networking == "cilium" ? 1 : 0
+
+  security_group_id = aws_security_group.worker.id
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 9962
+  to_port   = 9965
   self      = true
 }
 

--- a/aws/flatcar-linux/kubernetes/security.tf
+++ b/aws/flatcar-linux/kubernetes/security.tf
@@ -92,6 +92,30 @@ resource "aws_security_group_rule" "controller-cilium-health-self" {
   self      = true
 }
 
+resource "aws_security_group_rule" "controller-cilium-metrics" {
+  count = var.networking == "cilium" ? 1 : 0
+
+  security_group_id = aws_security_group.controller.id
+
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9962
+  to_port                  = 9965
+  source_security_group_id = aws_security_group.worker.id
+}
+
+resource "aws_security_group_rule" "controller-cilium-metrics-self" {
+  count = var.networking == "cilium" ? 1 : 0
+
+  security_group_id = aws_security_group.controller.id
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 9962
+  to_port   = 9965
+  self      = true
+}
+
 # IANA VXLAN default
 resource "aws_security_group_rule" "controller-vxlan" {
   count = var.networking == "flannel" ? 1 : 0
@@ -376,6 +400,30 @@ resource "aws_security_group_rule" "worker-cilium-health-self" {
   protocol  = "tcp"
   from_port = 4240
   to_port   = 4240
+  self      = true
+}
+
+resource "aws_security_group_rule" "worker-cilium-metrics" {
+  count = var.networking == "cilium" ? 1 : 0
+
+  security_group_id = aws_security_group.worker.id
+
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9962
+  to_port                  = 9965
+  source_security_group_id = aws_security_group.controller.id
+}
+
+resource "aws_security_group_rule" "worker-cilium-metrics-self" {
+  count = var.networking == "cilium" ? 1 : 0
+
+  security_group_id = aws_security_group.worker.id
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 9962
+  to_port   = 9965
   self      = true
 }
 

--- a/azure/fedora-coreos/kubernetes/security.tf
+++ b/azure/fedora-coreos/kubernetes/security.tf
@@ -121,12 +121,28 @@ resource "azurerm_network_security_rule" "controller-cilium-health" {
 
   name                         = "allow-cilium-health"
   network_security_group_name  = azurerm_network_security_group.controller.name
-  priority                     = "2019"
+  priority                     = "2018"
   access                       = "Allow"
   direction                    = "Inbound"
   protocol                     = "Tcp"
   source_port_range            = "*"
   destination_port_range       = "4240"
+  source_address_prefixes      = concat(azurerm_subnet.controller.address_prefixes, azurerm_subnet.worker.address_prefixes)
+  destination_address_prefixes = azurerm_subnet.controller.address_prefixes
+}
+
+resource "azurerm_network_security_rule" "controller-cilium-metrics" {
+  resource_group_name = azurerm_resource_group.cluster.name
+  count               = var.networking == "cilium" ? 1 : 0
+
+  name                         = "allow-cilium-metrics"
+  network_security_group_name  = azurerm_network_security_group.controller.name
+  priority                     = "2019"
+  access                       = "Allow"
+  direction                    = "Inbound"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "9962-9965"
   source_address_prefixes      = concat(azurerm_subnet.controller.address_prefixes, azurerm_subnet.worker.address_prefixes)
   destination_address_prefixes = azurerm_subnet.controller.address_prefixes
 }
@@ -303,12 +319,28 @@ resource "azurerm_network_security_rule" "worker-cilium-health" {
 
   name                         = "allow-cilium-health"
   network_security_group_name  = azurerm_network_security_group.worker.name
-  priority                     = "2014"
+  priority                     = "2013"
   access                       = "Allow"
   direction                    = "Inbound"
   protocol                     = "Tcp"
   source_port_range            = "*"
   destination_port_range       = "4240"
+  source_address_prefixes      = concat(azurerm_subnet.controller.address_prefixes, azurerm_subnet.worker.address_prefixes)
+  destination_address_prefixes = azurerm_subnet.worker.address_prefixes
+}
+
+resource "azurerm_network_security_rule" "worker-cilium-metrics" {
+  resource_group_name = azurerm_resource_group.cluster.name
+  count               = var.networking == "cilium" ? 1 : 0
+
+  name                         = "allow-cilium-metrics"
+  network_security_group_name  = azurerm_network_security_group.worker.name
+  priority                     = "2014"
+  access                       = "Allow"
+  direction                    = "Inbound"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "9962-9965"
   source_address_prefixes      = concat(azurerm_subnet.controller.address_prefixes, azurerm_subnet.worker.address_prefixes)
   destination_address_prefixes = azurerm_subnet.worker.address_prefixes
 }

--- a/azure/flatcar-linux/kubernetes/security.tf
+++ b/azure/flatcar-linux/kubernetes/security.tf
@@ -121,12 +121,28 @@ resource "azurerm_network_security_rule" "controller-cilium-health" {
 
   name                         = "allow-cilium-health"
   network_security_group_name  = azurerm_network_security_group.controller.name
-  priority                     = "2019"
+  priority                     = "2018"
   access                       = "Allow"
   direction                    = "Inbound"
   protocol                     = "Tcp"
   source_port_range            = "*"
   destination_port_range       = "4240"
+  source_address_prefixes      = concat(azurerm_subnet.controller.address_prefixes, azurerm_subnet.worker.address_prefixes)
+  destination_address_prefixes = azurerm_subnet.controller.address_prefixes
+}
+
+resource "azurerm_network_security_rule" "controller-cilium-metrics" {
+  resource_group_name = azurerm_resource_group.cluster.name
+  count               = var.networking == "cilium" ? 1 : 0
+
+  name                         = "allow-cilium-metrics"
+  network_security_group_name  = azurerm_network_security_group.controller.name
+  priority                     = "2019"
+  access                       = "Allow"
+  direction                    = "Inbound"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "9962-9965"
   source_address_prefixes      = concat(azurerm_subnet.controller.address_prefixes, azurerm_subnet.worker.address_prefixes)
   destination_address_prefixes = azurerm_subnet.controller.address_prefixes
 }
@@ -303,12 +319,28 @@ resource "azurerm_network_security_rule" "worker-cilium-health" {
 
   name                         = "allow-cilium-health"
   network_security_group_name  = azurerm_network_security_group.worker.name
-  priority                     = "2014"
+  priority                     = "2013"
   access                       = "Allow"
   direction                    = "Inbound"
   protocol                     = "Tcp"
   source_port_range            = "*"
   destination_port_range       = "4240"
+  source_address_prefixes      = concat(azurerm_subnet.controller.address_prefixes, azurerm_subnet.worker.address_prefixes)
+  destination_address_prefixes = azurerm_subnet.worker.address_prefixes
+}
+
+resource "azurerm_network_security_rule" "worker-cilium-metrics" {
+  resource_group_name = azurerm_resource_group.cluster.name
+  count               = var.networking == "cilium" ? 1 : 0
+
+  name                         = "allow-cilium-metrics"
+  network_security_group_name  = azurerm_network_security_group.worker.name
+  priority                     = "2014"
+  access                       = "Allow"
+  direction                    = "Inbound"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "9962-9965"
   source_address_prefixes      = concat(azurerm_subnet.controller.address_prefixes, azurerm_subnet.worker.address_prefixes)
   destination_address_prefixes = azurerm_subnet.worker.address_prefixes
 }

--- a/digital-ocean/fedora-coreos/kubernetes/network.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/network.tf
@@ -32,6 +32,13 @@ resource "digitalocean_firewall" "rules" {
     source_tags = [digitalocean_tag.controllers.name, digitalocean_tag.workers.name]
   }
 
+  # Cilium metrics
+  inbound_rule {
+    protocol    = "tcp"
+    port_range  = "9962-9965"
+    source_tags = [digitalocean_tag.controllers.name, digitalocean_tag.workers.name]
+  }
+
   # IANA vxlan (flannel, calico)
   inbound_rule {
     protocol    = "udp"

--- a/digital-ocean/flatcar-linux/kubernetes/network.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/network.tf
@@ -32,6 +32,13 @@ resource "digitalocean_firewall" "rules" {
     source_tags = [digitalocean_tag.controllers.name, digitalocean_tag.workers.name]
   }
 
+  # Cilium metrics
+  inbound_rule {
+    protocol    = "tcp"
+    port_range  = "9962-9965"
+    source_tags = [digitalocean_tag.controllers.name, digitalocean_tag.workers.name]
+  }
+
   # IANA vxlan (flannel, calico)
   inbound_rule {
     protocol    = "udp"

--- a/google-cloud/fedora-coreos/kubernetes/network.tf
+++ b/google-cloud/fedora-coreos/kubernetes/network.tf
@@ -112,13 +112,14 @@ resource "google_compute_firewall" "internal-vxlan" {
   target_tags = ["${var.cluster_name}-controller", "${var.cluster_name}-worker"]
 }
 
-# Cilium VXLAN
-resource "google_compute_firewall" "internal-linux-vxlan" {
+# Cilium
+resource "google_compute_firewall" "internal-cilium" {
   count = var.networking == "cilium" ? 1 : 0
 
-  name    = "${var.cluster_name}-linux-vxlan"
+  name    = "${var.cluster_name}-cilium"
   network = google_compute_network.network.name
 
+  # vxlan
   allow {
     protocol = "udp"
     ports    = [8472]
@@ -128,10 +129,15 @@ resource "google_compute_firewall" "internal-linux-vxlan" {
   allow {
     protocol = "icmp"
   }
-
   allow {
     protocol = "tcp"
     ports    = [4240]
+  }
+
+  # metrics
+  allow {
+    protocol = "tcp"
+    ports    = [9962, 9963, 9964, 9965]
   }
 
   source_tags = ["${var.cluster_name}-controller", "${var.cluster_name}-worker"]

--- a/google-cloud/flatcar-linux/kubernetes/network.tf
+++ b/google-cloud/flatcar-linux/kubernetes/network.tf
@@ -112,13 +112,14 @@ resource "google_compute_firewall" "internal-vxlan" {
   target_tags = ["${var.cluster_name}-controller", "${var.cluster_name}-worker"]
 }
 
-# Cilium VXLAN
-resource "google_compute_firewall" "internal-linux-vxlan" {
+# Cilium
+resource "google_compute_firewall" "internal-cilium" {
   count = var.networking == "cilium" ? 1 : 0
 
-  name    = "${var.cluster_name}-linux-vxlan"
+  name    = "${var.cluster_name}-cilium"
   network = google_compute_network.network.name
 
+  # vxlan
   allow {
     protocol = "udp"
     ports    = [8472]
@@ -128,10 +129,15 @@ resource "google_compute_firewall" "internal-linux-vxlan" {
   allow {
     protocol = "icmp"
   }
-
   allow {
     protocol = "tcp"
     ports    = [4240]
+  }
+
+  # metrics
+  allow {
+    protocol = "tcp"
+    ports    = [9962, 9963, 9964, 9965]
   }
 
   source_tags = ["${var.cluster_name}-controller", "${var.cluster_name}-worker"]


### PR DESCRIPTION
* Add firewall or security riles to allow node-to-node traffic on ports 9962-9965 for Cilium and Hubble metrics. Cilium runs with host network, so these require cloud firewall changes