### PR TITLE
Fix Fedora CoreOS kernel image URL/name in worker module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Notable changes between versions.
 * Kubernetes [v1.33.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1333)
 * Update Cilium from v1.17.5 to [v1.17.6](https://github.com/cilium/cilium/releases/tag/v1.17.6)
 
+### Fedora CoreOS
+
+* Fix `kernel` name/URL used in the `worker` module, since this changed with Fedora CoreOS 42
+
 ## v1.33.2
 
 * Kubernetes [v1.33.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1332)

--- a/bare-metal/fedora-coreos/kubernetes/worker/matchbox.tf
+++ b/bare-metal/fedora-coreos/kubernetes/worker/matchbox.tf
@@ -1,5 +1,5 @@
 locals {
-  remote_kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-kernel-x86_64"
+  remote_kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-kernel.x86_64"
   remote_initrd = [
     "--name main https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
   ]
@@ -11,7 +11,7 @@ locals {
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
   ]
 
-  cached_kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel-x86_64"
+  cached_kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel.x86_64"
   cached_initrd = [
     "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
   ]


### PR DESCRIPTION
* Similar to https://github.com/poseidon/typhoon/pull/1602, but for those who use the standalone worker module directly
* Closes #1624