### PR TITLE
Remove some seldom used variables and set reasonable values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@ Notable changes between versions.
 
 ## Latest
 
+* Remove `enable_aggregation` variable for Kubernetes Aggregation Layer, always set to true
 * Remove `cluster_domain_suffix` variable, always use "cluster.local"
+* Remove `enable_reporting` variable for analytics, always set to false
 
 ## v1.30.3
 

--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -9,8 +9,6 @@ module "bootstrap" {
   network_mtu           = var.network_mtu
   pod_cidr              = var.pod_cidr
   service_cidr          = var.service_cidr
-  enable_reporting      = var.enable_reporting
-  enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
   components            = var.components
 }

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -172,18 +172,6 @@ variable "worker_node_labels" {
 
 # advanced
 
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 variable "controller_arch" {
   type        = string
   description = "Controller node(s) architecture (amd64 or arm64)"

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -9,8 +9,6 @@ module "bootstrap" {
   network_mtu           = var.network_mtu
   pod_cidr              = var.pod_cidr
   service_cidr          = var.service_cidr
-  enable_reporting      = var.enable_reporting
-  enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
   components            = var.components
 }

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -172,18 +172,6 @@ variable "worker_node_labels" {
 
 # advanced
 
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 variable "controller_arch" {
   type        = string
   description = "Controller node(s) architecture (amd64 or arm64)"

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -14,8 +14,6 @@ module "bootstrap" {
 
   pod_cidr              = var.pod_cidr
   service_cidr          = var.service_cidr
-  enable_reporting      = var.enable_reporting
-  enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
   components            = var.components
 }

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -152,18 +152,6 @@ variable "worker_node_labels" {
 
 # advanced
 
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 variable "daemonset_tolerations" {
   type        = list(string)
   description = "List of additional taint keys kube-system DaemonSets should tolerate (e.g. ['custom-role', 'gpu-role'])"

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -14,8 +14,6 @@ module "bootstrap" {
 
   pod_cidr              = var.pod_cidr
   service_cidr          = var.service_cidr
-  enable_reporting      = var.enable_reporting
-  enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
   components            = var.components
 }

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -150,18 +150,6 @@ EOD
   default     = "10.3.0.0/16"
 }
 
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 variable "worker_node_labels" {
   type        = list(string)
   description = "List of initial worker node labels"

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -10,8 +10,6 @@ module "bootstrap" {
   network_ip_autodetection_method = var.network_ip_autodetection_method
   pod_cidr                        = var.pod_cidr
   service_cidr                    = var.service_cidr
-  enable_reporting                = var.enable_reporting
-  enable_aggregation              = var.enable_aggregation
   components                      = var.components
 }
 

--- a/bare-metal/fedora-coreos/kubernetes/variables.tf
+++ b/bare-metal/fedora-coreos/kubernetes/variables.tf
@@ -139,18 +139,6 @@ variable "kernel_args" {
   default     = []
 }
 
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 # advanced
 
 variable "components" {

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -10,8 +10,6 @@ module "bootstrap" {
   network_ip_autodetection_method = var.network_ip_autodetection_method
   pod_cidr                        = var.pod_cidr
   service_cidr                    = var.service_cidr
-  enable_reporting                = var.enable_reporting
-  enable_aggregation              = var.enable_aggregation
   components                      = var.components
 }
 

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -144,18 +144,6 @@ variable "kernel_args" {
   default     = []
 }
 
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 variable "oem_type" {
   type        = string
   description = <<EOD

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -11,10 +11,8 @@ module "bootstrap" {
   network_encapsulation = "vxlan"
   network_mtu           = "1450"
 
-  pod_cidr           = var.pod_cidr
-  service_cidr       = var.service_cidr
-  enable_reporting   = var.enable_reporting
-  enable_aggregation = var.enable_aggregation
-  components         = var.components
+  pod_cidr     = var.pod_cidr
+  service_cidr = var.service_cidr
+  components   = var.components
 }
 

--- a/digital-ocean/fedora-coreos/kubernetes/variables.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/variables.tf
@@ -86,18 +86,6 @@ EOD
   default     = "10.3.0.0/16"
 }
 
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 # advanced
 
 variable "components" {

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -11,10 +11,8 @@ module "bootstrap" {
   network_encapsulation = "vxlan"
   network_mtu           = "1450"
 
-  pod_cidr           = var.pod_cidr
-  service_cidr       = var.service_cidr
-  enable_reporting   = var.enable_reporting
-  enable_aggregation = var.enable_aggregation
-  components         = var.components
+  pod_cidr     = var.pod_cidr
+  service_cidr = var.service_cidr
+  components   = var.components
 }
 

--- a/digital-ocean/flatcar-linux/kubernetes/variables.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/variables.tf
@@ -86,18 +86,6 @@ EOD
   default     = "10.3.0.0/16"
 }
 
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 # advanced
 
 variable "components" {

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -9,8 +9,6 @@ module "bootstrap" {
   network_mtu           = 1440
   pod_cidr              = var.pod_cidr
   service_cidr          = var.service_cidr
-  enable_reporting      = var.enable_reporting
-  enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
   components            = var.components
 

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -115,19 +115,6 @@ EOD
   default     = "10.3.0.0/16"
 }
 
-
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 variable "worker_node_labels" {
   type        = list(string)
   description = "List of initial worker node labels"

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -9,8 +9,6 @@ module "bootstrap" {
   network_mtu           = 1440
   pod_cidr              = var.pod_cidr
   service_cidr          = var.service_cidr
-  enable_reporting      = var.enable_reporting
-  enable_aggregation    = var.enable_aggregation
   daemonset_tolerations = var.daemonset_tolerations
   components            = var.components
 

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -115,18 +115,6 @@ EOD
   default     = "10.3.0.0/16"
 }
 
-variable "enable_reporting" {
-  type        = bool
-  description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = false
-}
-
-variable "enable_aggregation" {
-  type        = bool
-  description = "Enable the Kubernetes Aggregation Layer"
-  default     = true
-}
-
 variable "worker_node_labels" {
   type        = list(string)
   description = "List of initial worker node labels"


### PR DESCRIPTION
* Set reasonable values and remove some variable clutter
* enable_reporting is only used with Calico and we can just default to false, I doubt anyone uses Calico and cares much about reporting metrics to upstream Calico