### PR TITLE
Add region to gcp instance template resource

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,15 @@ Notable changes between versions.
 
 ## Latest
 
+## v1.31.1
+
 * Kubernetes [v1.31.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1311)
 * Update flannel from v0.25.5 to [v0.25.6](https://github.com/flannel-io/flannel/releases/tag/v0.25.6)
 
 ### Google
 
 * Add `controller_disk_type` and `worker_disk_type` variables ([#1513](https://github.com/poseidon/typhoon/pull/1513))
+* Add explicit `region` field to regional worker instance templates ([#1524](https://github.com/poseidon/typhoon/pull/1524))
 
 ## v1.31.0
 

--- a/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
@@ -62,6 +62,7 @@ resource "google_compute_region_instance_template" "worker" {
   name_prefix  = "${var.name}-worker-"
   description  = "${var.name} worker instance template"
   machine_type = var.machine_type
+  region       = var.region
 
   metadata = {
     user-data = data.ct_config.worker.rendered

--- a/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
@@ -62,6 +62,7 @@ resource "google_compute_region_instance_template" "worker" {
   name_prefix  = "${var.name}-worker-"
   description  = "Worker Instance template"
   machine_type = var.machine_type
+  region       = var.region
 
   metadata = {
     user-data = data.ct_config.worker.rendered


### PR DESCRIPTION
* Configure the regional worker instance templates with the region of the cluster. This defaults to the provider's region which isn't always what you want and if left off causes an error
* Close #1512