### PR TITLE
google: Use regional instance templates for workers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,11 @@ Notable changes between versions.
   * The Amazon DNS server can resolve A and AAAA queries to IPv4 and IPv6 node addresses
 * Tag controller node EBS volumes with a name based on the controller node name
 
+### Google
+
+* Use `google_compute_region_instance_template` instead of `google_compute_instance_template`
+  * Google's regional instance template metadata is kept in the associated region for greater resiliency. The "global" instance templates were kept in a single region
+
 ## v1.30.4
 
 * Kubernetes [v1.30.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v1304)

--- a/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
@@ -8,7 +8,7 @@ resource "google_compute_region_instance_group_manager" "workers" {
   region             = var.region
   version {
     name              = "default"
-    instance_template = google_compute_instance_template.worker.self_link
+    instance_template = google_compute_region_instance_template.worker.self_link
   }
 
   # Roll out MIG instance template changes by replacing instances.
@@ -58,7 +58,7 @@ resource "google_compute_health_check" "worker" {
 }
 
 # Worker instance template
-resource "google_compute_instance_template" "worker" {
+resource "google_compute_region_instance_template" "worker" {
   name_prefix  = "${var.name}-worker-"
   description  = "${var.name} worker instance template"
   machine_type = var.machine_type

--- a/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
@@ -8,7 +8,7 @@ resource "google_compute_region_instance_group_manager" "workers" {
   region             = var.region
   version {
     name              = "default"
-    instance_template = google_compute_instance_template.worker.self_link
+    instance_template = google_compute_region_instance_template.worker.self_link
   }
 
   # Roll out MIG instance template changes by replacing instances.
@@ -58,7 +58,7 @@ resource "google_compute_health_check" "worker" {
 }
 
 # Worker instance template
-resource "google_compute_instance_template" "worker" {
+resource "google_compute_region_instance_template" "worker" {
   name_prefix  = "${var.name}-worker-"
   description  = "Worker Instance template"
   machine_type = var.machine_type


### PR DESCRIPTION
* Use regional instance templates for the worker node regional managed instance groups. Regional instance templates are kept in the associated region, whereas the older "global" instance templates were kept in a particular region (regardless of where the MIG region) so outages in a region X could affect clusters in a region Y which is undesired