### PR TITLE
azure: Add controller security group and subnet outputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ Notable changes between versions.
 * Update Cilium from v1.15.3 to [v1.15.4](https://github.com/cilium/cilium/releases/tag/v1.15.4)
 * Update flannel from v0.24.4 to [v0.25.1](https://github.com/flannel-io/flannel/releases/tag/v0.25.1)
 
+### Azure
+
+* Add `controller_security_group_name` output for adding custom security rules ([#1450](https://github.com/poseidon/typhoon/pull/1450))
+* Add `controller_address_prefixes` output for adding custom security rules ([#1450](https://github.com/poseidon/typhoon/pull/1450))
+
 ## v1.30.0
 
 * Kubernetes [v1.30.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v1300)

--- a/azure/fedora-coreos/kubernetes/outputs.tf
+++ b/azure/fedora-coreos/kubernetes/outputs.tf
@@ -39,8 +39,19 @@ output "kubeconfig" {
 
 # Outputs for custom firewalling
 
+output "controller_security_group_name" {
+  description = "Network Security Group for controller nodes"
+  value       = azurerm_network_security_group.controller.name
+}
+
 output "worker_security_group_name" {
-  value = azurerm_network_security_group.worker.name
+  description = "Network Security Group for worker nodes"
+  value       = azurerm_network_security_group.worker.name
+}
+
+output "controller_address_prefixes" {
+  description = "Controller network subnet CIDR addresses (for source/destination)"
+  value       = azurerm_subnet.controller.address_prefixes
 }
 
 output "worker_address_prefixes" {

--- a/azure/flatcar-linux/kubernetes/outputs.tf
+++ b/azure/flatcar-linux/kubernetes/outputs.tf
@@ -39,8 +39,19 @@ output "kubeconfig" {
 
 # Outputs for custom firewalling
 
+output "controller_security_group_name" {
+  description = "Network Security Group for controller nodes"
+  value       = azurerm_network_security_group.controller.name
+}
+
 output "worker_security_group_name" {
-  value = azurerm_network_security_group.worker.name
+  description = "Network Security Group for worker nodes"
+  value       = azurerm_network_security_group.worker.name
+}
+
+output "controller_address_prefixes" {
+  description = "Controller network subnet CIDR addresses (for source/destination)"
+  value       = azurerm_subnet.controller.address_prefixes
 }
 
 output "worker_address_prefixes" {

--- a/docs/architecture/azure.md
+++ b/docs/architecture/azure.md
@@ -51,7 +51,7 @@ Add firewall rules to the worker security group.
 
 ```tf
 resource "azurerm_network_security_rule" "some-app" {
-  resource_group_name = "${module.ramius.resource_group_name}"
+  resource_group_name = module.ramius.resource_group_name
 
   name                         = "some-app"
   network_security_group_name  = module.ramius.worker_security_group_name


### PR DESCRIPTION
* Output the network security group name and address prefixes for controller nodes, to allow adding custom network security rules that apply specifically to controller nodes