### PR TITLE
[aws] Add option for using only IPv6 public addresses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Notable changes between versions.
 
 ### AWS
 
+* Add `worker_ipv4_address` variable to associate public IPv4 addresses to worker instances (default true)
+  * When IPv6 is all you need, set to false to remove IPv4 access to instances and outbound IPv4 access to the internet
 * Relax `aws` provider version constraint to allow upgrades to v6.x ([#1617](https://github.com/poseidon/typhoon/pull/1617))
 
 ### Azure

--- a/aws/fedora-coreos/kubernetes/nlb.tf
+++ b/aws/fedora-coreos/kubernetes/nlb.tf
@@ -13,6 +13,20 @@ resource "aws_route53_record" "apiserver" {
   }
 }
 
+resource "aws_route53_record" "apiserver-ipv6" {
+  zone_id = var.dns_zone_id
+
+  name = format("%s.%s.", var.cluster_name, var.dns_zone)
+  type = "AAAA"
+
+  # AWS recommends their special "alias" records for NLBs
+  alias {
+    name                   = aws_lb.nlb.dns_name
+    zone_id                = aws_lb.nlb.zone_id
+    evaluate_target_health = true
+  }
+}
+
 # Network Load Balancer for apiservers and ingress
 resource "aws_lb" "nlb" {
   name               = "${var.cluster_name}-nlb"

--- a/aws/fedora-coreos/kubernetes/security.tf
+++ b/aws/fedora-coreos/kubernetes/security.tf
@@ -40,11 +40,12 @@ resource "aws_security_group_rule" "controller-icmp-self" {
 resource "aws_security_group_rule" "controller-ssh" {
   security_group_id = aws_security_group.controller.id
 
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = 22
-  to_port     = 22
-  cidr_blocks = ["0.0.0.0/0"]
+  type             = "ingress"
+  protocol         = "tcp"
+  from_port        = 22
+  to_port          = 22
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
 }
 
 resource "aws_security_group_rule" "controller-etcd" {

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -76,6 +76,12 @@ variable "worker_type" {
   default     = "t3.small"
 }
 
+variable "worker_public_ipv4" {
+  type        = bool
+  description = "Associate a public IPv4 address to instances (otherwise, no IPv4 access to instances from the internet and no outbound IPv4 access to the internet)"
+  default     = true
+}
+
 variable "worker_disk_size" {
   type        = number
   description = "Size of the EBS volume in GB"

--- a/aws/fedora-coreos/kubernetes/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers.tf
@@ -19,6 +19,8 @@ module "workers" {
   spot_price    = var.worker_price
   target_groups = var.worker_target_groups
 
+  associate_public_ipv4_address = var.worker_public_ipv4
+
   # configuration
   kubeconfig         = module.bootstrap.kubeconfig-kubelet
   ssh_authorized_key = var.ssh_authorized_key

--- a/aws/fedora-coreos/kubernetes/workers/variables.tf
+++ b/aws/fedora-coreos/kubernetes/workers/variables.tf
@@ -34,6 +34,12 @@ variable "instance_type" {
   default     = "t3.small"
 }
 
+variable "associate_public_ipv4_address" {
+  type        = bool
+  description = "Associate a public IPv4 address to instances (otherwise, no IPv4 access to instances from the internet and no outbound IPv4 access to the internet)"
+  default     = true
+}
+
 variable "os_stream" {
   type        = string
   description = "Fedora CoreOS image stream for instances (e.g. stable, testing, next)"

--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -75,7 +75,7 @@ resource "aws_launch_template" "worker" {
 
   # network
   network_interfaces {
-    associate_public_ip_address = true
+    associate_public_ip_address = var.associate_public_ipv4_address
     security_groups             = var.security_groups
   }
 

--- a/aws/flatcar-linux/kubernetes/nlb.tf
+++ b/aws/flatcar-linux/kubernetes/nlb.tf
@@ -13,6 +13,20 @@ resource "aws_route53_record" "apiserver" {
   }
 }
 
+resource "aws_route53_record" "apiserver-ipv6" {
+  zone_id = var.dns_zone_id
+
+  name = format("%s.%s.", var.cluster_name, var.dns_zone)
+  type = "AAAA"
+
+  # AWS recommends their special "alias" records for NLBs
+  alias {
+    name                   = aws_lb.nlb.dns_name
+    zone_id                = aws_lb.nlb.zone_id
+    evaluate_target_health = true
+  }
+}
+
 # Network Load Balancer for apiservers and ingress
 resource "aws_lb" "nlb" {
   name               = "${var.cluster_name}-nlb"

--- a/aws/flatcar-linux/kubernetes/security.tf
+++ b/aws/flatcar-linux/kubernetes/security.tf
@@ -40,11 +40,12 @@ resource "aws_security_group_rule" "controller-icmp-self" {
 resource "aws_security_group_rule" "controller-ssh" {
   security_group_id = aws_security_group.controller.id
 
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = 22
-  to_port     = 22
-  cidr_blocks = ["0.0.0.0/0"]
+  type             = "ingress"
+  protocol         = "tcp"
+  from_port        = 22
+  to_port          = 22
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
 }
 
 resource "aws_security_group_rule" "controller-etcd" {

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -76,6 +76,12 @@ variable "worker_type" {
   default     = "t3.small"
 }
 
+variable "worker_public_ipv4" {
+  type        = bool
+  description = "Associate a public IPv4 address to instances (otherwise, no IPv4 access to instances from the internet and no outbound IPv4 access to the internet)"
+  default     = true
+}
+
 variable "worker_disk_size" {
   type        = number
   description = "Size of the EBS volume in GB"

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -18,6 +18,8 @@ module "workers" {
   spot_price    = var.worker_price
   target_groups = var.worker_target_groups
 
+  associate_public_ipv4_address = var.worker_public_ipv4
+
   # configuration
   kubeconfig         = module.bootstrap.kubeconfig-kubelet
   ssh_authorized_key = var.ssh_authorized_key

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -34,6 +34,12 @@ variable "instance_type" {
   default     = "t3.small"
 }
 
+variable "associate_public_ipv4_address" {
+  type        = bool
+  description = "Associate a public IPv4 address to instances (otherwise, no IPv4 access to instances from the internet and no outbound IPv4 access to the internet)"
+  default     = true
+}
+
 variable "os_image" {
   type        = string
   description = "AMI channel for a Container Linux derivative (flatcar-stable, flatcar-beta, flatcar-alpha)"

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -74,7 +74,7 @@ resource "aws_launch_template" "worker" {
 
   # network
   network_interfaces {
-    associate_public_ip_address = true
+    associate_public_ip_address = var.associate_public_ipv4_address
     security_groups             = var.security_groups
   }
 


### PR DESCRIPTION
* AWS IPv4 address pricing is quite high compared to other clouds, and an NLB unavoidably uses at least 3.
* Unlike Azure's nice outbound through LB options, AWS has only NAT options which are even more costly than IPv4 in budget clusters. Another option is to simply forget about accessing nodes via IPv4 or outbound IPv4 internet access (tradeoff: GitHub is a notable website that only serves via IPv4, so cut ties)