### PR TITLE
azure: Add `enable_ipv6_load_balancing` variable and default false

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,12 @@ Notable changes between versions.
   * Remove `network_mtu`, `network_encapsulation`, and `network_ip_autodetection_method` variables (Calico-specific)
   * Remove Calico-specific Kubelet mounts
 
+### Azure
+
+* Add `enable_ipv6_load_balancing` variable and change the default to false (**breaking**)
+  * Azure Load Balancers include 5 rules (3 LB rules, 2 outbound) whether used or not
+  * [#1468](https://github.com/poseidon/typhoon/pull/1468) added 3 LB rules to support IPv6 load balancing,
+  raising the rules count from 5 to 8 and added ~$21/mo to the cost of the load balancer
 
 ### Fedora CoreOS
 

--- a/azure/fedora-coreos/kubernetes/lb.tf
+++ b/azure/fedora-coreos/kubernetes/lb.tf
@@ -18,7 +18,7 @@ resource "azurerm_dns_aaaa_record" "apiserver" {
   # DNS record
   name = var.cluster_name
   ttl  = 300
-  # IPv4 address of apiserver load balancer
+  # IPv6 address of apiserver load balancer
   records = [azurerm_public_ip.frontend-ipv6.ip_address]
 }
 
@@ -74,6 +74,8 @@ resource "azurerm_lb_rule" "apiserver-ipv4" {
 }
 
 resource "azurerm_lb_rule" "apiserver-ipv6" {
+  count = var.enable_ipv6_load_balancing ? 1 : 0
+
   name                           = "apiserver-ipv6"
   loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "frontend-ipv6"
@@ -113,6 +115,8 @@ resource "azurerm_lb_rule" "ingress-https-ipv4" {
 }
 
 resource "azurerm_lb_rule" "ingress-http-ipv6" {
+  count = var.enable_ipv6_load_balancing ? 1 : 0
+
   name                           = "ingress-http-ipv6"
   loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "frontend-ipv6"
@@ -126,6 +130,8 @@ resource "azurerm_lb_rule" "ingress-http-ipv6" {
 }
 
 resource "azurerm_lb_rule" "ingress-https-ipv6" {
+  count = var.enable_ipv6_load_balancing ? 1 : 0
+
   name                           = "ingress-https-ipv6"
   loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "frontend-ipv6"
@@ -140,7 +146,7 @@ resource "azurerm_lb_rule" "ingress-https-ipv6" {
 
 # Backend Address Pools
 
-# Address pool of controllers
+# Address pools for controllers
 resource "azurerm_lb_backend_address_pool" "controller-ipv4" {
   name            = "controller-ipv4"
   loadbalancer_id = azurerm_lb.cluster.id
@@ -151,7 +157,7 @@ resource "azurerm_lb_backend_address_pool" "controller-ipv6" {
   loadbalancer_id = azurerm_lb.cluster.id
 }
 
-# Address pool of workers
+# Address pools for workers
 resource "azurerm_lb_backend_address_pool" "worker-ipv4" {
   name            = "worker-ipv4"
   loadbalancer_id = azurerm_lb.cluster.id

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -144,6 +144,11 @@ EOD
   default     = "10.3.0.0/16"
 }
 
+variable "enable_ipv6_load_balancing" {
+  description = "Enable IPv6 LB rules (note: Azure charges ~$20/mo more)"
+  default     = false
+}
+
 variable "worker_node_labels" {
   type        = list(string)
   description = "List of initial worker node labels"

--- a/azure/flatcar-linux/kubernetes/lb.tf
+++ b/azure/flatcar-linux/kubernetes/lb.tf
@@ -74,6 +74,8 @@ resource "azurerm_lb_rule" "apiserver-ipv4" {
 }
 
 resource "azurerm_lb_rule" "apiserver-ipv6" {
+  count = var.enable_ipv6_load_balancing ? 1 : 0
+
   name                           = "apiserver-ipv6"
   loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "frontend-ipv6"
@@ -113,6 +115,8 @@ resource "azurerm_lb_rule" "ingress-https-ipv4" {
 }
 
 resource "azurerm_lb_rule" "ingress-http-ipv6" {
+  count = var.enable_ipv6_load_balancing ? 1 : 0
+
   name                           = "ingress-http-ipv6"
   loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "frontend-ipv6"
@@ -126,6 +130,8 @@ resource "azurerm_lb_rule" "ingress-http-ipv6" {
 }
 
 resource "azurerm_lb_rule" "ingress-https-ipv6" {
+  count = var.enable_ipv6_load_balancing ? 1 : 0
+
   name                           = "ingress-https-ipv6"
   loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "frontend-ipv6"
@@ -140,7 +146,7 @@ resource "azurerm_lb_rule" "ingress-https-ipv6" {
 
 # Backend Address Pools
 
-# Address pool of controllers
+# Address pools for controllers
 resource "azurerm_lb_backend_address_pool" "controller-ipv4" {
   name            = "controller-ipv4"
   loadbalancer_id = azurerm_lb.cluster.id

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -150,6 +150,11 @@ EOD
   default     = "10.3.0.0/16"
 }
 
+variable "enable_ipv6_load_balancing" {
+  description = "Enable IPv6 LB rules (note: Azure charges ~$20/mo more)"
+  default     = false
+}
+
 variable "worker_node_labels" {
   type        = list(string)
   description = "List of initial worker node labels"


### PR DESCRIPTION
* Azure Load Balancers include 5 rules (e.g. 3 LB rules, 2 outbound), whether used or not (~$18/mo)
* [#1468](https://github.com/poseidon/typhoon/pull/1468) added 3 LB rules to support IPv6 load balancing, raising the rules count from 5 to 8 and added ~$21/mo to the cost of the load balancer
* I noticed this because my load balancing costs were up for the last few months. The gotcha is that outbound rules count toward the 5 rules included with the base cost of the LB (~$18/mo)

Docs: https://azure.microsoft.com/en-us/pricing/details/load-balancer/