### PR TITLE
feat: add option to enable IMDSv2

### DIFF
--- a/aws/fedora-coreos/kubernetes/controllers.tf
+++ b/aws/fedora-coreos/kubernetes/controllers.tf
@@ -16,6 +16,10 @@ resource "aws_route53_record" "etcds" {
 # Controller instances
 resource "aws_instance" "controllers" {
   count = var.controller_count
+  metadata_options {
+    http_tokens                 = var.http_tokens
+    http_put_response_hop_limit = var.http_put_response_hop_limit
+  }
 
   tags = {
     Name = "${var.cluster_name}-controller-${count.index}"

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -213,3 +213,13 @@ variable "components" {
   })
   default = null
 }
+
+variable "http_tokens" {
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2)"
+  default     = "optional"
+}
+
+variable "http_put_response_hop_limit" {
+  description = "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel."
+  default     = 1
+}

--- a/aws/fedora-coreos/kubernetes/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers.tf
@@ -20,10 +20,12 @@ module "workers" {
   target_groups = var.worker_target_groups
 
   # configuration
-  kubeconfig         = module.bootstrap.kubeconfig-kubelet
-  ssh_authorized_key = var.ssh_authorized_key
-  service_cidr       = var.service_cidr
-  snippets           = var.worker_snippets
-  node_labels        = var.worker_node_labels
+  kubeconfig                  = module.bootstrap.kubeconfig-kubelet
+  ssh_authorized_key          = var.ssh_authorized_key
+  service_cidr                = var.service_cidr
+  snippets                    = var.worker_snippets
+  node_labels                 = var.worker_node_labels
+  http_tokens                 = var.http_tokens
+  http_put_response_hop_limit = var.http_put_response_hop_limit
 }
 

--- a/aws/fedora-coreos/kubernetes/workers/variables.tf
+++ b/aws/fedora-coreos/kubernetes/workers/variables.tf
@@ -131,3 +131,13 @@ variable "arch" {
     error_message = "The arch must be amd64 or arm64."
   }
 }
+
+variable "http_tokens" {
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2)"
+  default     = "optional"
+}
+
+variable "http_put_response_hop_limit" {
+  description = "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel."
+  default     = 1
+}

--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -84,8 +84,10 @@ resource "aws_launch_template" "worker" {
 
   # metadata
   metadata_options {
-    http_tokens = "optional"
+    http_tokens                 = var.http_tokens
+    http_put_response_hop_limit = var.http_put_response_hop_limit
   }
+
   monitoring {
     enabled = false
   }

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -16,7 +16,10 @@ resource "aws_route53_record" "etcds" {
 # Controller instances
 resource "aws_instance" "controllers" {
   count = var.controller_count
-
+  metadata_options {
+    http_tokens                 = var.http_tokens
+    http_put_response_hop_limit = var.http_put_response_hop_limit
+  }
   tags = {
     Name = "${var.cluster_name}-controller-${count.index}"
   }

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -213,3 +213,13 @@ variable "components" {
   })
   default = null
 }
+
+variable "http_tokens" {
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2)"
+  default     = "optional"
+}
+
+variable "http_put_response_hop_limit" {
+  description = "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel."
+  default     = 1
+}

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -19,10 +19,12 @@ module "workers" {
   target_groups = var.worker_target_groups
 
   # configuration
-  kubeconfig         = module.bootstrap.kubeconfig-kubelet
-  ssh_authorized_key = var.ssh_authorized_key
-  service_cidr       = var.service_cidr
-  snippets           = var.worker_snippets
-  node_labels        = var.worker_node_labels
+  kubeconfig                  = module.bootstrap.kubeconfig-kubelet
+  ssh_authorized_key          = var.ssh_authorized_key
+  service_cidr                = var.service_cidr
+  snippets                    = var.worker_snippets
+  node_labels                 = var.worker_node_labels
+  http_tokens                 = var.http_tokens
+  http_put_response_hop_limit = var.http_put_response_hop_limit
 }
 

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -132,3 +132,13 @@ variable "arch" {
     error_message = "The arch must be amd64 or arm64."
   }
 }
+
+variable "http_tokens" {
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2)"
+  default     = "optional"
+}
+
+variable "http_put_response_hop_limit" {
+  description = "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel."
+  default     = 1
+}

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -83,8 +83,10 @@ resource "aws_launch_template" "worker" {
 
   # metadata
   metadata_options {
-    http_tokens = "optional"
+    http_tokens                 = var.http_tokens
+    http_put_response_hop_limit = var.http_put_response_hop_limit
   }
+
   monitoring {
     enabled = false
   }


### PR DESCRIPTION
Adding terraform variables to optionally enable IMDSv2 as in some organizations is not possible to deploy EC2 instances that do not have IMDSv2 enabled.


tested deploying 
```
module "bruvio" {
  source = "git::https://github.com/bruvio/typhoon//aws/flatcar-linux/kubernetes?ref=feature/enable-IMDSv2"



  cluster_name       = var.cluster_name
  dns_zone           = var.dns_zone
  dns_zone_id        = var.dns_zone_id
  ssh_authorized_key = var.ssh_authorized_key
  networking         = "calico"
  network_mtu        = 8981
  components         = local.custom_components


  # optional
  host_cidr          = "10.0.0.0/16"
  controller_count   = 1
  worker_count       = 2
  worker_node_labels = ["worker"]
  http_tokens = "required"
  http_put_response_hop_limit = 1
}
```

resolves #1510 