### PR TITLE
Modernize Google Cloud load balancer setups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,17 @@ Notable changes between versions.
 
 ## Latest
 
+### Google Cloud
+
+* Update Google Cloud load balancer proxies from classic to current
+* Google Cloud TCP proxies no longer restrict which frontend ports may be used
+  * Switch apiserver to listen on 6443 to match other cloud platforms
+  * Switch ingress port 80 from an HTTP to TCP proxy to match HTTPS handling
+* Add a variable `enable_http_lb` to make ingress/gateway TCP/80 IPv4/IPv6
+forwarding rules optional. Default to false.
+  * Google Cloud charges by forwarding rule, so dropping support for plaintext
+  http traffic can save costs if you're https-only.
+
 ## v1.33.1
 
 * Kubernetes [v1.33.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1331)

--- a/google-cloud/fedora-coreos/kubernetes/apiserver.tf
+++ b/google-cloud/fedora-coreos/kubernetes/apiserver.tf
@@ -20,11 +20,12 @@ resource "google_compute_global_address" "apiserver-ipv4" {
 
 # Forward IPv4 TCP traffic to the TCP proxy load balancer
 resource "google_compute_global_forwarding_rule" "apiserver" {
-  name        = "${var.cluster_name}-apiserver"
-  ip_address  = google_compute_global_address.apiserver-ipv4.address
-  ip_protocol = "TCP"
-  port_range  = "443"
-  target      = google_compute_target_tcp_proxy.apiserver.self_link
+  name                  = "${var.cluster_name}-apiserver"
+  ip_address            = google_compute_global_address.apiserver-ipv4.address
+  ip_protocol           = "TCP"
+  port_range            = "6443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  target                = google_compute_target_tcp_proxy.apiserver.self_link
 }
 
 # Global TCP Proxy Load Balancer for apiservers
@@ -52,7 +53,8 @@ resource "google_compute_backend_service" "apiserver" {
     }
   }
 
-  health_checks = [google_compute_health_check.apiserver.self_link]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  health_checks         = [google_compute_health_check.apiserver.self_link]
 }
 
 # Instance group of heterogeneous (unmanged) controller instances

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -11,8 +11,4 @@ module "bootstrap" {
   service_cidr           = var.service_cidr
   daemonset_tolerations  = var.daemonset_tolerations
   components             = var.components
-
-  // temporary
-  external_apiserver_port = 443
 }
-

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -107,6 +107,12 @@ variable "worker_snippets" {
   default     = []
 }
 
+variable "enable_http_lb" {
+  type        = bool
+  description = "Forward TCP/80 traffic to Backend Service of workers for HTTP ingress"
+  default     = false
+}
+
 # configuration
 
 variable "ssh_authorized_key" {

--- a/google-cloud/flatcar-linux/kubernetes/apiserver.tf
+++ b/google-cloud/flatcar-linux/kubernetes/apiserver.tf
@@ -20,11 +20,12 @@ resource "google_compute_global_address" "apiserver-ipv4" {
 
 # Forward IPv4 TCP traffic to the TCP proxy load balancer
 resource "google_compute_global_forwarding_rule" "apiserver" {
-  name        = "${var.cluster_name}-apiserver"
-  ip_address  = google_compute_global_address.apiserver-ipv4.address
-  ip_protocol = "TCP"
-  port_range  = "443"
-  target      = google_compute_target_tcp_proxy.apiserver.self_link
+  name                  = "${var.cluster_name}-apiserver"
+  ip_address            = google_compute_global_address.apiserver-ipv4.address
+  ip_protocol           = "TCP"
+  port_range            = "6443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  target                = google_compute_target_tcp_proxy.apiserver.self_link
 }
 
 # Global TCP Proxy Load Balancer for apiservers
@@ -52,7 +53,8 @@ resource "google_compute_backend_service" "apiserver" {
     }
   }
 
-  health_checks = [google_compute_health_check.apiserver.self_link]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  health_checks         = [google_compute_health_check.apiserver.self_link]
 }
 
 # Instance group of heterogeneous (unmanged) controller instances

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -11,8 +11,5 @@ module "bootstrap" {
   service_cidr           = var.service_cidr
   daemonset_tolerations  = var.daemonset_tolerations
   components             = var.components
-
-  // temporary
-  external_apiserver_port = 443
 }
 

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -107,6 +107,12 @@ variable "worker_snippets" {
   default     = []
 }
 
+variable "enable_http_lb" {
+  type        = bool
+  description = "Forward TCP/80 traffic to Backend Service of workers for HTTP ingress"
+  default     = false
+}
+
 # configuration
 
 variable "ssh_authorized_key" {


### PR DESCRIPTION
* Update Google Cloud TCP proxies from classic to current
* Google Cloud TCP proxies no longer restrict which frontend ports may be used
  * Switch apiserver to listen on 6443 to match other cloud platforms
  * Switch the HTTP (port 80) proxy to a TCP proxy to match what's done for HTTPS traffic to ingress/gateway controllers
* Add a variable `enable_http_lb` to make TCP/80 IPv4/IPv6 forwarding rules optional. Default to false. Google Cloud charges by forwarding rule, so dropping support for plaintext http traffic can save costs. And if you front traffic with global load balancer providers, you may handle http->https redirects there anyway, so there's no loss