### PR TITLE
Standardize load balancer variables before release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Notable changes between versions.
 * Change Azure VMSS instance update policy (i.e. upgrade policy) from Manual to Rolling
   * Set a rolling upgrade policy so that changes to the worker node pool are rolled out gradually. Previously, the VMSS model could change, but instances would not receive it until manually replaced
 * Define Azure automatic instance repair using Application Health Extension probes to 10256 (kube-proxy or Cilium equivalent) to match the strategy used on Google Cloud
-* Add `worker_ephemeral_placement` variable to allow workers with `NvmeDisk` Ephemeral OS disks ([docs](https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks))
+* Add `worker_ephemeral_disk_placement` variable to allow workers with `NvmeDisk` Ephemeral OS disks ([docs](https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks))
   * Requires `azurerm` provider with NvmeDisk support ([#30044](https://github.com/hashicorp/terraform-provider-azurerm/pull/30044))
 
 ### Google Cloud
@@ -28,8 +28,7 @@ Notable changes between versions.
   * Google Cloud TCP proxies no longer restrict which frontend ports may be used
   * Switch apiserver to listen on 6443 to match other cloud platforms
   * Switch ingress port 80 from an HTTP to TCP proxy to match HTTPS handling
-* Add a variable `enable_http_lb` to make ingress/gateway TCP/80 IPv4/IPv6
-forwarding rules optional. Default to false ([#1604](https://github.com/poseidon/typhoon/pull/1604))
+* Add a variable `enable_http_load_balancing` to make ingress/gateway TCP/80 forwarding rules optional. Default to false ([#1604](https://github.com/poseidon/typhoon/pull/1604))
   * Google Cloud charges by forwarding rule, so dropping support for plaintext
   http traffic can save costs if you're https-only.
 

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -20,6 +20,16 @@ variable "dns_zone_group" {
   description = "Resource group where the Azure DNS Zone resides (e.g. global)"
 }
 
+variable "enable_http_load_balancing" {
+  description = "Enable HTTP (port 80) LB rules"
+  default     = false
+}
+
+variable "enable_ipv6_load_balancing" {
+  description = "Enable IPv6 LB rules"
+  default     = false
+}
+
 # instances
 
 variable "os_image" {
@@ -152,16 +162,6 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
   default     = "10.3.0.0/16"
-}
-
-variable "enable_http_load_balancing" {
-  description = "Enable HTTP (port 80) LB rules"
-  default     = false
-}
-
-variable "enable_ipv6_load_balancing" {
-  description = "Enable IPv6 LB rules (note: Azure charges ~$20/mo more)"
-  default     = false
 }
 
 variable "worker_node_labels" {

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -20,6 +20,16 @@ variable "dns_zone_group" {
   description = "Resource group where the Azure DNS Zone resides (e.g. global)"
 }
 
+variable "enable_http_load_balancing" {
+  description = "Enable HTTP (port 80) LB rules"
+  default     = false
+}
+
+variable "enable_ipv6_load_balancing" {
+  description = "Enable IPv6 LB rules"
+  default     = true
+}
+
 # instances
 
 variable "os_image" {
@@ -158,16 +168,6 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
   default     = "10.3.0.0/16"
-}
-
-variable "enable_http_load_balancing" {
-  description = "Enable HTTP (port 80) LB rules"
-  default     = false
-}
-
-variable "enable_ipv6_load_balancing" {
-  description = "Enable IPv6 LB rules (note: Azure charges ~$20/mo more)"
-  default     = true
 }
 
 variable "worker_node_labels" {

--- a/google-cloud/fedora-coreos/kubernetes/ingress.tf
+++ b/google-cloud/fedora-coreos/kubernetes/ingress.tf
@@ -12,7 +12,7 @@ resource "google_compute_global_address" "ingress-ipv6" {
 
 # Forward IPv4 TCP/80 traffic to the TCP proxy load balancer
 resource "google_compute_global_forwarding_rule" "ingress-http-ipv4" {
-  count = var.enable_http_lb ? 1 : 0
+  count = var.enable_http_load_balancing ? 1 : 0
 
   name                  = "${var.cluster_name}-ingress-http-ipv4"
   ip_address            = google_compute_global_address.ingress-ipv4.address
@@ -34,7 +34,7 @@ resource "google_compute_global_forwarding_rule" "ingress-https-ipv4" {
 
 # Forward IPv6 TCP/80 traffic to the TCP proxy load balancer
 resource "google_compute_global_forwarding_rule" "ingress-http-ipv6" {
-  count = var.enable_http_lb ? 1 : 0
+  count = var.enable_http_load_balancing ? 1 : 0
 
   name                  = "${var.cluster_name}-ingress-http-ipv6"
   ip_address            = google_compute_global_address.ingress-ipv6.address
@@ -56,7 +56,7 @@ resource "google_compute_global_forwarding_rule" "ingress-https-ipv6" {
 
 # TCP proxy load balancer for ingress traffic
 resource "google_compute_target_tcp_proxy" "ingress-http" {
-  count = var.enable_http_lb ? 1 : 0
+  count = var.enable_http_load_balancing ? 1 : 0
 
   name            = "${var.cluster_name}-ingress-http"
   description     = "Distribute TCP/80 traffic across ${var.cluster_name} workers"
@@ -72,7 +72,7 @@ resource "google_compute_target_tcp_proxy" "ingress-https" {
 
 # Backend service backed by managed instance group of workers
 resource "google_compute_backend_service" "ingress-http" {
-  count = var.enable_http_lb ? 1 : 0
+  count = var.enable_http_load_balancing ? 1 : 0
 
   name        = "${var.cluster_name}-ingress-http"
   description = "${var.cluster_name} ingress service"

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -20,6 +20,12 @@ variable "dns_zone_name" {
   description = "Google Cloud DNS Zone name (e.g. example-zone)"
 }
 
+variable "enable_http_load_balancing" {
+  type        = bool
+  description = "Forward TCP/80 traffic to Backend Service of workers for HTTP ingress"
+  default     = false
+}
+
 # instances
 
 variable "os_stream" {
@@ -105,12 +111,6 @@ variable "worker_snippets" {
   type        = list(string)
   description = "Worker Butane snippets"
   default     = []
-}
-
-variable "enable_http_lb" {
-  type        = bool
-  description = "Forward TCP/80 traffic to Backend Service of workers for HTTP ingress"
-  default     = false
 }
 
 # configuration

--- a/google-cloud/flatcar-linux/kubernetes/ingress.tf
+++ b/google-cloud/flatcar-linux/kubernetes/ingress.tf
@@ -12,7 +12,7 @@ resource "google_compute_global_address" "ingress-ipv6" {
 
 # Forward IPv4 TCP/80 traffic to the TCP proxy load balancer
 resource "google_compute_global_forwarding_rule" "ingress-http-ipv4" {
-  count = var.enable_http_lb ? 1 : 0
+  count = var.enable_http_load_balancing ? 1 : 0
 
   name                  = "${var.cluster_name}-ingress-http-ipv4"
   ip_address            = google_compute_global_address.ingress-ipv4.address
@@ -34,7 +34,7 @@ resource "google_compute_global_forwarding_rule" "ingress-https-ipv4" {
 
 # Forward IPv6 TCP/80 traffic to the TCP proxy load balancer
 resource "google_compute_global_forwarding_rule" "ingress-http-ipv6" {
-  count = var.enable_http_lb ? 1 : 0
+  count = var.enable_http_load_balancing ? 1 : 0
 
   name                  = "${var.cluster_name}-ingress-http-ipv6"
   ip_address            = google_compute_global_address.ingress-ipv6.address
@@ -56,7 +56,7 @@ resource "google_compute_global_forwarding_rule" "ingress-https-ipv6" {
 
 # TCP proxy load balancer for ingress traffic
 resource "google_compute_target_tcp_proxy" "ingress-http" {
-  count = var.enable_http_lb ? 1 : 0
+  count = var.enable_http_load_balancing ? 1 : 0
 
   name            = "${var.cluster_name}-ingress-http"
   description     = "Distribute TCP/80 traffic across ${var.cluster_name} workers"
@@ -72,7 +72,7 @@ resource "google_compute_target_tcp_proxy" "ingress-https" {
 
 # Backend service backed by managed instance group of workers
 resource "google_compute_backend_service" "ingress-http" {
-  count = var.enable_http_lb ? 1 : 0
+  count = var.enable_http_load_balancing ? 1 : 0
 
   name        = "${var.cluster_name}-ingress-http"
   description = "${var.cluster_name} ingress service"

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -20,6 +20,12 @@ variable "dns_zone_name" {
   description = "Google Cloud DNS Zone name (e.g. example-zone)"
 }
 
+variable "enable_http_load_balancing" {
+  type        = bool
+  description = "Forward TCP/80 traffic to Backend Service of workers for HTTP ingress"
+  default     = false
+}
+
 # instances
 
 variable "os_image" {
@@ -105,12 +111,6 @@ variable "worker_snippets" {
   type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []
-}
-
-variable "enable_http_lb" {
-  type        = bool
-  description = "Forward TCP/80 traffic to Backend Service of workers for HTTP ingress"
-  default     = false
 }
 
 # configuration


### PR DESCRIPTION
* Use consistent variable names in AWS and Azure Kubernetes modules for whether HTTP load balancing rules should be enabled or not