### PR TITLE
Add service_account_issuer variable for kube-apiserver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Notable changes between versions.
 
 ## Latest
 
+* Allow `kube-apiserver` service account token issuer `iss` to be adjusted with the `service_account_issuer` variable
+  * Allows OpenID Connect discovery to be served from an external endpoint
+
 ## v1.32.1
 
 * Kubernetes [v1.32.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1321)

--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,14 +1,15 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
-  cluster_name          = var.cluster_name
-  api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers          = aws_route53_record.etcds.*.fqdn
-  networking            = var.networking
-  pod_cidr              = var.pod_cidr
-  service_cidr          = var.service_cidr
-  daemonset_tolerations = var.daemonset_tolerations
-  components            = var.components
+  cluster_name           = var.cluster_name
+  api_servers            = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  service_account_issuer = var.service_account_issuer
+  etcd_servers           = aws_route53_record.etcds.*.fqdn
+  networking             = var.networking
+  pod_cidr               = var.pod_cidr
+  service_cidr           = var.service_cidr
+  daemonset_tolerations  = var.daemonset_tolerations
+  components             = var.components
 }
 

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -206,3 +206,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,14 +1,15 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
-  cluster_name          = var.cluster_name
-  api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers          = aws_route53_record.etcds.*.fqdn
-  networking            = var.networking
-  pod_cidr              = var.pod_cidr
-  service_cidr          = var.service_cidr
-  daemonset_tolerations = var.daemonset_tolerations
-  components            = var.components
+  cluster_name           = var.cluster_name
+  api_servers            = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  service_account_issuer = var.service_account_issuer
+  etcd_servers           = aws_route53_record.etcds.*.fqdn
+  networking             = var.networking
+  pod_cidr               = var.pod_cidr
+  service_cidr           = var.service_cidr
+  daemonset_tolerations  = var.daemonset_tolerations
+  components             = var.components
 }
 

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -206,3 +206,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,15 +1,16 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
   cluster_name = var.cluster_name
-  api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
   etcd_servers = formatlist("%s.%s", azurerm_dns_a_record.etcds.*.name, var.dns_zone)
+  api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
 
-  networking            = var.networking
-  pod_cidr              = var.pod_cidr
-  service_cidr          = var.service_cidr
-  daemonset_tolerations = var.daemonset_tolerations
-  components            = var.components
+  service_account_issuer = var.service_account_issuer
+  networking             = var.networking
+  pod_cidr               = var.pod_cidr
+  service_cidr           = var.service_cidr
+  daemonset_tolerations  = var.daemonset_tolerations
+  components             = var.components
 }
 

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -177,3 +177,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,15 +1,16 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
   etcd_servers = formatlist("%s.%s", azurerm_dns_a_record.etcds.*.name, var.dns_zone)
 
-  networking            = var.networking
-  pod_cidr              = var.pod_cidr
-  service_cidr          = var.service_cidr
-  daemonset_tolerations = var.daemonset_tolerations
-  components            = var.components
+  service_account_issuer = var.service_account_issuer
+  networking             = var.networking
+  pod_cidr               = var.pod_cidr
+  service_cidr           = var.service_cidr
+  daemonset_tolerations  = var.daemonset_tolerations
+  components             = var.components
 }
 

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -203,3 +203,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,14 +1,15 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
-  cluster_name = var.cluster_name
-  api_servers  = [var.k8s_domain_name]
-  etcd_servers = var.controllers.*.domain
-  networking   = var.networking
-  pod_cidr     = var.pod_cidr
-  service_cidr = var.service_cidr
-  components   = var.components
+  cluster_name           = var.cluster_name
+  api_servers            = [var.k8s_domain_name]
+  service_account_issuer = var.service_account_issuer
+  etcd_servers           = var.controllers.*.domain
+  networking             = var.networking
+  pod_cidr               = var.pod_cidr
+  service_cidr           = var.service_cidr
+  components             = var.components
 }
 
 

--- a/bare-metal/fedora-coreos/kubernetes/variables.tf
+++ b/bare-metal/fedora-coreos/kubernetes/variables.tf
@@ -143,3 +143,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,13 +1,14 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
-  cluster_name = var.cluster_name
-  api_servers  = [var.k8s_domain_name]
-  etcd_servers = var.controllers.*.domain
-  networking   = var.networking
-  pod_cidr     = var.pod_cidr
-  service_cidr = var.service_cidr
-  components   = var.components
+  cluster_name           = var.cluster_name
+  api_servers            = [var.k8s_domain_name]
+  service_account_issuer = var.service_account_issuer
+  etcd_servers           = var.controllers.*.domain
+  networking             = var.networking
+  pod_cidr               = var.pod_cidr
+  service_cidr           = var.service_cidr
+  components             = var.components
 }
 

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -159,3 +159,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,14 +1,15 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
   etcd_servers = digitalocean_record.etcds.*.fqdn
 
-  networking   = var.networking
-  pod_cidr     = var.pod_cidr
-  service_cidr = var.service_cidr
-  components   = var.components
+  service_account_issuer = var.service_account_issuer
+  networking             = var.networking
+  pod_cidr               = var.pod_cidr
+  service_cidr           = var.service_cidr
+  components             = var.components
 }
 

--- a/digital-ocean/fedora-coreos/kubernetes/variables.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/variables.tf
@@ -102,3 +102,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/digital-ocean/flatcar-linux/kubernetes/variables.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/variables.tf
@@ -102,3 +102,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,15 +1,16 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
-  cluster_name          = var.cluster_name
-  api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers          = [for fqdn in google_dns_record_set.etcds.*.name : trimsuffix(fqdn, ".")]
-  networking            = var.networking
-  pod_cidr              = var.pod_cidr
-  service_cidr          = var.service_cidr
-  daemonset_tolerations = var.daemonset_tolerations
-  components            = var.components
+  cluster_name           = var.cluster_name
+  etcd_servers           = [for fqdn in google_dns_record_set.etcds.*.name : trimsuffix(fqdn, ".")]
+  api_servers            = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  service_account_issuer = var.service_account_issuer
+  networking             = var.networking
+  pod_cidr               = var.pod_cidr
+  service_cidr           = var.service_cidr
+  daemonset_tolerations  = var.daemonset_tolerations
+  components             = var.components
 
   // temporary
   external_apiserver_port = 443

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -163,3 +163,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,15 +1,16 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=997f6012b540617f7fda1603d169e6ec92be125c"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=c50071487ccd9a29f25767a5fa79dca260be7b86"
 
-  cluster_name          = var.cluster_name
-  api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers          = [for fqdn in google_dns_record_set.etcds.*.name : trimsuffix(fqdn, ".")]
-  networking            = var.networking
-  pod_cidr              = var.pod_cidr
-  service_cidr          = var.service_cidr
-  daemonset_tolerations = var.daemonset_tolerations
-  components            = var.components
+  cluster_name           = var.cluster_name
+  etcd_servers           = [for fqdn in google_dns_record_set.etcds.*.name : trimsuffix(fqdn, ".")]
+  api_servers            = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  service_account_issuer = var.service_account_issuer
+  networking             = var.networking
+  pod_cidr               = var.pod_cidr
+  service_cidr           = var.service_cidr
+  daemonset_tolerations  = var.daemonset_tolerations
+  components             = var.components
 
   // temporary
   external_apiserver_port = 443

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -163,3 +163,9 @@ variable "components" {
   })
   default = null
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}


### PR DESCRIPTION
* Allow the service account token issuer to be adjusted or served from a public bucket or static cache

Docs: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
Rel: https://github.com/poseidon/terraform-render-bootstrap/pull/405