### PR TITLE
Add cloud_provider variable for external cloud controller managers

### DIFF
--- a/aws/fedora-coreos/kubernetes/bootstrap.tf
+++ b/aws/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name           = var.cluster_name
   api_servers            = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -9,7 +9,7 @@ module "bootstrap" {
   networking             = var.networking
   pod_cidr               = var.pod_cidr
   service_cidr           = var.service_cidr
+  cloud_provider         = var.cloud_provider
   daemonset_tolerations  = var.daemonset_tolerations
   components             = var.components
 }
-

--- a/aws/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/aws/fedora-coreos/kubernetes/butane/controller.yaml
@@ -88,6 +88,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --node-labels=node.kubernetes.io/controller="true" \
           --provider-id=aws:///$${AFTERBURN_AWS_AVAILABILITY_ZONE}/$${AFTERBURN_AWS_INSTANCE_ID} \

--- a/aws/fedora-coreos/kubernetes/controllers.tf
+++ b/aws/fedora-coreos/kubernetes/controllers.tf
@@ -69,6 +69,7 @@ data "ct_config" "controllers" {
     kubeconfig             = indent(10, module.bootstrap.kubeconfig-kubelet)
     ssh_authorized_key     = var.ssh_authorized_key
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.controller_snippets

--- a/aws/fedora-coreos/kubernetes/variables.tf
+++ b/aws/fedora-coreos/kubernetes/variables.tf
@@ -218,3 +218,14 @@ variable "service_account_issuer" {
   description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
   default     = "https://kubernetes.default.svc.cluster.local"
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/aws/fedora-coreos/kubernetes/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers.tf
@@ -27,5 +27,5 @@ module "workers" {
   service_cidr       = var.service_cidr
   snippets           = var.worker_snippets
   node_labels        = var.worker_node_labels
+  cloud_provider     = var.cloud_provider
 }
-

--- a/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/aws/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -60,6 +60,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --node-labels=node.kubernetes.io/node \
           %{~ for label in split(",", node_labels) ~}

--- a/aws/fedora-coreos/kubernetes/workers/variables.tf
+++ b/aws/fedora-coreos/kubernetes/workers/variables.tf
@@ -137,3 +137,14 @@ variable "arch" {
     error_message = "The arch must be amd64 or arm64."
   }
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/aws/fedora-coreos/kubernetes/workers/workers.tf
+++ b/aws/fedora-coreos/kubernetes/workers/workers.tf
@@ -119,6 +119,7 @@ data "ct_config" "worker" {
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     node_labels            = join(",", var.node_labels)
     node_taints            = join(",", var.node_taints)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.snippets

--- a/aws/flatcar-linux/kubernetes/bootstrap.tf
+++ b/aws/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name           = var.cluster_name
   api_servers            = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -9,7 +9,7 @@ module "bootstrap" {
   networking             = var.networking
   pod_cidr               = var.pod_cidr
   service_cidr           = var.service_cidr
+  cloud_provider         = var.cloud_provider
   daemonset_tolerations  = var.daemonset_tolerations
   components             = var.components
 }
-

--- a/aws/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/aws/flatcar-linux/kubernetes/butane/controller.yaml
@@ -85,6 +85,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --node-labels=node.kubernetes.io/controller="true" \
           --provider-id=aws:///$${COREOS_EC2_AVAILABILITY_ZONE}/$${COREOS_EC2_INSTANCE_ID} \

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -69,6 +69,7 @@ data "ct_config" "controllers" {
     kubeconfig             = indent(10, module.bootstrap.kubeconfig-kubelet)
     ssh_authorized_key     = var.ssh_authorized_key
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.controller_snippets

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -218,3 +218,14 @@ variable "service_account_issuer" {
   description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
   default     = "https://kubernetes.default.svc.cluster.local"
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -26,5 +26,5 @@ module "workers" {
   service_cidr       = var.service_cidr
   snippets           = var.worker_snippets
   node_labels        = var.worker_node_labels
+  cloud_provider     = var.cloud_provider
 }
-

--- a/aws/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/aws/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -60,6 +60,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --node-labels=node.kubernetes.io/node \
           %{~ for label in split(",", node_labels) ~}

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -138,3 +138,14 @@ variable "arch" {
     error_message = "The arch must be amd64 or arm64."
   }
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -118,6 +118,7 @@ data "ct_config" "worker" {
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     node_labels            = join(",", var.node_labels)
     node_taints            = join(",", var.node_taints)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.snippets

--- a/azure/fedora-coreos/kubernetes/bootstrap.tf
+++ b/azure/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name = var.cluster_name
   etcd_servers = formatlist("%s.%s", azurerm_dns_a_record.etcds.*.name, var.dns_zone)
@@ -10,7 +10,7 @@ module "bootstrap" {
   networking             = var.networking
   pod_cidr               = var.pod_cidr
   service_cidr           = var.service_cidr
+  cloud_provider         = var.cloud_provider
   daemonset_tolerations  = var.daemonset_tolerations
   components             = var.components
 }
-

--- a/azure/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/azure/fedora-coreos/kubernetes/butane/controller.yaml
@@ -84,6 +84,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --node-labels=node.kubernetes.io/controller="true" \
           --register-with-taints=node-role.kubernetes.io/controller=:NoSchedule
@@ -267,4 +270,3 @@ passwd:
     - name: core
       ssh_authorized_keys:
         - ${ssh_authorized_key}
-

--- a/azure/fedora-coreos/kubernetes/controllers.tf
+++ b/azure/fedora-coreos/kubernetes/controllers.tf
@@ -163,6 +163,7 @@ data "ct_config" "controllers" {
     kubeconfig             = indent(10, module.bootstrap.kubeconfig-kubelet)
     ssh_authorized_key     = var.ssh_authorized_key
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.controller_snippets

--- a/azure/fedora-coreos/kubernetes/variables.tf
+++ b/azure/fedora-coreos/kubernetes/variables.tf
@@ -198,3 +198,14 @@ variable "service_account_issuer" {
   description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
   default     = "https://kubernetes.default.svc.cluster.local"
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/azure/fedora-coreos/kubernetes/workers.tf
+++ b/azure/fedora-coreos/kubernetes/workers.tf
@@ -26,4 +26,5 @@ module "workers" {
   service_cidr         = var.service_cidr
   snippets             = var.worker_snippets
   node_labels          = var.worker_node_labels
+  cloud_provider       = var.cloud_provider
 }

--- a/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/azure/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -56,6 +56,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           %{~ for label in split(",", node_labels) ~}
           --node-labels=${label} \
@@ -166,4 +169,3 @@ passwd:
     - name: core
       ssh_authorized_keys:
         - ${ssh_authorized_key}
-

--- a/azure/fedora-coreos/kubernetes/workers/variables.tf
+++ b/azure/fedora-coreos/kubernetes/workers/variables.tf
@@ -130,3 +130,14 @@ variable "node_taints" {
   description = "List of initial node taints"
   default     = []
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/azure/fedora-coreos/kubernetes/workers/workers.tf
+++ b/azure/fedora-coreos/kubernetes/workers/workers.tf
@@ -122,6 +122,7 @@ data "ct_config" "worker" {
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     node_labels            = join(",", var.node_labels)
     node_taints            = join(",", var.node_taints)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.snippets

--- a/azure/flatcar-linux/kubernetes/bootstrap.tf
+++ b/azure/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
@@ -10,7 +10,7 @@ module "bootstrap" {
   networking             = var.networking
   pod_cidr               = var.pod_cidr
   service_cidr           = var.service_cidr
+  cloud_provider         = var.cloud_provider
   daemonset_tolerations  = var.daemonset_tolerations
   components             = var.components
 }
-

--- a/azure/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/azure/flatcar-linux/kubernetes/butane/controller.yaml
@@ -82,6 +82,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --node-labels=node.kubernetes.io/controller="true" \
           --register-with-taints=node-role.kubernetes.io/controller=:NoSchedule

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -185,6 +185,7 @@ data "ct_config" "controllers" {
     kubeconfig             = indent(10, module.bootstrap.kubeconfig-kubelet)
     ssh_authorized_key     = var.ssh_authorized_key
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.controller_snippets

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -224,3 +224,14 @@ variable "service_account_issuer" {
   description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
   default     = "https://kubernetes.default.svc.cluster.local"
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/azure/flatcar-linux/kubernetes/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers.tf
@@ -25,5 +25,6 @@ module "workers" {
   service_cidr         = var.service_cidr
   snippets             = var.worker_snippets
   node_labels          = var.worker_node_labels
+  cloud_provider       = var.cloud_provider
   arch                 = var.worker_arch
 }

--- a/azure/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/azure/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -57,6 +57,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           %{~ for label in split(",", node_labels) ~}
           --node-labels=${label} \

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -147,3 +147,14 @@ variable "arch" {
     error_message = "The arch must be amd64 or arm64."
   }
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -143,6 +143,7 @@ data "ct_config" "worker" {
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     node_labels            = join(",", var.node_labels)
     node_taints            = join(",", var.node_taints)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.snippets

--- a/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
+++ b/bare-metal/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name           = var.cluster_name
   api_servers            = [var.k8s_domain_name]

--- a/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name           = var.cluster_name
   api_servers            = [var.k8s_domain_name]

--- a/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
+++ b/digital-ocean/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
+++ b/digital-ocean/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
+++ b/google-cloud/fedora-coreos/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name           = var.cluster_name
   etcd_servers           = [for fqdn in google_dns_record_set.etcds.*.name : trimsuffix(fqdn, ".")]
@@ -9,6 +9,7 @@ module "bootstrap" {
   networking             = var.networking
   pod_cidr               = var.pod_cidr
   service_cidr           = var.service_cidr
+  cloud_provider         = var.cloud_provider
   daemonset_tolerations  = var.daemonset_tolerations
   components             = var.components
 }

--- a/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/butane/controller.yaml
@@ -84,6 +84,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --node-labels=node.kubernetes.io/controller="true" \
           --register-with-taints=node-role.kubernetes.io/controller=:NoSchedule

--- a/google-cloud/fedora-coreos/kubernetes/controllers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/controllers.tf
@@ -82,6 +82,7 @@ data "ct_config" "controllers" {
     kubeconfig             = indent(10, module.bootstrap.kubeconfig-kubelet)
     ssh_authorized_key     = var.ssh_authorized_key
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.controller_snippets

--- a/google-cloud/fedora-coreos/kubernetes/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/variables.tf
@@ -175,3 +175,14 @@ variable "service_account_issuer" {
   description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
   default     = "https://kubernetes.default.svc.cluster.local"
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/google-cloud/fedora-coreos/kubernetes/workers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers.tf
@@ -19,4 +19,5 @@ module "workers" {
   service_cidr       = var.service_cidr
   snippets           = var.worker_snippets
   node_labels        = var.worker_node_labels
+  cloud_provider     = var.cloud_provider
 }

--- a/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
+++ b/google-cloud/fedora-coreos/kubernetes/workers/butane/worker.yaml
@@ -56,6 +56,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           %{~ for label in split(",", node_labels) ~}
           --node-labels=${label} \
@@ -165,4 +168,3 @@ passwd:
     - name: core
       ssh_authorized_keys:
         - ${ssh_authorized_key}
-

--- a/google-cloud/fedora-coreos/kubernetes/workers/variables.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/variables.tf
@@ -119,3 +119,14 @@ variable "accelerator_count" {
   default     = "0"
   description = "Number of compute engine accelerators"
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
+++ b/google-cloud/fedora-coreos/kubernetes/workers/workers.tf
@@ -115,6 +115,7 @@ data "ct_config" "worker" {
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     node_labels            = join(",", var.node_labels)
     node_taints            = join(",", var.node_taints)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.snippets

--- a/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootstrap.tf
@@ -1,6 +1,6 @@
 # Kubernetes assets (kubeconfig, manifests)
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=d8a499d10b653ee51e2b728b8eb09ffa60c91484"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=5bf3975fdb13524267b8e81988874f9c540a7c5e"
 
   cluster_name           = var.cluster_name
   etcd_servers           = [for fqdn in google_dns_record_set.etcds.*.name : trimsuffix(fqdn, ".")]
@@ -9,7 +9,7 @@ module "bootstrap" {
   networking             = var.networking
   pod_cidr               = var.pod_cidr
   service_cidr           = var.service_cidr
+  cloud_provider         = var.cloud_provider
   daemonset_tolerations  = var.daemonset_tolerations
   components             = var.components
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/butane/controller.yaml
@@ -82,6 +82,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --node-labels=node.kubernetes.io/controller="true" \
           --register-with-taints=node-role.kubernetes.io/controller=:NoSchedule

--- a/google-cloud/flatcar-linux/kubernetes/controllers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/controllers.tf
@@ -82,6 +82,7 @@ data "ct_config" "controllers" {
     kubeconfig             = indent(10, module.bootstrap.kubeconfig-kubelet)
     ssh_authorized_key     = var.ssh_authorized_key
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.controller_snippets

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -175,3 +175,14 @@ variable "service_account_issuer" {
   description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
   default     = "https://kubernetes.default.svc.cluster.local"
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/google-cloud/flatcar-linux/kubernetes/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers.tf
@@ -19,4 +19,5 @@ module "workers" {
   service_cidr       = var.service_cidr
   snippets           = var.worker_snippets
   node_labels        = var.worker_node_labels
+  cloud_provider     = var.cloud_provider
 }

--- a/google-cloud/flatcar-linux/kubernetes/workers/butane/worker.yaml
+++ b/google-cloud/flatcar-linux/kubernetes/workers/butane/worker.yaml
@@ -57,6 +57,9 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
           --config=/etc/kubernetes/kubelet.yaml \
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+          %{ if cloud_provider != null ~}
+          --cloud-provider=${cloud_provider} \
+          %{ endif ~}
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           %{~ for label in split(",", node_labels) ~}
           --node-labels=${label} \

--- a/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
@@ -119,3 +119,14 @@ variable "accelerator_count" {
   default     = "0"
   description = "Number of compute engine accelerators"
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Kubernetes cloud provider integration mode"
+  default     = null
+
+  validation {
+    condition     = var.cloud_provider == null || contains(["external"], var.cloud_provider)
+    error_message = "The cloud_provider must be external or null."
+  }
+}

--- a/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
@@ -115,6 +115,7 @@ data "ct_config" "worker" {
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     node_labels            = join(",", var.node_labels)
     node_taints            = join(",", var.node_taints)
+    cloud_provider         = var.cloud_provider
   })
   strict   = true
   snippets = var.snippets


### PR DESCRIPTION
* Add the cloud_provider variable so it can optionally be set to "external" to use external cloud controller managers to initialize nodes. Note that nodes will be tainted until they are initialized by a cloud-specific controller manager (various implementations)
* By default the flag is unset so there are no changes