### PR TITLE
Load nf_conntrack and br_netfilter for flannel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ Notable changes between versions.
   * Remove `network_mtu`, `network_encapsulation`, and `network_ip_autodetection_method` variables (Calico-specific)
   * Remove Calico-specific Kubelet mounts
 
+### Fedora CoreOS
+
+* Fix Fedora CoreOS support for flannel CNI ([#1557](https://github.com/poseidon/typhoon/pull/1557))
+  * Explicitly load the `nf_conntrack` and `br_netfilter` kernel modules flannel needs
+
 # v1.31.4
 
 * Kubernetes [v1.31.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1314)

--- a/aws/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/butane/controller.yaml
@@ -157,6 +157,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /opt/bootstrap/layout
       mode: 0544
       contents:

--- a/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -112,6 +112,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /etc/systemd/logind.conf.d/inhibitors.conf
       contents:
         inline: |

--- a/azure/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/butane/controller.yaml
@@ -152,6 +152,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /opt/bootstrap/layout
       mode: 0544
       contents:

--- a/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -107,6 +107,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /etc/systemd/logind.conf.d/inhibitors.conf
       contents:
         inline: |

--- a/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/butane/controller.yaml
@@ -162,6 +162,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /opt/bootstrap/layout
       mode: 0544
       contents:

--- a/bare-metal/fedora-coreos/kubernetes/worker/butane/worker.yaml
+++ b/bare-metal/fedora-coreos/kubernetes/worker/butane/worker.yaml
@@ -116,6 +116,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /etc/systemd/logind.conf.d/inhibitors.conf
       contents:
         inline: |

--- a/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/butane/controller.yaml
@@ -159,6 +159,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /opt/bootstrap/layout
       mode: 0544
       contents:

--- a/digital-ocean/fedora-coreos/kubernetes/butane/worker.yaml
+++ b/digital-ocean/fedora-coreos/kubernetes/butane/worker.yaml
@@ -112,6 +112,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /etc/systemd/logind.conf.d/inhibitors.conf
       contents:
         inline: |

--- a/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
@@ -151,6 +151,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /opt/bootstrap/layout
       mode: 0544
       contents:

--- a/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -106,6 +106,13 @@ storage:
           readOnlyPort: 0
           resolvConf: /run/systemd/resolve/resolv.conf
           volumePluginDir: /var/lib/kubelet/volumeplugins
+    - path: /etc/modules-load.d/typhoon.conf
+      mode: 0644
+      contents:
+        inline: |
+          # https://github.com/flannel-io/flannel/tree/master
+          nf_conntrack
+          br_netfilter
     - path: /etc/systemd/logind.conf.d/inhibitors.conf
       contents:
         inline: |


### PR DESCRIPTION
* Explicitly load the `nf_conntrack` and `br_netfilter` kernel modules to support flannel setups
* Flannel requires hosts have the `br_netfilter` kernel module loaded
* `kube-proxy` is still used when flannel is chosen, and it requires `nf_conntrack` module be loaded