### PR TITLE
Restore Azure auto-scale settings for VMSS node pools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between versions.
 
 ## Latest
 
+### Azure
+
+* Restore VMSS auto-scale setting to maintain node pools sizes during spot terminations ([#1567](https://github.com/poseidon/typhoon/pull/1567))
+
 # v1.32.0
 
 * Kubernetes [v1.32.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1320)

--- a/azure/fedora-coreos/kubernetes/workers/workers.tf
+++ b/azure/fedora-coreos/kubernetes/workers/workers.tf
@@ -91,3 +91,20 @@ data "ct_config" "worker" {
   snippets = var.snippets
 }
 
+# Scale up or down to maintain desired number, tolerating deallocations.
+resource "azurerm_monitor_autoscale_setting" "workers" {
+  name                = "${var.name}-maintain-desired"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  # autoscale
+  enabled            = true
+  target_resource_id = azurerm_orchestrated_virtual_machine_scale_set.workers.id
+  profile {
+    name = "default"
+    capacity {
+      minimum = var.worker_count
+      default = var.worker_count
+      maximum = var.worker_count
+    }
+  }
+}

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -111,3 +111,21 @@ data "ct_config" "worker" {
   strict   = true
   snippets = var.snippets
 }
+
+# Scale up or down to maintain desired number, tolerating deallocations.
+resource "azurerm_monitor_autoscale_setting" "workers" {
+  name                = "${var.name}-maintain-desired"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  # autoscale
+  enabled            = true
+  target_resource_id = azurerm_orchestrated_virtual_machine_scale_set.workers.id
+  profile {
+    name = "default"
+    capacity {
+      minimum = var.worker_count
+      default = var.worker_count
+      maximum = var.worker_count
+    }
+  }
+}


### PR DESCRIPTION
* Using spot instances, when an instance is deleted it actually lowers the desired number of nodes in the VMSS so the node is not replaced
* Restore the auto-scale setting needed to maintain a consistent desired number of workers while spot instances come and go. This was mistakely removed in refactoring