### PR TITLE
Configure Kubelets for parallel image pulls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Notable changes between versions.
 # v1.32.0
 
 * Kubernetes [v1.32.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1320)
+* Change the default Pod CIDR from 10.2.0.0/16 to 10.20.0.0/14 ([#1555](https://github.com/poseidon/typhoon/pull/1555))
+* Configure Kubelets for parallel image pulls ([#1556](https://github.com/poseidon/typhoon/pull/1556))
 
 # v1.31.4
 

--- a/aws/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/butane/controller.yaml
@@ -152,6 +152,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -107,6 +107,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/aws/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/aws/flatcar-linux/kubernetes/butane/controller.yaml
@@ -151,6 +151,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/aws/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/aws/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -106,6 +106,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/azure/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/butane/controller.yaml
@@ -147,6 +147,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -102,6 +102,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/azure/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/azure/flatcar-linux/kubernetes/butane/controller.yaml
@@ -147,6 +147,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/azure/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/azure/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -102,6 +102,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
@@ -157,6 +157,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/bare-metal/fedora-coreos/kubernetes/worker/butane/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/worker/butane/worker.yaml
@@ -111,6 +111,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/butane/controller.yaml
@@ -158,6 +158,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/bare-metal/flatcar-linux/kubernetes/worker/butane/worker.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/worker/butane/worker.yaml
@@ -116,6 +116,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
@@ -154,6 +154,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/digital-ocean/fedora-coreos/kubernetes/butane/worker.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/butane/worker.yaml
@@ -107,6 +107,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/digital-ocean/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/digital-ocean/flatcar-linux/kubernetes/butane/controller.yaml
@@ -156,6 +156,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/digital-ocean/flatcar-linux/kubernetes/butane/worker.yaml
+++ b/digital-ocean/flatcar-linux/kubernetes/butane/worker.yaml
@@ -106,6 +106,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
@@ -146,6 +146,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -101,6 +101,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
@@ -146,6 +146,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests

--- a/google-cloud/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -101,6 +101,7 @@ storage:
           clusterDomain: cluster.local
           healthzPort: 0
           rotateCertificates: true
+          serializeImagePulls: false
           shutdownGracePeriod: 45s
           shutdownGracePeriodCriticalPods: 30s
           staticPodPath: /etc/kubernetes/manifests


### PR DESCRIPTION
* By default, Kubelet will pull container images one by one (in series), which is mostly related to Docker-era bugs in parallel image pulls. These days we use containerd so parallel pulls should be fine
* Serial image pulls are undesirable because one slow registry or image can cause other image pulls to wait. Parallel image pulls ensure only large images / slow registries see that impact

Docs: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/