### PR TITLE
Add enable_http_load_balancing variable to Azure clusters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,14 +4,20 @@ Notable changes between versions.
 
 ## Latest
 
+### Azure
+
+* Add `enable_http_load_balancing` variable to reduce load balancer rules count
+  * Azure charges by load balancer rules (5 included)
+
 ### Google Cloud
 
-* Update Google Cloud load balancer proxies from classic to current
-* Google Cloud TCP proxies no longer restrict which frontend ports may be used
+* Update Google Cloud load balancer proxies from classic to current ([#1604](https://github.com/poseidon/typhoon/pull/1604))
+* Change `apiserver` and ingress/gateway service proxies ([#1604](https://github.com/poseidon/typhoon/pull/1604))
+  * Google Cloud TCP proxies no longer restrict which frontend ports may be used
   * Switch apiserver to listen on 6443 to match other cloud platforms
   * Switch ingress port 80 from an HTTP to TCP proxy to match HTTPS handling
 * Add a variable `enable_http_lb` to make ingress/gateway TCP/80 IPv4/IPv6
-forwarding rules optional. Default to false.
+forwarding rules optional. Default to false ([#1604](https://github.com/poseidon/typhoon/pull/1604))
   * Google Cloud charges by forwarding rule, so dropping support for plaintext
   http traffic can save costs if you're https-only.
 

--- a/azure/fedora-coreos/kubernetes/lb.tf
+++ b/azure/fedora-coreos/kubernetes/lb.tf
@@ -89,6 +89,8 @@ resource "azurerm_lb_rule" "apiserver-ipv6" {
 }
 
 resource "azurerm_lb_rule" "ingress-http-ipv4" {
+count = var.enable_http_load_balancing ? 1 : 0
+
   name                           = "ingress-http-ipv4"
   loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "frontend-ipv4"
@@ -115,7 +117,7 @@ resource "azurerm_lb_rule" "ingress-https-ipv4" {
 }
 
 resource "azurerm_lb_rule" "ingress-http-ipv6" {
-  count = var.enable_ipv6_load_balancing ? 1 : 0
+  count = var.enable_http_load_balancing && var.enable_ipv6_load_balancing ? 1 : 0
 
   name                           = "ingress-http-ipv6"
   loadbalancer_id                = azurerm_lb.cluster.id

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -144,6 +144,11 @@ EOD
   default     = "10.3.0.0/16"
 }
 
+variable "enable_http_load_balancing" {
+  description = "Enable HTTP (port 80) LB rules"
+  default = false
+}
+
 variable "enable_ipv6_load_balancing" {
   description = "Enable IPv6 LB rules (note: Azure charges ~$20/mo more)"
   default     = false

--- a/azure/flatcar-linux/kubernetes/lb.tf
+++ b/azure/flatcar-linux/kubernetes/lb.tf
@@ -89,6 +89,8 @@ resource "azurerm_lb_rule" "apiserver-ipv6" {
 }
 
 resource "azurerm_lb_rule" "ingress-http-ipv4" {
+count = var.enable_http_load_balancing ? 1 : 0
+
   name                           = "ingress-http-ipv4"
   loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "frontend-ipv4"
@@ -115,7 +117,7 @@ resource "azurerm_lb_rule" "ingress-https-ipv4" {
 }
 
 resource "azurerm_lb_rule" "ingress-http-ipv6" {
-  count = var.enable_ipv6_load_balancing ? 1 : 0
+  count = var.enable_http_load_balancing && var.enable_ipv6_load_balancing ? 1 : 0
 
   name                           = "ingress-http-ipv6"
   loadbalancer_id                = azurerm_lb.cluster.id

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -150,9 +150,14 @@ EOD
   default     = "10.3.0.0/16"
 }
 
+variable "enable_http_load_balancing" {
+  description = "Enable HTTP (port 80) LB rules"
+  default = false
+}
+
 variable "enable_ipv6_load_balancing" {
   description = "Enable IPv6 LB rules (note: Azure charges ~$20/mo more)"
-  default     = false
+  default     = true
 }
 
 variable "worker_node_labels" {


### PR DESCRIPTION
* Azure Load Balancers charge by load balancer rues (5 included) so its useful to provide ways to stay under that number, either by dropping support for port 80 traffic or IPv6 traffic. When using global proxies, you can usually serve IPv6 or http->https redirects separately anyway