### PR TITLE
Remove calico from component configuration

### DIFF
--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -202,7 +202,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -202,7 +202,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -168,7 +168,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -194,7 +194,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null

--- a/bare-metal/fedora-coreos/kubernetes/variables.tf
+++ b/bare-metal/fedora-coreos/kubernetes/variables.tf
@@ -139,7 +139,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -155,7 +155,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null

--- a/digital-ocean/fedora-coreos/kubernetes/variables.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/variables.tf
@@ -98,7 +98,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null

--- a/digital-ocean/flatcar-linux/kubernetes/variables.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/variables.tf
@@ -98,7 +98,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null

--- a/docs/addons/overview.md
+++ b/docs/addons/overview.md
@@ -51,9 +51,6 @@ module "yavin" {
     flannel = {
       enable = true
     }
-    calico = {
-      enable = true
-    }
     cilium = {
       enable = true
     }

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -159,7 +159,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -159,7 +159,6 @@ variable "components" {
     coredns    = optional(map(any))
     kube_proxy = optional(map(any))
     flannel    = optional(map(any))
-    calico     = optional(map(any))
     cilium     = optional(map(any))
   })
   default = null


### PR DESCRIPTION
* Calico is no longer supported, so enabling or disabling the component does nothing. Remove the field from components