### PR TITLE
Fix nginx addon (service selector on bare-metal, rbac for all except gcp)

### DIFF
--- a/addons/nginx-ingress/aws/rbac/cluster-role.yaml
+++ b/addons/nginx-ingress/aws/rbac/cluster-role.yaml
@@ -29,7 +29,7 @@ rules:
       - list
       - watch
   - apiGroups:
-    - ""
+      - ""
     resources:
       - events
     verbs:
@@ -59,4 +59,11 @@ rules:
       - get
       - list
       - watch
-
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - "endpointslices"
+    verbs:
+      - get
+      - list
+      - watch

--- a/addons/nginx-ingress/azure/rbac/cluster-role.yaml
+++ b/addons/nginx-ingress/azure/rbac/cluster-role.yaml
@@ -29,7 +29,7 @@ rules:
       - list
       - watch
   - apiGroups:
-    - ""
+      - ""
     resources:
       - events
     verbs:
@@ -59,4 +59,11 @@ rules:
       - get
       - list
       - watch
-
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - "endpointslices"
+    verbs:
+      - get
+      - list
+      - watch

--- a/addons/nginx-ingress/bare-metal/rbac/cluster-role.yaml
+++ b/addons/nginx-ingress/bare-metal/rbac/cluster-role.yaml
@@ -29,7 +29,7 @@ rules:
       - list
       - watch
   - apiGroups:
-    - ""
+      - ""
     resources:
       - events
     verbs:
@@ -59,4 +59,11 @@ rules:
       - get
       - list
       - watch
-
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - "endpointslices"
+    verbs:
+      - get
+      - list
+      - watch

--- a/addons/nginx-ingress/bare-metal/service.yaml
+++ b/addons/nginx-ingress/bare-metal/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ingress-controller-public
+  name: nginx-ingress-controller
   namespace: ingress
   annotations:
     prometheus.io/scrape: 'true'
@@ -10,7 +10,7 @@ spec:
   type: ClusterIP
   clusterIP: 10.3.0.12
   selector:
-    name: ingress-controller-public
+    name: nginx-ingress-controller
     phase: prod
   ports:
     - name: http

--- a/addons/nginx-ingress/digital-ocean/rbac/cluster-role.yaml
+++ b/addons/nginx-ingress/digital-ocean/rbac/cluster-role.yaml
@@ -29,7 +29,7 @@ rules:
       - list
       - watch
   - apiGroups:
-    - ""
+      - ""
     resources:
       - events
     verbs:
@@ -59,4 +59,11 @@ rules:
       - get
       - list
       - watch
-
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - "endpointslices"
+    verbs:
+      - get
+      - list
+      - watch

--- a/addons/nginx-ingress/google-cloud/rbac/cluster-role.yaml
+++ b/addons/nginx-ingress/google-cloud/rbac/cluster-role.yaml
@@ -29,7 +29,7 @@ rules:
       - list
       - watch
   - apiGroups:
-    - ""
+      - ""
     resources:
       - events
     verbs:
@@ -59,11 +59,11 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
       - discovery.k8s.io
     resources:
       - "endpointslices"
-    verbs: 
+    verbs:
       - get
       - list
       - watch


### PR DESCRIPTION
This extends #1409 to all other platforms + fixes the selector for bare-metal deployments. 

I've only validated the necessary rbac role on bare-metal, but I think it's fair to assume that it applies to nginx on all other platforms too. Happy to remove the unvalidated fixes though if you'd rather not merge them.