### PR TITLE
Rename Azure cluster region variable to location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Notable changes between versions.
 
 ### Azure
 
+* Rename `region` variable to `location` to align with Azure platform conventions
 * Configure the virtual network and subnets with IPv6 private address space
   * Change `host_cidr` variable (string) to a `network_cidr` object with `ipv4` and `ipv6` fields that list CIDR strings. Leave the variable unset to use the defaults. (**breaking**)
 * Add support for dual-stack Kubernetes Ingress Load Balancing
@@ -21,6 +22,8 @@ Notable changes between versions.
 ```diff
 module "cluster" {
   ...
+- region = "centralus"
++ location = "centralus"
   # optional
 - host_cidr = "10.0.0.0/16"
 + network_cidr = {

--- a/azure/fedora-coreos/kubernetes/controllers.tf
+++ b/azure/fedora-coreos/kubernetes/controllers.tf
@@ -26,7 +26,7 @@ resource "azurerm_dns_a_record" "etcds" {
 resource "azurerm_availability_set" "controllers" {
   name                         = "${var.cluster_name}-controllers"
   resource_group_name          = azurerm_resource_group.cluster.name
-  location                     = var.region
+  location                     = var.location
   platform_fault_domain_count  = 2
   platform_update_domain_count = 4
   managed                      = true
@@ -38,7 +38,7 @@ resource "azurerm_linux_virtual_machine" "controllers" {
 
   name                = "${var.cluster_name}-controller-${count.index}"
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   availability_set_id = azurerm_availability_set.controllers.id
   size                = var.controller_type
 

--- a/azure/fedora-coreos/kubernetes/lb.tf
+++ b/azure/fedora-coreos/kubernetes/lb.tf
@@ -17,7 +17,7 @@ resource "azurerm_dns_a_record" "apiserver" {
 resource "azurerm_public_ip" "apiserver-ipv4" {
   name                = "${var.cluster_name}-apiserver-ipv4"
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   sku                 = "Standard"
   allocation_method   = "Static"
 }
@@ -26,7 +26,7 @@ resource "azurerm_public_ip" "apiserver-ipv4" {
 resource "azurerm_public_ip" "ingress-ipv4" {
   name                = "${var.cluster_name}-ingress-ipv4"
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   ip_version          = "IPv4"
   sku                 = "Standard"
   allocation_method   = "Static"
@@ -36,7 +36,7 @@ resource "azurerm_public_ip" "ingress-ipv4" {
 resource "azurerm_public_ip" "ingress-ipv6" {
   name                = "${var.cluster_name}-ingress-ipv6"
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   ip_version          = "IPv6"
   sku                 = "Standard"
   allocation_method   = "Static"
@@ -46,7 +46,7 @@ resource "azurerm_public_ip" "ingress-ipv6" {
 resource "azurerm_lb" "cluster" {
   name                = var.cluster_name
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   sku                 = "Standard"
 
   frontend_ip_configuration {

--- a/azure/fedora-coreos/kubernetes/network.tf
+++ b/azure/fedora-coreos/kubernetes/network.tf
@@ -19,7 +19,7 @@ locals {
 # Organize cluster into a resource group
 resource "azurerm_resource_group" "cluster" {
   name     = var.cluster_name
-  location = var.region
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "network" {

--- a/azure/fedora-coreos/kubernetes/outputs.tf
+++ b/azure/fedora-coreos/kubernetes/outputs.tf
@@ -17,7 +17,7 @@ output "ingress_static_ipv6" {
 
 # Outputs for worker pools
 
-output "region" {
+output "location" {
   value = azurerm_resource_group.cluster.location
 }
 

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -5,9 +5,9 @@ variable "cluster_name" {
 
 # Azure
 
-variable "region" {
+variable "location" {
   type        = string
-  description = "Azure Region (e.g. centralus , see `az account list-locations --output table`)"
+  description = "Azure location (e.g. centralus , see `az account list-locations --output table`)"
 }
 
 variable "dns_zone" {

--- a/azure/fedora-coreos/kubernetes/workers.tf
+++ b/azure/fedora-coreos/kubernetes/workers.tf
@@ -4,7 +4,7 @@ module "workers" {
 
   # Azure
   resource_group_name      = azurerm_resource_group.cluster.name
-  region                   = azurerm_resource_group.cluster.location
+  location                 = azurerm_resource_group.cluster.location
   subnet_id                = azurerm_subnet.worker.id
   security_group_id        = azurerm_network_security_group.worker.id
   backend_address_pool_ids = local.backend_address_pool_ids

--- a/azure/fedora-coreos/kubernetes/workers/variables.tf
+++ b/azure/fedora-coreos/kubernetes/workers/variables.tf
@@ -5,9 +5,9 @@ variable "name" {
 
 # Azure
 
-variable "region" {
+variable "location" {
   type        = string
-  description = "Must be set to the Azure Region of cluster"
+  description = "Must be set to the Azure location of cluster"
 }
 
 variable "resource_group_name" {

--- a/azure/fedora-coreos/kubernetes/workers/workers.tf
+++ b/azure/fedora-coreos/kubernetes/workers/workers.tf
@@ -6,7 +6,7 @@ locals {
 resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   name                = "${var.name}-worker"
   resource_group_name = var.resource_group_name
-  location            = var.region
+  location            = var.location
   sku                 = var.vm_type
   instances           = var.worker_count
   # instance name prefix for instances in the set
@@ -70,7 +70,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
 resource "azurerm_monitor_autoscale_setting" "workers" {
   name                = "${var.name}-maintain-desired"
   resource_group_name = var.resource_group_name
-  location            = var.region
+  location            = var.location
   # autoscale
   enabled            = true
   target_resource_id = azurerm_linux_virtual_machine_scale_set.workers.id

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -32,7 +32,7 @@ resource "azurerm_dns_a_record" "etcds" {
 resource "azurerm_availability_set" "controllers" {
   name                         = "${var.cluster_name}-controllers"
   resource_group_name          = azurerm_resource_group.cluster.name
-  location                     = var.region
+  location                     = var.location
   platform_fault_domain_count  = 2
   platform_update_domain_count = 4
   managed                      = true
@@ -44,7 +44,7 @@ resource "azurerm_linux_virtual_machine" "controllers" {
 
   name                = "${var.cluster_name}-controller-${count.index}"
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   availability_set_id = azurerm_availability_set.controllers.id
   size                = var.controller_type
 

--- a/azure/flatcar-linux/kubernetes/lb.tf
+++ b/azure/flatcar-linux/kubernetes/lb.tf
@@ -17,7 +17,7 @@ resource "azurerm_dns_a_record" "apiserver" {
 resource "azurerm_public_ip" "apiserver-ipv4" {
   name                = "${var.cluster_name}-apiserver-ipv4"
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   sku                 = "Standard"
   allocation_method   = "Static"
 }
@@ -26,7 +26,7 @@ resource "azurerm_public_ip" "apiserver-ipv4" {
 resource "azurerm_public_ip" "ingress-ipv4" {
   name                = "${var.cluster_name}-ingress-ipv4"
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   ip_version          = "IPv4"
   sku                 = "Standard"
   allocation_method   = "Static"
@@ -36,7 +36,7 @@ resource "azurerm_public_ip" "ingress-ipv4" {
 resource "azurerm_public_ip" "ingress-ipv6" {
   name                = "${var.cluster_name}-ingress-ipv6"
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   ip_version          = "IPv6"
   sku                 = "Standard"
   allocation_method   = "Static"
@@ -46,7 +46,7 @@ resource "azurerm_public_ip" "ingress-ipv6" {
 resource "azurerm_lb" "cluster" {
   name                = var.cluster_name
   resource_group_name = azurerm_resource_group.cluster.name
-  location            = var.region
+  location            = var.location
   sku                 = "Standard"
 
   frontend_ip_configuration {

--- a/azure/flatcar-linux/kubernetes/network.tf
+++ b/azure/flatcar-linux/kubernetes/network.tf
@@ -19,7 +19,7 @@ locals {
 # Organize cluster into a resource group
 resource "azurerm_resource_group" "cluster" {
   name     = var.cluster_name
-  location = var.region
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "network" {

--- a/azure/flatcar-linux/kubernetes/outputs.tf
+++ b/azure/flatcar-linux/kubernetes/outputs.tf
@@ -17,7 +17,7 @@ output "ingress_static_ipv6" {
 
 # Outputs for worker pools
 
-output "region" {
+output "location" {
   value = azurerm_resource_group.cluster.location
 }
 

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -5,9 +5,9 @@ variable "cluster_name" {
 
 # Azure
 
-variable "region" {
+variable "location" {
   type        = string
-  description = "Azure Region (e.g. centralus , see `az account list-locations --output table`)"
+  description = "Azure location (e.g. centralus , see `az account list-locations --output table`)"
 }
 
 variable "dns_zone" {

--- a/azure/flatcar-linux/kubernetes/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers.tf
@@ -4,7 +4,7 @@ module "workers" {
 
   # Azure
   resource_group_name      = azurerm_resource_group.cluster.name
-  region                   = azurerm_resource_group.cluster.location
+  location                 = azurerm_resource_group.cluster.location
   subnet_id                = azurerm_subnet.worker.id
   security_group_id        = azurerm_network_security_group.worker.id
   backend_address_pool_ids = local.backend_address_pool_ids

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -5,9 +5,9 @@ variable "name" {
 
 # Azure
 
-variable "region" {
+variable "location" {
   type        = string
-  description = "Must be set to the Azure Region of cluster"
+  description = "Must be set to the Azure location of cluster"
 }
 
 variable "resource_group_name" {

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -11,7 +11,7 @@ locals {
 resource "azurerm_linux_virtual_machine_scale_set" "workers" {
   name                = "${var.name}-worker"
   resource_group_name = var.resource_group_name
-  location            = var.region
+  location            = var.location
   sku                 = var.vm_type
   instances           = var.worker_count
   # instance name prefix for instances in the set
@@ -91,7 +91,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "workers" {
 resource "azurerm_monitor_autoscale_setting" "workers" {
   name                = "${var.name}-maintain-desired"
   resource_group_name = var.resource_group_name
-  location            = var.region
+  location            = var.location
   # autoscale
   enabled            = true
   target_resource_id = azurerm_linux_virtual_machine_scale_set.workers.id

--- a/docs/advanced/arm64.md
+++ b/docs/advanced/arm64.md
@@ -190,7 +190,7 @@ module "ramius" {
 
   # Azure
   cluster_name   = "ramius"
-  region         = "centralus"
+  location       = "centralus"
   dns_zone       = "azure.example.com"
   dns_zone_group = "example-group"
 
@@ -202,6 +202,5 @@ module "ramius" {
   controller_type = "Standard_D2pls_v5"
   worker_type     = "Standard_D2pls_v5"
   worker_count    = 2
-  host_cidr       = "10.0.0.0/20"
 }
 ```

--- a/docs/advanced/worker-pools.md
+++ b/docs/advanced/worker-pools.md
@@ -114,7 +114,7 @@ Create a cluster following the Azure [tutorial](../flatcar-linux/azure.md#cluste
       source = "git::https://github.com/poseidon/typhoon//azure/fedora-coreos/kubernetes/workers?ref=v1.30.2"
 
       # Azure
-      region                   = module.ramius.region
+      location                 = module.ramius.location
       resource_group_name      = module.ramius.resource_group_name
       subnet_id                = module.ramius.subnet_id
       security_group_id        = module.ramius.security_group_id
@@ -140,7 +140,7 @@ Create a cluster following the Azure [tutorial](../flatcar-linux/azure.md#cluste
       source = "git::https://github.com/poseidon/typhoon//azure/flatcar-linux/kubernetes/workers?ref=v1.30.2"
 
       # Azure
-      region                   = module.ramius.region
+      location                 = module.ramius.location
       resource_group_name      = module.ramius.resource_group_name
       subnet_id                = module.ramius.subnet_id
       security_group_id        = module.ramius.security_group_id

--- a/docs/fedora-coreos/azure.md
+++ b/docs/fedora-coreos/azure.md
@@ -90,7 +90,7 @@ module "ramius" {
 
   # Azure
   cluster_name   = "ramius"
-  region         = "centralus"
+  location       = "centralus"
   dns_zone       = "azure.example.com"
   dns_zone_group = "example-group"
 
@@ -199,14 +199,14 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/azure/f
 | Name | Description | Example |
 |:-----|:------------|:--------|
 | cluster_name | Unique cluster name (prepended to dns_zone) | "ramius" |
-| region | Azure region | "centralus" |
+| location | Azure location | "centralus" |
 | dns_zone | Azure DNS zone | "azure.example.com" |
 | dns_zone_group | Resource group where the Azure DNS zone resides | "global" |
 | os_image | Fedora CoreOS image for instances | "/subscriptions/..../custom-image" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-ed25519 AAAAB3NZ..." |
 
 !!! tip
-    Regions are shown in [docs](https://azure.microsoft.com/en-us/global-infrastructure/regions/) or with `az account list-locations --output table`.
+    Locations are shown in [docs](https://azure.microsoft.com/en-us/global-infrastructure/regions/) or with `az account list-locations --output table`.
 
 #### DNS Zone
 

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -79,7 +79,7 @@ module "ramius" {
 
   # Azure
   cluster_name   = "ramius"
-  region         = "centralus"
+  location       = "centralus"
   dns_zone       = "azure.example.com"
   dns_zone_group = "example-group"
 
@@ -187,13 +187,13 @@ Check the [variables.tf](https://github.com/poseidon/typhoon/blob/master/azure/f
 | Name | Description | Example |
 |:-----|:------------|:--------|
 | cluster_name | Unique cluster name (prepended to dns_zone) | "ramius" |
-| region | Azure region | "centralus" |
+| location | Azure location | "centralus" |
 | dns_zone | Azure DNS zone | "azure.example.com" |
 | dns_zone_group | Resource group where the Azure DNS zone resides | "global" |
 | ssh_authorized_key | SSH public key for user 'core' | "ssh-rsa AAAAB3NZ..." |
 
 !!! tip
-    Regions are shown in [docs](https://azure.microsoft.com/en-us/global-infrastructure/regions/) or with `az account list-locations --output table`.
+    Locations are shown in [docs](https://azure.microsoft.com/en-us/global-infrastructure/regions/) or with `az account list-locations --output table`.
 
 #### DNS Zone
 


### PR DESCRIPTION
* Rename the region variable to location to align with Azure platform conventions, where resources are created within an Azure location, which are themselves part of broader geographical regions