### PR TITLE
Remove upper bound on azurerm provider version

### DIFF
--- a/azure/fedora-coreos/kubernetes/versions.tf
+++ b/azure/fedora-coreos/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    azurerm = ">= 2.8, < 4.0"
+    azurerm = ">= 2.8"
     null    = ">= 2.1"
     ct = {
       source  = "poseidon/ct"

--- a/azure/fedora-coreos/kubernetes/workers/versions.tf
+++ b/azure/fedora-coreos/kubernetes/workers/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    azurerm = ">= 2.8, < 4.0"
+    azurerm = ">= 2.8"
     ct = {
       source  = "poseidon/ct"
       version = "~> 0.13"

--- a/azure/flatcar-linux/kubernetes/versions.tf
+++ b/azure/flatcar-linux/kubernetes/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    azurerm = ">= 2.8, < 4.0"
+    azurerm = ">= 2.8"
     null    = ">= 2.1"
     ct = {
       source  = "poseidon/ct"

--- a/azure/flatcar-linux/kubernetes/workers/versions.tf
+++ b/azure/flatcar-linux/kubernetes/workers/versions.tf
@@ -3,7 +3,7 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    azurerm = ">= 2.8, < 4.0"
+    azurerm = ">= 2.8"
     ct = {
       source  = "poseidon/ct"
       version = "~> 0.13"


### PR DESCRIPTION
* Allow folks to start upgrading to azurerm provider v4.0.0, don't set an upper bound on versions going forward