### PR TITLE
Remove duplicate Kubelet flag in bare-metal flatcar-linux

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/worker/butane/worker.yaml
+++ b/bare-metal/flatcar-linux/kubernetes/worker/butane/worker.yaml
@@ -67,7 +67,6 @@ systemd:
           --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
           --hostname-override=${domain_name} \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
-          --node-labels=node.kubernetes.io/node \
           %{~ for label in compact(split(",", node_labels)) ~}
           --node-labels=${label} \
           %{~ endfor ~}


### PR DESCRIPTION
## Summary

* Remove the duplicate `--node-labels=node.kubernetes.io/node` flag from the bare-metal Flatcar Linux worker template
* Keep behavior unchanged because the worker already sets the same node label later in the kubelet command
* Close #1654

## Validation

* Inspect the generated diff
* Confirm only one `node.kubernetes.io/node` flag remains in the affected template