### PR TITLE
Disable Azure VM extensions/repair/rolling upgrades on Fedora CoreOS

### DIFF
--- a/azure/fedora-coreos/kubernetes/workers/workers.tf
+++ b/azure/fedora-coreos/kubernetes/workers/workers.tf
@@ -66,44 +66,14 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "workers" {
         public_key = local.azure_authorized_key
       }
       computer_name_prefix = "${var.name}-worker"
+      provision_vm_agent   = false
     }
   }
 
-  # Roll out VMSS changes to instances gradually
-  upgrade_mode = "Rolling"
-  rolling_upgrade_policy {
-    max_batch_instance_percent = 20
-    pause_time_between_batches = "PT2M"
-
-    maximum_surge_instances_enabled = true
-    # Upgrade unhealthy instances first
-    prioritize_unhealthy_instances_enabled = true
-
-    # Safety gate to stop bad rollouts
-    max_unhealthy_instance_percent          = 20
-    max_unhealthy_upgraded_instance_percent = 25
-  }
-
-  # Azure instance repair replaces instances that fail probes from the
-  # ApplicationHealthExtension
-  automatic_instance_repair {
-    enabled      = true
-    grace_period = "PT15M"
-    action       = "Replace"
-  }
-
-  extension {
-    name                 = "ApplicationHealthExtension"
-    publisher            = "Microsoft.ManagedServices"
-    type                 = "ApplicationHealthLinux"
-    type_handler_version = "1.0"
-    settings = jsonencode({
-      protocol    = "http"
-      port        = 10256
-      requestPath = "/healthz"
-    })
-  }
-
+  # Fedora CoreOS does not include the Azure Linux Agent required for VM
+  # extensions, automatic instance repair, or rolling upgrades.
+  extension_operations_enabled = false
+  upgrade_mode                 = "Manual"
 
   # lifecycle
   # eviction policy may only be set when priority is Spot


### PR DESCRIPTION
* Fedora CoreOS does not include the Azure Linux Agent required for VM extensions, automatic instance repair, or rolling upgrades
* Without this fix, automatic instance repair will replace Fedora CoreOS instances every 15 minutes