### PR TITLE
Fix Fedora CoreOS kernel URL for metal iPXE booting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ Notable changes between versions.
 * Update Cilium from v1.17.2 to [v1.17.4](https://github.com/cilium/cilium/releases/tag/v1.17.4)
 * Update flannel from v0.26.5 to [v0.26.7](https://github.com/flannel-io/flannel/releases/tag/v0.26.7)
 
+### Fedora CoreOS
+
+* Fix `kernel` URL name, which changed with Fedora CoreOS 42
+
 ## v1.33.0
 
 * Kubernetes [v1.33.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1330)

--- a/bare-metal/fedora-coreos/kubernetes/profiles.tf
+++ b/bare-metal/fedora-coreos/kubernetes/profiles.tf
@@ -1,5 +1,5 @@
 locals {
-  remote_kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-kernel-x86_64"
+  remote_kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-kernel.x86_64"
   remote_initrd = [
     "--name main https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
   ]
@@ -11,7 +11,7 @@ locals {
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
   ]
 
-  cached_kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel-x86_64"
+  cached_kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel.x86_64"
   cached_initrd = [
     "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
   ]


### PR DESCRIPTION
* Fedora CoreOS 42 seems to have slightly changed the kernel image's name (a dash was changed to a dot), which can cause iPXE booting to fail